### PR TITLE
examples/unified-secureboot: Add Secure Boot signed example

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,7 +1,9 @@
+/*/VARS_CUSTOM.secboot.fd*
 /*/cfsctl
 /*/extra/usr/lib/dracut/modules.d/37composefs/composefs-pivot-sysroot
 /*/image-efi.qcow2
 /*/image.qcow2
+/*/secureboot
 /*/tmp/
 /common/fix-verity/fix-verity.efi
 /test/bots

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,3 +11,4 @@ a verified operating system image.
    In this case we simply hack the bootloader entry to refer to the correct composefs hash at install type.
  - `unified`: similar to the `uki` example, but avoiding the intermediate `cfsctl` step by running `cfsctl` inside a build stage from the `Containerfile` itself.
    This involves bind-mounting the earlier build stage of the base image so that we can measure it from inside the stage that builds the UKI.
+ - `unified-secureboot`: based on the `unified` example, adding signing for Secure Boot.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,11 @@
 This directory contains a few different approaches to using `cfsctl` to produce
 a verified operating system image.
 
- - `uki`: an OS built around a [Unified Kernel
-   Image](https://github.com/uapi-group/specifications/blob/main/specs/unified_kernel_image.md).  If this image is signed then the signature effectively covers every single file in the filesystem.  This works with a special form of multi-stage `Containerfile` which builds a base image, measures it using `cfsctl` and then uses that measurement to inject the composefs image fs-verity hash into the second stage of the build which actually builds the UKI (and embeds the hash into the `.cmdline`).  We avoid a circular hash dependency by removing the UKI from the final image via a white-out (but `cfsctl` still knows how to find it).
- - `bls`: an OS built around a separate kernel and initramfs installed with a [Type #1 Boot Loader Specification Entries](https://uapi-group.org/specifications/specs/boot_loader_specification/#type-1-boot-loader-specification-entries).  In this case we simply hack the bootloader entry to refer to the correct composefs hash at install type.
- - `unified`: similar to the `uki` example, but avoiding the intermediate `cfsctl` step by running `cfsctl` inside a build stage from the `Containerfile` itself.  This involves bind-mounting the earlier build stage of the base image so that we can measure it from inside the stage that builds the UKI.
+ - `uki`: an OS built around a [Unified Kernel Image](https://github.com/uapi-group/specifications/blob/main/specs/unified_kernel_image.md).
+   If this image is signed then the signature effectively covers every single file in the filesystem.
+   This works with a special form of multi-stage `Containerfile` which builds a base image, measures it using `cfsctl` and then uses that measurement to inject the composefs image fs-verity hash into the second stage of the build which actually builds the UKI (and embeds the hash into the `.cmdline`).
+   We avoid a circular hash dependency by removing the UKI from the final image via a white-out (but `cfsctl` still knows how to find it).
+ - `bls`: an OS built around a separate kernel and initramfs installed with a [Type #1 Boot Loader Specification Entries](https://uapi-group.org/specifications/specs/boot_loader_specification/#type-1-boot-loader-specification-entries).
+   In this case we simply hack the bootloader entry to refer to the correct composefs hash at install type.
+ - `unified`: similar to the `uki` example, but avoiding the intermediate `cfsctl` step by running `cfsctl` inside a build stage from the `Containerfile` itself.
+   This involves bind-mounting the earlier build stage of the base image so that we can measure it from inside the stage that builds the UKI.

--- a/examples/common/run
+++ b/examples/common/run
@@ -1,12 +1,45 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eux
 
 cd "${0%/*}"
 
+if [[ -d "secureboot" ]]; then
+    echo "Running with Secure Boot enabled"
+
+    # See: https://github.com/rhuefi/qemu-ovmf-secureboot
+    # $ dnf install -y python3-virt-firmware
+    if [[ ! -f "VARS_CUSTOM.secboot.fd.template" ]]; then
+        GUID=$(cat secureboot/GUID.txt)
+        virt-fw-vars --input "/usr/share/edk2/ovmf/OVMF_VARS.fd" \
+            --secure-boot  \
+            --set-pk  $GUID "secureboot/PK.crt" \
+            --add-kek $GUID "secureboot/KEK.crt" \
+            --add-db  $GUID "secureboot/db.crt" \
+            -o "VARS_CUSTOM.secboot.fd.template"
+    fi
+
+    # Reset the firmware config to the default
+    cp "VARS_CUSTOM.secboot.fd.template" "VARS_CUSTOM.secboot.fd"
+
+    qemu_args=(
+        '-cpu' 'host'
+        '-machine' 'pc-q35-9.1,smm=on'
+        '-global' 'driver=cfi.pflash01,property=secure,value=on'
+        '-drive' 'if=pflash,format=raw,unit=0,readonly=on,file=/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd'
+        '-drive' 'if=pflash,format=raw,unit=1,file=./VARS_CUSTOM.secboot.fd'
+    )
+else
+    echo "Not running with Secure Boot enabled"
+
+    qemu_args=(
+        '-bios /usr/share/edk2/ovmf/OVMF_CODE.fd'
+    )
+fi
+
 qemu-system-x86_64 \
     -m 4096 \
     -enable-kvm \
-    -bios /usr/share/edk2/ovmf/OVMF_CODE.fd \
     -drive file=image.qcow2,if=virtio,cache=unsafe \
-    -nic user,model=virtio-net-pci
+    -nic user,model=virtio-net-pci \
+    "${qemu_args[@]}"

--- a/examples/unified-secureboot/Containerfile
+++ b/examples/unified-secureboot/Containerfile
@@ -1,0 +1,51 @@
+# Need 6.12 kernel from rawhide
+FROM fedora:rawhide AS base
+COPY extra /
+COPY cfsctl /usr/bin
+RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
+    set -eux
+
+    # we should install kernel-modules here, but can't
+    # because it'll pull in the entire kernel with it
+    # it seems to work fine for now....
+    dnf --setopt keepcache=1 install -y \
+        composefs \
+        dosfstools \
+        mokutil \
+        policycoreutils-python-utils \
+        selinux-policy-targeted \
+        skopeo \
+        strace \
+        systemd \
+        util-linux
+    systemctl enable systemd-networkd
+    semanage permissive -a systemd_gpt_generator_t  # for volatile-root workaround
+    passwd -d root
+    mkdir /sysroot
+EOF
+
+FROM base AS kernel
+RUN --mount=type=bind,from=base,target=/mnt/base <<EOF
+    set -eux
+
+    mkdir -p /tmp/sysroot/composefs
+    COMPOSEFS_FSVERITY="$(cfsctl --repo /tmp/sysroot create-image /mnt/base)"
+
+    mkdir -p /etc/kernel /etc/dracut.conf.d
+    echo "composefs=${COMPOSEFS_FSVERITY} rw" > /etc/kernel/cmdline
+EOF
+RUN --mount=type=cache,target=/var/cache/libdnf5 \
+    --mount=type=secret,id=key \
+    --mount=type=secret,id=cert <<EOF
+    # systemd-boot-unsigned: ditto
+    # btrfs-progs: dracut wants to include this in the initramfs
+    # ukify: dracut doesn't want to take our cmdline args?
+    dnf --setopt keepcache=1 install -y kernel btrfs-progs systemd-boot-unsigned systemd-ukify sbsigntools
+EOF
+
+# This could (better?) be done from cfsctl...
+FROM base AS bootable
+COPY --from=kernel /boot /composefs-meta/boot
+# https://github.com/containers/buildah/issues/5950
+RUN --mount=type=tmpfs,target=/run \
+    rm -rf /composefs-meta

--- a/examples/unified-secureboot/build
+++ b/examples/unified-secureboot/build
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -eux
+
+cd "${0%/*}"
+
+cargo build --release
+
+cp ../../target/release/cfsctl .
+cp ../../target/release/composefs-pivot-sysroot extra/usr/lib/dracut/modules.d/37composefs/
+CFSCTL='./cfsctl --repo tmp/sysroot/composefs'
+
+rm -rf tmp
+mkdir -p tmp/sysroot/composefs tmp/sysroot/var
+
+# See: https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot
+# Alternative to generate keys for testing: `sbctl create-keys`
+if [[ ! -d "secureboot" ]]; then
+    echo "Generating test Secure Boot keys"
+    mkdir secureboot
+    pushd secureboot > /dev/null
+    uuidgen --random > GUID.txt
+    openssl req -newkey rsa:4096 -nodes -keyout PK.key -new -x509 -sha256 -days 3650 -subj "/CN=Test Platform Key/" -out PK.crt
+    openssl x509 -outform DER -in PK.crt -out PK.cer
+    openssl req -newkey rsa:4096 -nodes -keyout KEK.key -new -x509 -sha256 -days 3650 -subj "/CN=Test Key Exchange Key/" -out KEK.crt
+    openssl x509 -outform DER -in KEK.crt -out KEK.cer
+    openssl req -newkey rsa:4096 -nodes -keyout db.key -new -x509 -sha256 -days 3650 -subj "/CN=Test Signature Database key/" -out db.crt
+    openssl x509 -outform DER -in db.crt -out db.cer
+    popd > /dev/null
+fi
+
+# For debugging, add --no-cache to podman command
+mkdir tmp/internal-sysroot
+podman build \
+    --iidfile=tmp/iid \
+    -v $(pwd)/tmp/internal-sysroot:/tmp/sysroot:z,U \
+    --secret=id=key,src=secureboot/db.key \
+    --secret=id=cert,src=secureboot/db.crt \
+    "$@" .
+
+IMAGE_ID="$(sed s/sha256:// tmp/iid)"
+podman save --format oci-archive -o tmp/final.tar "${IMAGE_ID}"
+${CFSCTL} oci pull oci-archive:tmp/final.tar
+IMAGE_FSVERITY="$(${CFSCTL} oci create-image "${IMAGE_ID}")"
+fsck.erofs "tmp/sysroot/composefs/images/${IMAGE_FSVERITY}"
+
+mkdir -p tmp/efi/loader
+echo 'timeout 3' > tmp/efi/loader/loader.conf
+mkdir -p tmp/efi/EFI/BOOT tmp/efi/EFI/systemd
+sbsign --key secureboot/db.key --cert secureboot/db.crt \
+    /usr/lib/systemd/boot/efi/systemd-bootx64.efi \
+    --output tmp/efi/EFI/systemd/systemd-bootx64.efi
+cp tmp/efi/EFI/{systemd/systemd-bootx64.efi,BOOT/BOOTX64.EFI}
+${CFSCTL} oci prepare-boot "${IMAGE_ID}" tmp/efi
+
+../common/make-image image.qcow2

--- a/examples/unified-secureboot/extra/etc/kernel/uki.conf
+++ b/examples/unified-secureboot/extra/etc/kernel/uki.conf
@@ -1,0 +1,4 @@
+[UKI]
+SecureBootSigningTool=sbsign
+SecureBootPrivateKey=/run/secrets/key
+SecureBootCertificate=/run/secrets/cert

--- a/examples/unified-secureboot/extra/etc/resolv.conf
+++ b/examples/unified-secureboot/extra/etc/resolv.conf
@@ -1,0 +1,1 @@
+../run/systemd/resolve/stub-resolv.conf

--- a/examples/unified-secureboot/extra/usr/lib/dracut/dracut.conf.d/37composefs.conf
+++ b/examples/unified-secureboot/extra/usr/lib/dracut/dracut.conf.d/37composefs.conf
@@ -1,0 +1,6 @@
+# we want to make sure the virtio disk drivers get included
+hostonly=no
+
+# we need to force these in via the initramfs because we don't have modules in
+# the base image
+force_drivers+=" virtio_net vfat "

--- a/examples/unified-secureboot/extra/usr/lib/dracut/modules.d/37composefs/composefs-pivot-sysroot.service
+++ b/examples/unified-secureboot/extra/usr/lib/dracut/modules.d/37composefs/composefs-pivot-sysroot.service
@@ -1,0 +1,34 @@
+# Copyright (C) 2013 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+[Unit]
+DefaultDependencies=no
+ConditionKernelCommandLine=composefs
+ConditionPathExists=/etc/initrd-release
+After=sysroot.mount
+Requires=sysroot.mount
+Before=initrd-root-fs.target
+Before=initrd-switch-root.target
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/composefs-pivot-sysroot
+StandardInput=null
+StandardOutput=journal
+StandardError=journal+console
+RemainAfterExit=yes

--- a/examples/unified-secureboot/extra/usr/lib/dracut/modules.d/37composefs/module-setup.sh
+++ b/examples/unified-secureboot/extra/usr/lib/dracut/modules.d/37composefs/module-setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+check() {
+    return 0
+}
+
+depends() {
+    return 0
+}
+
+install() {
+    inst \
+        "${moddir}/composefs-pivot-sysroot" /bin/composefs-pivot-sysroot
+    inst \
+        "${moddir}/composefs-pivot-sysroot.service" \
+        "${systemdsystemunitdir}/composefs-pivot-sysroot.service"
+
+    $SYSTEMCTL -q --root "${initdir}" add-wants \
+        'initrd-root-fs.target' 'composefs-pivot-sysroot.service'
+}

--- a/examples/unified-secureboot/extra/usr/lib/kernel/install.conf.d/37composefs.conf
+++ b/examples/unified-secureboot/extra/usr/lib/kernel/install.conf.d/37composefs.conf
@@ -1,0 +1,2 @@
+layout = uki
+uki_generator = ukify

--- a/examples/unified-secureboot/extra/usr/lib/systemd/network/37-wired.network
+++ b/examples/unified-secureboot/extra/usr/lib/systemd/network/37-wired.network
@@ -1,0 +1,9 @@
+[Match]
+Type=ether
+
+[Link]
+RequiredForOnline=routable
+
+[Network]
+DHCP=yes
+

--- a/examples/unified-secureboot/extra/usr/lib/systemd/system/systemd-growfs-root.service.d/37-composefs.conf
+++ b/examples/unified-secureboot/extra/usr/lib/systemd/system/systemd-growfs-root.service.d/37-composefs.conf
@@ -1,0 +1,6 @@
+# Make sure we grow the right root filesystem
+
+[Service]
+ExecStart=
+ExecStart=/usr/lib/systemd/systemd-growfs /sysroot
+

--- a/examples/unified-secureboot/run
+++ b/examples/unified-secureboot/run
@@ -1,0 +1,1 @@
+../common/run

--- a/examples/unified/build
+++ b/examples/unified/build
@@ -13,10 +13,12 @@ CFSCTL='./cfsctl --repo tmp/sysroot/composefs'
 rm -rf tmp
 mkdir -p tmp/sysroot/composefs tmp/sysroot/var
 
-# mkdir tmp/internal-sysroot  # for debugging
-# podman build -v $(pwd)/tmp/internal-sysroot:/tmp/sysroot:z,U --iidfile=tmp/iid "$@" .
-#
-podman build --iidfile=tmp/iid "$@" .
+# For debugging, add --no-cache to podman command
+mkdir tmp/internal-sysroot
+podman build \
+    --iidfile=tmp/iid \
+    -v $(pwd)/tmp/internal-sysroot:/tmp/sysroot:z,U \
+    "$@" .
 
 IMAGE_ID="$(sed s/sha256:// tmp/iid)"
 podman save --format oci-archive -o tmp/final.tar "${IMAGE_ID}"


### PR DESCRIPTION
examples/README: Split each sentence on its own line

Signed-off-by: Timothée Ravier <tim@siosm.fr>

---

examples/unified: Bind mount /tmp/sysroot

We need an fs-verity enabled for this operation so mount it from the
host which is more likely to have it (btrfs or ext4).

Signed-off-by: Timothée Ravier <tim@siosm.fr>

---

examples/unified-secureboot: Add Secure Boot signed example

- Based on `unified` example
- Generate keys for Secure Boot signing on demand
- Add mokutil to list Secure Boot related info
- Sign the UKI & systemd-boot
- Generate EUFI VARS including only our own keys and pass it to the EDK2
  firwmare with QEMU

Signed-off-by: Timothée Ravier <tim@siosm.fr>