### PR TITLE
Cargo.toml: Add clap features: help, usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/.git*", "/examples/"]
 [dependencies]
 anyhow = { version = "1.0.89", default-features = false }
 async-compression = { version = "0.4.17", default-features = false, features = ["tokio", "gzip"] }
-clap = { version = "4.5.19", default-features = false, features = ["std", "derive"] }
+clap = { version = "4.5.19", default-features = false, features = ["std", "help", "usage", "derive"] }
 containers-image-proxy = "0.7.0"
 hex = "0.4.3"
 indicatif = { version = "0.17.8", features = ["tokio"] }


### PR DESCRIPTION
In order to provide help, there are missing features.
It seems been removed in 
https://github.com/containers/composefs-rs/commit/3e49e280577b46789a321b78e2ca6d30a74676b8

```
./target/release/cfsctl --help
cfsctl

Usage: cfsctl [OPTIONS] <COMMAND>

Commands:
  transaction      Take a transaction lock on the repository. This prevents garbage collection from occurring
  cat              Reconstitutes a split stream and writes it to stdout
...
```



