### PR TITLE
tests: use `test_with` and skip tests that need `mkcomposefs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ zstd = "0.13.2"
 
 [dev-dependencies]
 similar-asserts = "1.6.0"
+test-with = { version = "0.14", default-features = false, features = ["executable"] }
 
 [profile.dev.package.sha2]
 # this is *really* slow otherwise

--- a/src/dumpfile_parse.rs
+++ b/src/dumpfile_parse.rs
@@ -864,6 +864,7 @@ mod tests {
         }
     }
 
+    #[test_with::executable(mkcomposefs)]
     #[test]
     fn test_load_cfs() -> Result<()> {
         let mut tmpf = tempfile::tempfile()?;
@@ -879,6 +880,7 @@ mod tests {
         Ok(())
     }
 
+    #[test_with::executable(mkcomposefs)]
     #[test]
     fn test_load_cfs_filtered() -> Result<()> {
         const FILTERED: &str =


### PR DESCRIPTION
This commit adds the `test_with` crate and skips the tests that require `mkcomposefs`.

It uses use the minimal configuration of `tests_with` and with that we now pull in 229 `cargo tree` lines vs the pervious 217 (fwiw, the default configuration of tests_with incrases the crates from 217 to 497). Even the extra 12 might be too much for this tiny feature, feel free to close again if you feel this is not worth it.

