### PR TITLE
tree-wide: Add Debug impls

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -120,6 +120,7 @@ pub fn write_to_path(repo: &Repository, dir: &Directory, output_dir: &Path) -> R
     write_directory_contents(dir, &fd, repo)
 }
 
+#[derive(Debug)]
 pub struct FilesystemReader<'repo> {
     repo: Option<&'repo Repository>,
     inodes: HashMap<(u64, u64), Rc<Leaf>>,

--- a/src/fsverity/digest.rs
+++ b/src/fsverity/digest.rs
@@ -6,6 +6,7 @@ use super::Sha256HashValue;
 
 // TODO: support Sha512
 
+#[derive(Debug)]
 struct FsVerityLayer {
     context: Sha256,
     remaining: usize,
@@ -31,6 +32,7 @@ impl FsVerityLayer {
     }
 }
 
+#[derive(Debug)]
 pub struct FsVerityHasher {
     layers: Vec<FsVerityLayer>,
     value: Option<Sha256HashValue>,

--- a/src/fsverity/ioctl.rs
+++ b/src/fsverity/ioctl.rs
@@ -19,6 +19,7 @@ pub enum MeasureVerityError {
 
 // See /usr/include/linux/fsverity.h
 #[repr(C)]
+#[derive(Debug)]
 pub struct FsVerityEnableArg {
     version: u32,
     hash_algorithm: u32,
@@ -60,6 +61,7 @@ pub fn fs_ioc_enable_verity<F: AsFd, H: FsVerityHashValue>(fd: F) -> std::io::Re
 
 /// Core definition of a fsverity digest.
 #[repr(C)]
+#[derive(Debug)]
 pub struct FsVerityDigest<F> {
     digest_algorithm: u16,
     digest_size: u16,

--- a/src/image.rs
+++ b/src/image.rs
@@ -180,6 +180,7 @@ impl Directory {
     }
 }
 
+#[derive(Debug)]
 pub struct FileSystem {
     pub root: Directory,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_debug_implementations)]
+
 pub mod dumpfile;
 pub mod dumpfile_parse;
 pub mod fs;

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -163,6 +163,7 @@ pub fn pivot_sysroot(image: impl AsFd, basedir: &Path, sysroot: &Path) -> Result
     }
 }
 
+#[derive(Debug)]
 pub struct MountOptions<'a> {
     image: &'a str,
     basedir: &'a Path,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -28,6 +28,7 @@ use crate::{
     util::{parse_sha256, proc_self_fd},
 };
 
+#[derive(Debug)]
 pub struct Repository {
     repository: OwnedFd,
     path: PathBuf,

--- a/src/splitstream.rs
+++ b/src/splitstream.rs
@@ -15,11 +15,13 @@ use crate::{
     util::read_exactish,
 };
 
+#[derive(Debug)]
 pub struct DigestMapEntry {
     pub body: Sha256HashValue,
     pub verity: Sha256HashValue,
 }
 
+#[derive(Debug)]
 pub struct DigestMap {
     pub map: Vec<DigestMapEntry>,
 }
@@ -61,6 +63,17 @@ pub struct SplitStreamWriter<'a> {
     inline_content: Vec<u8>,
     writer: Encoder<'a, Vec<u8>>,
     pub sha256: Option<(Sha256, Sha256HashValue)>,
+}
+
+impl std::fmt::Debug for SplitStreamWriter<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // writer doesn't impl Debug
+        f.debug_struct("SplitStreamWriter")
+            .field("repo", &self.repo)
+            .field("inline_content", &self.inline_content)
+            .field("sha256", &self.sha256)
+            .finish()
+    }
 }
 
 impl SplitStreamWriter<'_> {
@@ -153,6 +166,7 @@ impl SplitStreamWriter<'_> {
     }
 }
 
+#[derive(Debug)]
 pub enum SplitStreamData {
     Inline(Vec<u8>),
     External(Sha256HashValue),
@@ -163,6 +177,16 @@ pub struct SplitStreamReader<R: Read> {
     decoder: Decoder<'static, BufReader<R>>,
     pub refs: DigestMap,
     inline_bytes: usize,
+}
+
+impl<R: Read> std::fmt::Debug for SplitStreamReader<R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // decoder doesn't impl Debug
+        f.debug_struct("SplitStreamReader")
+            .field("refs", &self.refs)
+            .field("inline_bytes", &self.inline_bytes)
+            .finish()
+    }
 }
 
 fn read_u64_le<R: Read>(reader: &mut R) -> Result<Option<usize>> {


### PR DESCRIPTION
I find this really useful as a general baseline; I'm a "printf debugger" person by default. Add derives tree wide (plus two manual impls). Enable deny-by-default lint.