### PR TITLE
repo: Add missing O_CLOEXEC

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -462,7 +462,13 @@ impl Repository {
     }
 
     fn openat(&self, name: &str, flags: OFlags) -> ErrnoResult<OwnedFd> {
-        openat(&self.repository, name, flags, Mode::empty())
+        // Unconditionally add CLOEXEC as we always want it.
+        openat(
+            &self.repository,
+            name,
+            flags | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
     }
 
     fn gc_category(&self, category: &str) -> Result<HashSet<Sha256HashValue>> {


### PR DESCRIPTION
We're pervasively missing this and O_CLOEXEC is IMO quite important for anything caring about security. Rust notably does *not* automatically close fds with `std::process::Command`.

Now...digging into this I do think we should take a dep on cap-std{,-ext} but that's a distinct thread.