### PR TITLE
selabel: Fix clippy lint

### DIFF
--- a/src/selabel.rs
+++ b/src/selabel.rs
@@ -245,7 +245,7 @@ fn parse_config(file: impl Read) -> Result<Option<String>> {
     for line in BufReader::new(file).lines() {
         if let Some((key, value)) = line?.split_once('=') {
             // this might be a comment, but then key will start with '#'
-            if key.trim().to_ascii_uppercase() == "SELINUXTYPE" {
+            if key.trim().eq_ignore_ascii_case("SELINUXTYPE") {
                 return Ok(Some(value.trim().to_string()));
             }
         }


### PR DESCRIPTION
```
warning: manual case-insensitive ASCII comparison
   --> src/selabel.rs:248:16
    |
248 |             if key.trim().to_ascii_uppercase() == "SELINUXTYPE" {
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_ignore_case_cmp
    = note: `#[warn(clippy::manual_ignore_case_cmp)]` on by default
help: consider using `.eq_ignore_ascii_case()` instead
    |
248 |             if key.trim().eq_ignore_ascii_case("SELINUXTYPE") {
    |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```