### PR TITLE
some fixes to prepare to publish composefs 0.2.0 crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-fedora:
+  fedora:
     runs-on: ubuntu-24.04
     container:
       image: quay.io/fedora/fedora:41
@@ -25,3 +25,4 @@ jobs:
     - run: cargo fmt --check
     - run: cargo clippy -- -Dwarnings
     - run: env CFS_TEST_TMPDIR=/run/host/var/tmp cargo test --verbose
+    - run: cargo publish --dry-run

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/containers/composefs-rs"
 readme = "README.md"
 default-run = "cfsctl"
-exclude = ["/.git*", "/examples/uki/"]
+exclude = ["/.git*", "/examples/"]
 
 [dependencies]
 anyhow = { version = "1.0.89", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,17 @@ default-run = "cfsctl"
 exclude = ["/.git*", "/examples/uki/"]
 
 [dependencies]
-anyhow = { version = "1.0.89", features = ["backtrace"] }
-async-compression = { version = "0.4.17", features = ["tokio", "gzip", "zstd"] }
-clap = { version = "4.5.19", features = ["derive"] }
+anyhow = { version = "1.0.89", default-features = false }
+async-compression = { version = "0.4.17", default-features = false, features = ["tokio", "gzip"] }
+clap = { version = "4.5.19", default-features = false, features = ["std", "derive"] }
 containers-image-proxy = "0.7.0"
 hex = "0.4.3"
 indicatif = { version = "0.17.8", features = ["tokio"] }
 oci-spec = "0.7.0"
-rand = "0.8.5"
-regex-automata = "0.4.8"
+regex-automata = { version = "0.4.8", default-features = false }
 rustix = { version = "0.38.37", features = ["fs", "mount", "process"] }
 sha2 = "0.10.8"
-tar = "0.4.42"
+tar = { version = "0.4.42", default-features = false }
 tempfile = "3.13.0"
 tokio = "1.41.0"
 zstd = "0.13.2"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -143,8 +143,6 @@ impl<'repo> FilesystemReader<'repo> {
             "xattrs changed during read"
         );
 
-        let names: Vec<u8> = names.into_iter().map(|c| c as u8).collect(); // fml
-
         let mut buffer = [0; 65536];
         for name in names.split_inclusive(|c| *c == 0) {
             let name = CStr::from_bytes_with_nul(name)?;


### PR DESCRIPTION
I tried to publish the crate and it failed.  Fix the reason for that, and check for future failures by doing a publish dry-run on each push.

Also add some bonus dependency pruning!