### PR TITLE
Issue clean up tar header handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /Cargo.lock
 /target
+*.tar

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ oci-spec = "0.7.0"
 regex-automata = { version = "0.4.8", default-features = false }
 rustix = { version = "0.38.37", features = ["fs", "mount", "process"] }
 sha2 = "0.10.8"
-tar = { version = "0.4.42", default-features = false }
+tar = { version = "0.4.44", default-features = false }
 tempfile = "3.13.0"
 thiserror = "2.0.4"
 tokio = "1.41.0"

--- a/src/image.rs
+++ b/src/image.rs
@@ -11,13 +11,15 @@ use anyhow::{bail, Context, Result};
 
 use crate::fsverity::Sha256HashValue;
 
+pub type StatXattrs = BTreeMap<Box<OsStr>, Box<[u8]>>;
+
 #[derive(Debug)]
 pub struct Stat {
     pub st_mode: u32,
     pub st_uid: u32,
     pub st_gid: u32,
     pub st_mtim_sec: i64,
-    pub xattrs: RefCell<BTreeMap<Box<OsStr>, Box<[u8]>>>,
+    pub xattrs: RefCell<StatXattrs>,
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_debug_implementations)]
+#![allow(clippy::needless_return)]
 
 pub mod dumpfile;
 pub mod dumpfile_parse;
@@ -11,6 +12,7 @@ pub mod oci;
 pub mod repository;
 pub mod selabel;
 pub mod splitstream;
+pub mod trace;
 pub mod util;
 
 /// All files that contain 64 or fewer bytes (size <= INLINE_CONTENT_MAX) should be stored inline

--- a/src/oci/image.rs
+++ b/src/oci/image.rs
@@ -17,11 +17,10 @@ pub fn process_entry(filesystem: &mut FileSystem, entry: oci::tar::TarEntry) -> 
     let mut components = entry.path.components();
 
     let Some(Component::Normal(filename)) = components.next_back() else {
-        bail!("Empty filename. Processing entry: {entry:#?}")
+        bail!("Empty filename")
     };
 
     let mut dir = &mut filesystem.root;
-
     for component in components {
         if let Component::Normal(name) = component {
             dir = dir.recurse(name)?;
@@ -29,7 +28,6 @@ pub fn process_entry(filesystem: &mut FileSystem, entry: oci::tar::TarEntry) -> 
     }
 
     let bytes = filename.as_bytes();
-
     if let Some(whiteout) = bytes.strip_prefix(b".wh.") {
         if whiteout == b".wh.opq" {
             // complete name is '.wh..wh.opq'
@@ -40,7 +38,6 @@ pub fn process_entry(filesystem: &mut FileSystem, entry: oci::tar::TarEntry) -> 
     } else {
         match entry.item {
             oci::tar::TarItem::Directory => dir.mkdir(filename, entry.stat),
-
             oci::tar::TarItem::Leaf(content) => dir.insert(
                 filename,
                 Inode::Leaf(Rc::new(Leaf {
@@ -48,7 +45,6 @@ pub fn process_entry(filesystem: &mut FileSystem, entry: oci::tar::TarEntry) -> 
                     content,
                 })),
             ),
-
             oci::tar::TarItem::Hardlink(ref target) => {
                 // TODO: would be nice to do this inline, but borrow checker doesn't like it
                 filesystem.hardlink(&entry.path, target)?;
@@ -64,7 +60,6 @@ pub fn compose_filesystem(repo: &Repository, layers: &[String]) -> Result<FileSy
 
     for layer in layers {
         let mut split_stream = repo.open_stream(layer, None)?;
-
         while let Some(entry) = oci::tar::get_entry(&mut split_stream)? {
             process_entry(&mut filesystem, entry)?;
         }
@@ -99,7 +94,6 @@ pub fn create_image(
         let layer_verity = config_stream.lookup(&layer_sha256)?;
 
         let mut layer_stream = repo.open_stream(&hex::encode(layer_sha256), Some(layer_verity))?;
-
         while let Some(entry) = oci::tar::get_entry(&mut layer_stream)? {
             process_entry(&mut filesystem, entry)?;
         }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -291,6 +291,8 @@ impl Repository {
         Ok(object_id)
     }
 
+    /// Opens "composefs/sysroot/<name>"
+    /// If `verity` is `Some`, validates verity of the file
     pub fn open_stream(
         &self,
         name: &str,

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,13 @@
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        println!("{}:{}: {}", file!(), line!(), format_args!($($arg)*));
+    };
+}
+
+#[macro_export]
+macro_rules! etrace {
+    ($($arg:tt)*) => {
+        eprintln!("{}:{}: {}", file!(), line!(), format_args!($($arg)*));
+    };
+}


### PR DESCRIPTION
- Use the tar crate for parsing archive entries
- Update tar crate to `0.4.44` from `0.4.42`