### PR TITLE
build-sys: Lower rust-version to 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "composefs"
 version = "0.2.0"
 edition = "2021"
-rust-version = "1.83.0"
+rust-version = "1.82.0"
 description = "Rust library for the composefs filesystem"
 keywords = ["composefs"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This is what's in C9S (a primary dev target for me) at the moment. The claimed rationale for the bump around lifetime elison rules doesn't seem correct (this builds just fine for me with 1.82).

I suspect it's more newer clippy has newer suggestions.