### PR TITLE
Use zerocopy instead of unsafe transmute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ tar = { version = "0.4.42", default-features = false }
 tempfile = "3.13.0"
 thiserror = "2.0.4"
 tokio = "1.41.0"
+zerocopy = "0.8.13"
 zstd = "0.13.2"
 
 [dev-dependencies]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -19,6 +19,7 @@ use rustix::{
     },
     io::{read_uninit, write, Errno},
 };
+use zerocopy::IntoBytes;
 
 use crate::{
     fsverity::{digest::FsVerityHasher, Sha256HashValue},
@@ -153,8 +154,7 @@ impl FilesystemReader<'_> {
 
         let mut buffer = [0; 65536];
         for name in names.split_inclusive(|c| *c == 0) {
-            // SAFETY: casting i8 to u8 is safe.
-            let name: &[u8] = unsafe { std::mem::transmute(name) };
+            let name: &[u8] = name.as_bytes();
             let name = CStr::from_bytes_with_nul(name)?;
             let value_size = getxattr(&filename, name, &mut buffer)?;
             let key = Box::from(OsStr::from_bytes(name.to_bytes()));


### PR DESCRIPTION
Followup to https://github.com/containers/composefs-rs/pull/50

---

ref https://lwn.net/Articles/995814/ etc.

I also did a PR for tar-rs: https://github.com/alexcrichton/tar-rs/pull/392

Thanks to the maintainer who helped me on Discord
to know the right API to call here.