### PR TITLE
fs: clean up filesystem import state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "composefs"
 version = "0.2.0"
 edition = "2021"
+rust-version = "1.83.0"
 description = "Rust library for the composefs filesystem"
 keywords = ["composefs"]
 license = "MIT OR Apache-2.0"

--- a/src/dumpfile_parse.rs
+++ b/src/dumpfile_parse.rs
@@ -180,7 +180,7 @@ fn unescape_limited(s: &str, max: usize) -> Result<Cow<[u8]>> {
 
 /// Unescape a byte array according to the composefs dump file escaping format.
 fn unescape(s: &str) -> Result<Cow<[u8]>> {
-    return unescape_limited(s, usize::MAX);
+    unescape_limited(s, usize::MAX)
 }
 
 /// Unescape a string into a Rust `OsStr` which is really just an alias for a byte array,
@@ -492,7 +492,7 @@ impl<'p> Entry<'p> {
     }
 }
 
-impl<'p> Item<'p> {
+impl Item<'_> {
     pub(crate) fn size(&self) -> u64 {
         match self {
             Item::Regular { size, .. } | Item::Directory { size, .. } => *size,
@@ -536,7 +536,7 @@ impl Display for Mtime {
     }
 }
 
-impl<'p> Display for Entry<'p> {
+impl Display for Entry<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         escape(f, self.path.as_os_str().as_bytes(), EscapeMode::Standard)?;
         write!(

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -125,7 +125,7 @@ pub struct FilesystemReader<'repo> {
     root_mtime: i64,
 }
 
-impl<'repo> FilesystemReader<'repo> {
+impl FilesystemReader<'_> {
     fn read_xattrs(&mut self, fd: &OwnedFd) -> Result<BTreeMap<Box<OsStr>, Box<[u8]>>> {
         // flistxattr() and fgetxattr() don't with with O_PATH fds, so go via /proc/self/fd. Note:
         // we want the symlink-following version of this call, which produces the correct behaviour

--- a/src/image.rs
+++ b/src/image.rs
@@ -57,6 +57,15 @@ pub struct DirEnt {
     pub inode: Inode,
 }
 
+impl Inode {
+    pub fn stat(&self) -> &Stat {
+        match self {
+            Inode::Directory(dir) => &dir.stat,
+            Inode::Leaf(leaf) => &leaf.stat,
+        }
+    }
+}
+
 impl Directory {
     pub fn find_entry(&self, name: &OsStr) -> Result<usize, usize> {
         // OCI layer tarballs are typically sorted, with the entries for a particular directory


### PR DESCRIPTION
Clean up two aspects of importing filesystems:

First: instead of trying to avoid crossing mountpoints (by checking `.st_dev`) in order to use `.st_ino` values as a "unique key" for tracking hardlinks, just take the `(.st_dev, .st_ino)` pair.  This resolves some issues with overlayfs where adjacent files can end up with different `.st_dev`.

Second: we were abusing the first setting of `st_dev` as a flag field to determine if we were `stat()`-ing the root inode or not, which was always a bit evil.  We did this to avoid collecting the mtime of the root directory for determining the newest file in the filesystem.  Let's change our approach here: we can collect the mtime when adding items to their parent directories (which is never done for the root directory). Use a impl on `Inode` to make it easier to collect that information.

These changes together turn .stat() into a pure operation (with respect to the state of the reader), so remove the `&mut self` reference.

Fixes #41