### PR TITLE
Pass `--allowerasing` to dnf for package conflict resolution

### DIFF
--- a/examples/bls/Containerfile
+++ b/examples/bls/Containerfile
@@ -4,7 +4,7 @@ COPY extra /
 COPY cfsctl /usr/bin
 RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
     set -eux
-    dnf --setopt keepcache=1 install -y systemd util-linux skopeo composefs strace dosfstools kernel
+    dnf --setopt keepcache=1 install --allowerasing -y systemd util-linux skopeo composefs strace dosfstools kernel
     systemctl enable systemd-networkd
     passwd -d root
     mkdir /sysroot

--- a/examples/uki/Containerfile
+++ b/examples/uki/Containerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
     # we should install kernel-modules here, but can't
     # because it'll pull in the entire kernel with it
     # it seems to work fine for now....
-    dnf --setopt keepcache=1 install -y \
+    dnf --setopt keepcache=1 install --allowerasing -y \
         composefs \
         dosfstools \
         policycoreutils-python-utils \

--- a/examples/unified/Containerfile
+++ b/examples/unified/Containerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
     # we should install kernel-modules here, but can't
     # because it'll pull in the entire kernel with it
     # it seems to work fine for now....
-    dnf --setopt keepcache=1 install -y \
+    dnf --setopt keepcache=1 install --allowerasing -y \
         composefs \
         dosfstools \
         policycoreutils-python-utils \


### PR DESCRIPTION
Fixes conflicts introduced by some `systemd-standalone-sysusers` packages

```
Failed to resolve the transaction:
Problem: installed package systemd-standalone-sysusers-257.3-7.fc43.x86_64 conflicts with systemd-standalone-sysusers provided by systemd-sysusers-257.3-6.fc43.x86_64 from rawhide
  - problem with installed package
  - package systemd-257.3-6.fc43.x86_64 from rawhide requires systemd-sysusers(x86-64) = 257.3-6.fc43, but none of the providers can be installed
  - package systemd-standalone-sysusers-257.3-6.fc43.x86_64 from rawhide conflicts with systemd provided by systemd-257.3-6.fc43.x86_64 from rawhide
  - package systemd-udev-257.3-6.fc43.x86_64 from rawhide requires systemd(x86-64) = 257.3-6.fc43, but none of the providers can be installed
  - package kernel-core-6.14.0-0.rc2.20250211gitfebbc555cf0f.23.fc43.x86_64 from rawhide requires /usr/bin/kernel-install, but none of the providers can be installed
  - package kernel-6.14.0-0.rc2.20250211gitfebbc555cf0f.23.fc43.x86_64 from rawhide requires kernel-core-uname-r = 6.14.0-0.rc2.20250211gitfebbc555cf0f.23.fc43.x86_64, 
but none of the providers can be installed
  - conflicting requests
```