### PR TITLE
selinux relabel support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,9 +18,7 @@ jobs:
     - name: Enable fs-verity on /
       run: sudo tune2fs -O verity $(findmnt -vno SOURCE /)
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Clippy
-      run: cargo clippy
-    - name: Run tests
-      run: cargo test --verbose
+    - run: cargo build --verbose
+    - run: cargo fmt --check
+    - run: cargo clippy -- -Dwarnings
+    - run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hex = "0.4.3"
 indicatif = { version = "0.17.8", features = ["tokio"] }
 oci-spec = "0.7.0"
 rand = "0.8.5"
+regex-automata = "0.4.8"
 rustix = { version = "0.38.37", features = ["fs", "mount", "process"] }
 sha2 = "0.10.8"
 tar = "0.4.42"

--- a/examples/uki/Containerfile
+++ b/examples/uki/Containerfile
@@ -22,8 +22,17 @@ RUN <<EOF
     # we should install kernel-modules here, but can't
     # because it'll pull in the entire kernel with it
     # it seems to work fine for now....
-    dnf --setopt keepcache=1 install -y systemd util-linux skopeo composefs strace dosfstools
+    dnf --setopt keepcache=1 install -y \
+        composefs \
+        dosfstools \
+        policycoreutils-python-utils \
+        selinux-policy-targeted \
+        skopeo \
+        strace \
+        systemd \
+        util-linux
     systemctl enable systemd-networkd
+    semanage permissive -a systemd_gpt_generator_t  # for volatile-root workaround
     passwd -d root
     mkdir /sysroot
 EOF

--- a/examples/uki/build
+++ b/examples/uki/build
@@ -53,18 +53,6 @@ cp /usr/lib/systemd/boot/efi/systemd-bootx64.efi tmp/efi/EFI/systemd
 cp /usr/lib/systemd/boot/efi/systemd-bootx64.efi tmp/efi/EFI/BOOT/BOOTX64.EFI
 ${CFSCTL} oci prepare-boot "${FINAL_ID}" tmp/efi
 
-> tmp/image.raw
-SYSTEMD_REPART_MKFS_OPTIONS_EXT4='-O verity' \
-    fakeroot \
-        systemd-repart \
-            --empty=require \
-            --size=auto \
-            --dry-run=no \
-            --no-pager \
-            --offline=yes \
-            --root=tmp \
-            --definitions=repart.d \
-            tmp/image.raw
-
+fakeroot ./make-image
 qemu-img convert -f raw tmp/image.raw -O qcow2 image.qcow2
 ./fix-verity image.qcow2  # https://github.com/tytso/e2fsprogs/issues/201

--- a/examples/uki/make-image
+++ b/examples/uki/make-image
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eux
+
+chown -R 0:0 tmp/sysroot
+chcon -R system_u:object_r:usr_t:s0 tmp/sysroot/composefs
+chcon system_u:object_r:var_t:s0 tmp/sysroot/var
+
+> tmp/image.raw
+SYSTEMD_REPART_MKFS_OPTIONS_EXT4='-O verity' \
+    systemd-repart \
+        --empty=require \
+        --size=auto \
+        --dry-run=no \
+        --no-pager \
+        --offline=yes \
+        --root=tmp \
+        --definitions=repart.d \
+        tmp/image.raw

--- a/src/bin/cfsctl.rs
+++ b/src/bin/cfsctl.rs
@@ -56,7 +56,7 @@ enum OciCommand {
     },
     PrepareBoot {
         name: String,
-        bootdir: Option<PathBuf>
+        bootdir: Option<PathBuf>,
     },
 }
 
@@ -164,7 +164,6 @@ fn main() -> Result<()> {
                 let output = bootdir.unwrap_or(PathBuf::from("/boot"));
                 oci::prepare_boot(&repo, name, None, &output)?;
             }
-
         },
         Command::Mount { name, mountpoint } => {
             repo.mount(&name, &mountpoint)?;

--- a/src/bin/composefs-pivot-sysroot.rs
+++ b/src/bin/composefs-pivot-sysroot.rs
@@ -32,7 +32,7 @@ fn test_parse() {
         assert!(parse_composefs_cmdline(case.as_bytes()).is_err());
     }
     let digest = "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52";
-    let digest_bytes = hex::decode(&digest).unwrap();
+    let digest_bytes = hex::decode(digest).unwrap();
     assert_eq!(
         parse_composefs_cmdline(format!("composefs={digest}").as_bytes())
             .unwrap()

--- a/src/dumpfile.rs
+++ b/src/dumpfile.rs
@@ -71,7 +71,7 @@ fn write_entry(
         write_empty(writer)?;
     }
 
-    for (key, value) in &stat.xattrs {
+    for (key, value) in &*stat.xattrs.borrow() {
         write!(writer, " ")?;
         write_escaped(writer, key.as_bytes())?;
         write!(writer, "=")?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -33,7 +33,12 @@ fn set_file_contents(dirfd: &OwnedFd, name: &OsStr, stat: &Stat, data: &[u8]) ->
         }
         Err(Errno::OPNOTSUPP) => {
             // vfat? yolo...
-            let fd = openat(dirfd, name, OFlags::CREATE | OFlags::WRONLY, stat.st_mode.into())?;
+            let fd = openat(
+                dirfd,
+                name,
+                OFlags::CREATE | OFlags::WRONLY,
+                stat.st_mode.into(),
+            )?;
             write(&fd, data)?;
             fdatasync(&fd)?;
         }

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     cmp::{Ord, Ordering},
     ffi::{OsStr, OsString},
     io::Read,
@@ -17,7 +18,7 @@ pub struct Stat {
     pub st_uid: u32,
     pub st_gid: u32,
     pub st_mtim_sec: i64,
-    pub xattrs: Vec<(OsString, Vec<u8>)>,
+    pub xattrs: RefCell<Vec<(OsString, Vec<u8>)>>,
 }
 
 #[derive(Debug)]
@@ -174,7 +175,7 @@ impl FileSystem {
                     st_uid: 0,
                     st_gid: 0,
                     st_mtim_sec: 0,
-                    xattrs: vec![],
+                    xattrs: RefCell::new(vec![]),
                 },
                 entries: vec![],
             },

--- a/src/image.rs
+++ b/src/image.rs
@@ -74,13 +74,13 @@ impl Directory {
         }
     }
 
-    pub fn recurse<'a>(&'a mut self, name: &OsStr) -> Result<&'a mut Directory> {
-        match self.find_entry(name) {
+    pub fn recurse(&mut self, name: impl AsRef<OsStr>) -> Result<&mut Directory> {
+        match self.find_entry(name.as_ref()) {
             Ok(idx) => match &mut self.entries[idx].inode {
                 Inode::Directory(ref mut subdir) => Ok(subdir),
                 _ => bail!("Parent directory is not a directory"),
             },
-            _ => bail!("Unable to find parent directory {:?}", name),
+            _ => bail!("Unable to find parent directory {:?}", name.as_ref()),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod image;
 pub mod mount;
 pub mod oci;
 pub mod repository;
+pub mod selabel;
 pub mod splitstream;
 pub mod util;

--- a/src/oci/image.rs
+++ b/src/oci/image.rs
@@ -9,6 +9,7 @@ use crate::{
     image::{mkcomposefs, FileSystem, Leaf},
     oci,
     repository::Repository,
+    selabel::selabel,
 };
 
 pub fn process_entry(filesystem: &mut FileSystem, entry: oci::tar::TarEntry) -> Result<()> {
@@ -63,6 +64,8 @@ pub fn compose_filesystem(repo: &Repository, layers: &[String]) -> Result<FileSy
         }
     }
 
+    selabel(&mut filesystem, repo)?;
+
     Ok(filesystem)
 }
 
@@ -93,6 +96,8 @@ pub fn create_image(
             process_entry(&mut filesystem, entry)?;
         }
     }
+
+    selabel(&mut filesystem, repo)?;
 
     let image = mkcomposefs(filesystem)?;
     repo.write_image(name, &image)

--- a/src/oci/image.rs
+++ b/src/oci/image.rs
@@ -101,7 +101,7 @@ pub fn create_image(
 #[cfg(test)]
 use crate::image::{LeafContent, Stat};
 #[cfg(test)]
-use std::{io::BufRead, path::PathBuf};
+use std::{cell::RefCell, io::BufRead, path::PathBuf};
 
 #[cfg(test)]
 fn file_entry(path: &str) -> oci::tar::TarEntry {
@@ -112,7 +112,7 @@ fn file_entry(path: &str) -> oci::tar::TarEntry {
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: vec![],
+            xattrs: RefCell::new(vec![]),
         },
         item: oci::tar::TarItem::Leaf(LeafContent::InlineFile(vec![])),
     }
@@ -127,7 +127,7 @@ fn dir_entry(path: &str) -> oci::tar::TarEntry {
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: vec![],
+            xattrs: RefCell::new(vec![]),
         },
         item: oci::tar::TarItem::Directory,
     }

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -331,5 +331,5 @@ pub fn prepare_boot(
         .recurse(OsStr::new("composefs-meta"))?
         .recurse(OsStr::new("boot"))?;
 
-    write_to_path(&repo, &boot, output_dir)
+    write_to_path(repo, boot, output_dir)
 }

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -1,7 +1,7 @@
 pub mod image;
 pub mod tar;
 
-use std::{collections::HashMap, ffi::OsStr, io::Read, iter::zip, path::Path};
+use std::{collections::HashMap, io::Read, iter::zip, path::Path};
 
 use anyhow::{bail, ensure, Context, Result};
 use async_compression::tokio::bufread::GzipDecoder;
@@ -326,10 +326,7 @@ pub fn prepare_boot(
         image::process_entry(&mut filesystem, entry)?;
     }
 
-    let boot = filesystem
-        .root
-        .recurse(OsStr::new("composefs-meta"))?
-        .recurse(OsStr::new("boot"))?;
+    let boot = filesystem.root.recurse("composefs-meta")?.recurse("boot")?;
 
     write_to_path(repo, boot, output_dir)
 }

--- a/src/oci/tar.rs
+++ b/src/oci/tar.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::RefCell,
     ffi::{OsStr, OsString},
     fmt,
     io::Read,
@@ -252,7 +253,7 @@ pub fn get_entry<R: Read>(reader: &mut SplitStreamReader<R>) -> Result<Option<Ta
                 st_gid: header.gid()? as u32,
                 st_mode: header.mode()?,
                 st_mtim_sec: header.mtime()? as i64,
-                xattrs,
+                xattrs: RefCell::new(xattrs),
             },
             item,
         }));

--- a/src/selabel.rs
+++ b/src/selabel.rs
@@ -1,0 +1,278 @@
+use std::{
+    collections::HashMap,
+    ffi::{OsStr, OsString},
+    fs::File,
+    io::{BufRead, BufReader, Read},
+    os::unix::ffi::OsStrExt,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{bail, ensure, Context, Result};
+use regex_automata::{hybrid::dfa, util::syntax, Anchored, Input};
+
+use crate::{
+    image::{DirEnt, Directory, FileSystem, Inode, Leaf, LeafContent, Stat},
+    repository::Repository,
+};
+
+/* We build the entire SELinux policy into a single "lazy DFA" such that:
+ *
+ *  - the input string is the filename plus a single character representing the type of the file,
+ *    using the 'file type' codes listed in selabel_file(5): 'b', 'c', 'd', 'p', 'l', 's', and '-'
+ *
+ *  - the output pattern ID is the index of the selected context
+ *
+ * The 'subs' mapping is handled as a hash table.  We consult it each time we enter a directory and
+ * perform the substitution a single time at that point instead of doing it for each contained
+ * file.
+ *
+ * We could maybe add a string table to deduplicate contexts to save memory (as they are often
+ * repeated).  It's not an order-of-magnitude kind of gain, though, and it would increase code
+ * complexity, and slightly decrease efficiency.
+ *
+ * Note: we are not 100% compatible with PCRE here, so it's theoretically possible that someone
+ * could write a policy that we can't properly handle...
+ */
+
+fn process_subs_file(file: impl Read, aliases: &mut HashMap<OsString, OsString>) -> Result<()> {
+    // r"\s*([^\s]+)\s+([^\s]+)\s*";
+    for (line_nr, item) in BufReader::new(file).lines().enumerate() {
+        let line = item?;
+        let mut parts = line.split_whitespace();
+        let alias = match parts.next() {
+            None => continue, // empty line or line with only whitespace
+            Some(comment) if comment.starts_with("#") => continue,
+            Some(alias) => alias,
+        };
+        let Some(original) = parts.next() else {
+            bail!("{line_nr}: missing original path");
+        };
+        ensure!(parts.next().is_none(), "{line_nr}: trailing data");
+
+        aliases.insert(OsString::from(alias), OsString::from(original));
+    }
+    Ok(())
+}
+
+fn process_spec_file(
+    file: impl Read,
+    regexps: &mut Vec<String>,
+    contexts: &mut Vec<String>,
+) -> Result<()> {
+    // r"\s*([^\s]+)\s+(?:-([-bcdpls])\s+)?([^\s]+)\s*";
+    for (line_nr, item) in BufReader::new(file).lines().enumerate() {
+        let line = item?;
+
+        let mut parts = line.split_whitespace();
+        let regex = match parts.next() {
+            None => continue, // empty line or line with only whitespace
+            Some(comment) if comment.starts_with("#") => continue,
+            Some(regex) => regex,
+        };
+
+        /* TODO: https://github.com/rust-lang/rust/issues/51114
+         *  match parts.next() {
+         *      Some(opt) if let Some(ifmt) = opt.strip_prefix("-") => ...
+         */
+        let Some(next) = parts.next() else {
+            bail!("{line_nr}: missing separator after regex");
+        };
+        if let Some(ifmt) = next.strip_prefix("-") {
+            ensure!(
+                ["b", "c", "d", "p", "l", "s", "-"].contains(&ifmt),
+                "{line_nr}: invalid type code -{ifmt}"
+            );
+            let Some(context) = parts.next() else {
+                bail!("{line_nr}: missing context field");
+            };
+            regexps.push(format!("^({regex}){ifmt}$"));
+            contexts.push(context.to_string());
+        } else {
+            let context = next;
+            regexps.push(format!("^({regex}).$"));
+            contexts.push(context.to_string());
+        }
+        ensure!(parts.next().is_none(), "{line_nr}: trailing data");
+    }
+
+    Ok(())
+}
+
+struct Policy {
+    aliases: HashMap<OsString, OsString>,
+    dfa: dfa::DFA,
+    cache: dfa::Cache,
+    contexts: Vec<String>,
+}
+
+pub fn openat<'a>(
+    dir: &'a Directory,
+    filename: impl AsRef<OsStr>,
+    repo: &Repository,
+) -> Result<Option<Box<dyn Read + 'a>>> {
+    let Ok(idx) = dir.find_entry(filename.as_ref()) else {
+        return Ok(None);
+    };
+
+    match &dir.entries[idx].inode {
+        Inode::Leaf(leaf) => match &leaf.content {
+            LeafContent::InlineFile(data) => Ok(Some(Box::new(data.as_slice()))),
+            LeafContent::ExternalFile(id, ..) => {
+                Ok(Some(Box::new(File::from(repo.open_object(id)?))))
+            }
+            _ => bail!("Invalid file type"),
+        },
+        Inode::Directory(..) => bail!("Invalid file type (directory)"),
+    }
+}
+
+impl Policy {
+    pub fn build(dir: &Directory, repo: &Repository) -> Result<Self> {
+        let mut aliases = HashMap::new();
+        let mut regexps = vec![];
+        let mut contexts = vec![];
+
+        for suffix in ["", ".local", ".homedirs"] {
+            if let Some(file) = openat(dir, format!("file_contexts{suffix}"), repo)? {
+                process_spec_file(file, &mut regexps, &mut contexts)
+                    .with_context(|| format!("SELinux spec file file_contexts{suffix}"))?;
+            } else if suffix.is_empty() {
+                bail!("SELinux policy is missing mandatory file_contexts file");
+            }
+        }
+
+        for suffix in [".subs", ".subs_dist"] {
+            if let Some(file) = openat(dir, format!("file_contexts{suffix}"), repo)? {
+                process_subs_file(file, &mut aliases)
+                    .with_context(|| format!("SELinux subs file file_contexts{suffix}"))?;
+            }
+        }
+
+        // The DFA matches the first-found.  We want to match the last-found.
+        regexps.reverse();
+        contexts.reverse();
+
+        let mut builder = dfa::Builder::new();
+        builder.syntax(
+            syntax::Config::new()
+                .unicode(false)
+                .utf8(false)
+                .line_terminator(0),
+        );
+        builder.configure(
+            dfa::Config::new()
+                .cache_capacity(10_000_000)
+                .skip_cache_capacity_check(true),
+        );
+        let dfa = builder.build_many(&regexps)?;
+        let cache = dfa.create_cache();
+
+        Ok(Policy {
+            aliases,
+            dfa,
+            cache,
+            contexts,
+        })
+    }
+
+    pub fn check_aliased(&self, filename: &OsStr) -> Option<&OsStr> {
+        self.aliases.get(filename).map(|x| x.as_os_str())
+    }
+
+    // mut because it touches the cache
+    pub fn lookup(&mut self, filename: &OsStr, ifmt: u8) -> Option<&str> {
+        let key = &[filename.as_bytes(), &[ifmt]].concat();
+        let input = Input::new(&key).anchored(Anchored::Yes);
+
+        match self
+            .dfa
+            .try_search_fwd(&mut self.cache, &input)
+            .expect("regex troubles")
+        {
+            Some(halfmatch) => match self.contexts[halfmatch.pattern()].as_str() {
+                "<<none>>" => None,
+                ctx => Some(ctx),
+            },
+            None => None,
+        }
+    }
+}
+
+fn relabel(stat: &Stat, path: &Path, ifmt: u8, policy: &mut Policy) {
+    if let Some(label) = policy.lookup(path.as_os_str(), ifmt) {
+        stat.xattrs.borrow_mut().push((
+            OsString::from("security.selinux"),
+            Vec::from(label.as_bytes()),
+        ))
+    }
+}
+
+fn relabel_leaf(leaf: &Leaf, path: &Path, policy: &mut Policy) {
+    let ifmt = match leaf.content {
+        LeafContent::InlineFile(..) | LeafContent::ExternalFile(..) => b'-',
+        LeafContent::Fifo => b'p', // NB: 'pipe', not 'fifo'
+        LeafContent::Socket => b's',
+        LeafContent::Symlink(..) => b'l',
+        LeafContent::BlockDevice(..) => b'b',
+        LeafContent::CharacterDevice(..) => b'c',
+    };
+    relabel(&leaf.stat, path, ifmt, policy);
+}
+
+fn relabel_inode(inode: &Inode, path: &mut PathBuf, policy: &mut Policy) {
+    match inode {
+        Inode::Directory(ref dir) => relabel_dir(dir, path, policy),
+        Inode::Leaf(ref leaf) => relabel_leaf(leaf, path, policy),
+    }
+}
+
+fn relabel_dir(dir: &Directory, path: &mut PathBuf, policy: &mut Policy) {
+    relabel(&dir.stat, path, b'd', policy);
+
+    for DirEnt { name, inode } in dir.entries.iter() {
+        path.push(name);
+        match policy.check_aliased(path.as_os_str()) {
+            Some(original) => relabel_inode(inode, &mut PathBuf::from(original), policy),
+            None => relabel_inode(inode, path, policy),
+        }
+        path.pop();
+    }
+}
+
+fn parse_config(file: impl Read) -> Result<Option<String>> {
+    for line in BufReader::new(file).lines() {
+        if let Some((key, value)) = line?.split_once('=') {
+            // this might be a comment, but then key will start with '#'
+            if key.trim().to_ascii_uppercase() == "SELINUXTYPE" {
+                return Ok(Some(value.trim().to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+pub fn selabel(fs: &mut FileSystem, repo: &Repository) -> Result<()> {
+    // if /etc/selinux/config doesn't exist then it's not an error
+    let Ok(etc) = fs.root.recurse("etc") else {
+        return Ok(());
+    };
+    let Ok(etc_selinux) = etc.recurse("selinux") else {
+        return Ok(());
+    };
+    let Some(etc_selinux_config) = openat(etc_selinux, "config", repo)? else {
+        return Ok(());
+    };
+    let Some(policy) = parse_config(etc_selinux_config)? else {
+        return Ok(());
+    };
+
+    let dir = etc_selinux
+        .recurse(policy)?
+        .recurse("contexts")?
+        .recurse("files")?;
+
+    let mut policy = Policy::build(dir, repo)?;
+    let mut path = PathBuf::from("/");
+    relabel_dir(&fs.root, &mut path, &mut policy);
+    Ok(())
+}


### PR DESCRIPTION
There are some outstanding items here:
 - [x] figure out which policy to check.  It's hardcoded to `targeted` right now
 - [x] provide a nice fallback if the policy isn't present.  It's currently fatal.
 - [x] ~figure out a nicer way to handle linking to `libselinux`, possibly making it a conditional feature?~ don't link libselinux: do it ourselves
 - [x] figure out a better way to handle mutability of hardlinks in the filesystem tree
 - [x] properly label our `/run/systemd/volatile-root` hack symlink to avoid this: `[    3.055118] audit: type=1400 audit(1731016644.835:3): avc:  denied  { read } for  pid=447 comm="systemd-gpt-aut" name="volatile-root" dev="tmpfs" ino=679 scontext=system_u:system_r:systemd_gpt_generator_t:s0 tcontext=system_u:object_r:init_var_run_t:s0 tclass=lnk_file permissive=1
`
 - [x] drop `enforcing=0`

Closes #29