### PR TITLE
gc: use internal objects-for-image code

### DIFF
--- a/src/bin/cfsctl.rs
+++ b/src/bin/cfsctl.rs
@@ -94,6 +94,9 @@ enum Command {
     CreateDumpfile {
         path: PathBuf,
     },
+    ImageObjects {
+        name: String,
+    },
 }
 
 fn main() -> Result<()> {
@@ -184,6 +187,12 @@ fn main() -> Result<()> {
         }
         Command::Mount { name, mountpoint } => {
             repo.mount(&name, &mountpoint)?;
+        }
+        Command::ImageObjects { name } => {
+            let objects = repo.objects_for_image(&name)?;
+            for object in objects {
+                println!("{}", hex::encode(object));
+            }
         }
         Command::GC => {
             repo.gc()?;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -546,10 +546,14 @@ impl Repository {
         }
 
         for first_byte in 0x0..=0xff {
-            let dirfd = self.openat(
+            let dirfd = match self.openat(
                 &format!("objects/{first_byte:02x}"),
                 OFlags::RDONLY | OFlags::DIRECTORY,
-            )?;
+            ) {
+                Ok(fd) => fd,
+                Err(Errno::NOENT) => continue,
+                Err(e) => Err(e)?,
+            };
             for item in Dir::new(dirfd)? {
                 let entry = item?;
                 let filename = entry.file_name();


### PR DESCRIPTION
Add an internal implementation of `composefs-info objects` and use it from our gc code.  This drops the last runtime dependency on the composefs command-line tools.
