### PR TITLE
fsverity: Use rustix Result, add fs_ioc_measure_verity_optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rustix = { version = "0.38.37", features = ["fs", "mount", "process"] }
 sha2 = "0.10.8"
 tar = { version = "0.4.42", default-features = false }
 tempfile = "3.13.0"
+thiserror = "2.0.4"
 tokio = "1.41.0"
 zstd = "0.13.2"
 

--- a/src/fsverity/ioctl.rs
+++ b/src/fsverity/ioctl.rs
@@ -1,9 +1,21 @@
 use std::os::fd::AsFd;
 
-use anyhow::Result;
+use rustix::io::Errno;
 use rustix::ioctl;
+use thiserror::Error;
 
 use super::FsVerityHashValue;
+
+/// Measuring fsverity failed.
+#[derive(Error, Debug)]
+pub enum MeasureVerityError {
+    #[error("i/o error")]
+    Io(#[from] std::io::Error),
+    #[error("Expected algorithm {expected}, found {found}")]
+    InvalidDigestAlgorithm { expected: u16, found: u16 },
+    #[error("Expected digest size {expected}")]
+    InvalidDigestSize { expected: u16 },
+}
 
 // See /usr/include/linux/fsverity.h
 #[repr(C)]
@@ -22,7 +34,10 @@ pub struct FsVerityEnableArg {
 // #define FS_IOC_ENABLE_VERITY    _IOW('f', 133, struct fsverity_enable_arg)
 type FsIocEnableVerity = ioctl::WriteOpcode<b'f', 133, FsVerityEnableArg>;
 
-pub fn fs_ioc_enable_verity<F: AsFd, H: FsVerityHashValue>(fd: F) -> Result<()> {
+/// Enable fsverity on the target file. This is a thin safe wrapper for the underlying base `ioctl`
+/// and hence all constraints apply such as requiring the file descriptor to already be `O_RDONLY`
+/// etc.
+pub fn fs_ioc_enable_verity<F: AsFd, H: FsVerityHashValue>(fd: F) -> std::io::Result<()> {
     unsafe {
         ioctl::ioctl(
             fd,
@@ -43,6 +58,7 @@ pub fn fs_ioc_enable_verity<F: AsFd, H: FsVerityHashValue>(fd: F) -> Result<()> 
     Ok(())
 }
 
+/// Core definition of a fsverity digest.
 #[repr(C)]
 pub struct FsVerityDigest<F> {
     digest_algorithm: u16,
@@ -53,7 +69,10 @@ pub struct FsVerityDigest<F> {
 // #define FS_IOC_MEASURE_VERITY   _IORW('f', 134, struct fsverity_digest)
 type FsIocMeasureVerity = ioctl::ReadWriteOpcode<b'f', 134, FsVerityDigest<()>>;
 
-pub fn fs_ioc_measure_verity<F: AsFd, H: FsVerityHashValue>(fd: F) -> Result<H> {
+/// Measure the fsverity digest of the provided file descriptor.
+pub fn fs_ioc_measure_verity<F: AsFd, H: FsVerityHashValue>(
+    fd: F,
+) -> Result<Option<H>, MeasureVerityError> {
     let digest_size = std::mem::size_of::<H>() as u16;
     let digest_algorithm = H::ALGORITHM as u16;
 
@@ -63,16 +82,48 @@ pub fn fs_ioc_measure_verity<F: AsFd, H: FsVerityHashValue>(fd: F) -> Result<H> 
         digest: H::EMPTY,
     };
 
-    unsafe {
+    let r = unsafe {
         ioctl::ioctl(
             fd,
             ioctl::Updater::<FsIocMeasureVerity, FsVerityDigest<H>>::new(&mut digest),
-        )?;
+        )
+    };
+    match r {
+        Ok(()) => {
+            if digest.digest_algorithm != digest_algorithm {
+                return Err(MeasureVerityError::InvalidDigestAlgorithm {
+                    expected: digest.digest_algorithm,
+                    found: digest_algorithm,
+                });
+            }
+            if digest.digest_size != digest_size {
+                return Err(MeasureVerityError::InvalidDigestSize {
+                    expected: digest.digest_size,
+                });
+            }
+            Ok(Some(digest.digest))
+        }
+        // This function returns Ok(None) if there's no verity digest found.
+        Err(Errno::NODATA | Errno::NOTTY | Errno::OPNOTSUPP) => Ok(None),
+        Err(Errno::OVERFLOW) => Err(MeasureVerityError::InvalidDigestSize {
+            expected: digest.digest_size,
+        }),
+        Err(e) => Err(std::io::Error::from(e).into()),
     }
+}
 
-    if digest.digest_algorithm != digest_algorithm || digest.digest_size != digest_size {
-        Err(std::io::Error::from(std::io::ErrorKind::InvalidData))?
-    } else {
-        Ok(digest.digest)
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsverity::Sha256HashValue;
+
+    #[test]
+    fn test_measure_verity_opt() -> anyhow::Result<()> {
+        let tf = tempfile::tempfile()?;
+        assert_eq!(
+            fs_ioc_measure_verity::<_, Sha256HashValue>(&tf).unwrap(),
+            None
+        );
+        Ok(())
     }
 }

--- a/src/fsverity/mod.rs
+++ b/src/fsverity/mod.rs
@@ -1,7 +1,13 @@
+use std::os::fd::AsFd;
+
+use anyhow::Result;
+use ioctl::MeasureVerityError;
+use thiserror::Error;
+
 pub mod digest;
 pub mod ioctl;
 
-pub trait FsVerityHashValue {
+pub trait FsVerityHashValue: Eq + AsRef<[u8]> {
     const ALGORITHM: u8;
     const EMPTY: Self;
 }
@@ -18,4 +24,62 @@ pub type Sha512HashValue = [u8; 64];
 impl FsVerityHashValue for Sha512HashValue {
     const ALGORITHM: u8 = 2;
     const EMPTY: Self = [0; 64];
+}
+
+/// A verity comparison failed.
+#[derive(Error, Debug)]
+pub enum CompareVerityError {
+    #[error("failed to read verity")]
+    Measure(#[from] MeasureVerityError),
+    #[error("fsverity is not enabled on target file")]
+    VerityMissing,
+    #[error("Expected digest {expected} but found {found}")]
+    DigestMismatch { expected: String, found: String },
+}
+
+/// Require the fsverity digest to be present.
+pub fn measure_verity_digest<F: AsFd, H: FsVerityHashValue>(
+    fd: F,
+) -> Result<H, CompareVerityError> {
+    match ioctl::fs_ioc_measure_verity::<_, H>(fd)? {
+        Some(found) => Ok(found),
+        None => Err(CompareVerityError::VerityMissing),
+    }
+}
+
+/// Compare the fsverity digest of the file versus the expected digest.
+pub fn ensure_verity<F: AsFd, H: FsVerityHashValue>(
+    fd: F,
+    expected: &H,
+) -> Result<(), CompareVerityError> {
+    let found = measure_verity_digest::<_, H>(fd)?;
+    if expected == &found {
+        Ok(())
+    } else {
+        Err(CompareVerityError::DigestMismatch {
+            expected: hex::encode(expected),
+            found: hex::encode(found.as_ref()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fsverity::Sha256HashValue;
+
+    #[test]
+    fn test_verity_missing() -> anyhow::Result<()> {
+        let tf = tempfile::tempfile()?;
+        match measure_verity_digest::<_, Sha256HashValue>(&tf) {
+            Err(CompareVerityError::VerityMissing) => {}
+            o => panic!("Unexpected {o:?}"),
+        }
+        let h = Sha256HashValue::default();
+        match ensure_verity(&tf, &h) {
+            Err(CompareVerityError::VerityMissing) => {}
+            o => panic!("Unexpected {o:?}"),
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
First switch to use `rustix::io::Result` since this is a raw low level API and we don't need generic errors.

Change the "wrong algorithm" error to `EILSEQ` which is what the C composefs library is doing today.

Next, add an API that maps the errno values to `Option` for callers that want to not have missing verity be a fatal error.