### PR TITLE
fsverity: introduce EnableVerifyError::FilesystemNotSupported error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ zstd = "0.13.2"
 [dev-dependencies]
 insta = "1.42.0"
 similar-asserts = "1.6.0"
-test-with = { version = "0.14", default-features = false, features = ["executable"] }
+test-with = { version = "0.14", default-features = false, features = ["executable", "runtime"] }
 
 [profile.dev.package.sha2]
 # this is *really* slow otherwise


### PR DESCRIPTION
This commit improves the UX of the error reporting when enabling fs-verity fails because the underlying filesystem does not support this. Here we currently just error with:
```
Inappropriate ioctl for device"
```
with the new code we error with:
```
Filesystem not supported by fs-verity
```

Note that the test relies on the fact that /dev/shm is not supported by fs-verity.

Closes: https://github.com/containers/composefs-rs/issues/59