### PR TITLE
composefs-pivot-sysroot improvements

### DIFF
--- a/src/bin/composefs-pivot-sysroot.rs
+++ b/src/bin/composefs-pivot-sysroot.rs
@@ -22,7 +22,7 @@ fn parse_composefs_cmdline(cmdline: &[u8]) -> Result<Sha256HashValue> {
     bail!("Unable to find composefs= cmdline parameter");
 }
 
-fn pivot_sysroot(image: impl AsFd, name: &str, basedir: &Path, sysroot: &Path) -> Result<()> {
+fn gpt_workaround() -> Result<()> {
     // https://github.com/systemd/systemd/issues/35017
     let rootdev = stat("/dev/gpt-auto-root")?;
     let target = format!(
@@ -31,6 +31,11 @@ fn pivot_sysroot(image: impl AsFd, name: &str, basedir: &Path, sysroot: &Path) -
         minor(rootdev.st_rdev)
     );
     symlink(target, "/run/systemd/volatile-root")?;
+    Ok(())
+}
+
+fn pivot_sysroot(image: impl AsFd, name: &str, basedir: &Path, sysroot: &Path) -> Result<()> {
+    let _ = gpt_workaround(); // best effort
 
     let mnt = composefs_fsmount(image, name, basedir)?;
 

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -5,13 +5,9 @@ use std::{
 };
 
 use anyhow::Result;
-use rustix::{
-    fs::{major, minor, stat, symlink, CWD},
-    io::Errno,
-    mount::{
-        fsconfig_create, fsconfig_set_string, fsmount, fsopen, move_mount, open_tree, unmount,
-        FsMountFlags, FsOpenFlags, MountAttrFlags, MoveMountFlags, OpenTreeFlags, UnmountFlags,
-    },
+use rustix::mount::{
+    fsconfig_create, fsconfig_set_string, fsmount, fsopen, move_mount, unmount, FsMountFlags,
+    FsOpenFlags, MountAttrFlags, MoveMountFlags, UnmountFlags,
 };
 
 struct FsHandle {
@@ -110,54 +106,4 @@ pub fn mount_fd<F: AsFd>(image: F, name: &str, basedir: &Path, mountpoint: &str)
     )?;
 
     Ok(())
-}
-
-pub fn pivot_sysroot(image: impl AsFd, name: &str, basedir: &Path, sysroot: &Path) -> Result<()> {
-    // https://github.com/systemd/systemd/issues/35017
-    let rootdev = stat("/dev/gpt-auto-root")?;
-    let target = format!(
-        "/dev/block/{}:{}",
-        major(rootdev.st_rdev),
-        minor(rootdev.st_rdev)
-    );
-    symlink(target, "/run/systemd/volatile-root")?;
-
-    let mnt = composefs_fsmount(image, name, basedir)?;
-
-    // try to move /sysroot to /sysroot/sysroot if it exists
-    let prev = open_tree(CWD, sysroot, OpenTreeFlags::OPEN_TREE_CLONE)?;
-    unmount(sysroot, UnmountFlags::DETACH)?;
-
-    move_mount(
-        mnt.as_fd(),
-        "",
-        rustix::fs::CWD,
-        sysroot,
-        MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
-    )?;
-
-    match move_mount(
-        prev.as_fd(),
-        "",
-        mnt.as_fd(),
-        "sysroot",
-        MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
-    ) {
-        Ok(()) | Err(Errno::NOENT) => {}
-        Err(err) => Err(err)?,
-    }
-
-    // try to bind-mount (original) /sysroot/var to (new) /sysroot/var, if it exists
-    match open_tree(prev.as_fd(), "var", OpenTreeFlags::OPEN_TREE_CLONE).and_then(|var| {
-        move_mount(
-            var.as_fd(),
-            "",
-            mnt.as_fd(),
-            "var",
-            MoveMountFlags::MOVE_MOUNT_F_EMPTY_PATH,
-        )
-    }) {
-        Ok(()) | Err(Errno::NOENT) => Ok(()),
-        Err(err) => Err(err)?,
-    }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -501,15 +501,7 @@ impl Repository {
     }
 
     pub fn objects_for_image(&self, name: &str) -> Result<HashSet<Sha256HashValue>> {
-        let filename = format!("images/{}", name);
-
-        let image = if name.contains("/") {
-            // no fsverity checking on this path
-            Ok(self.openat(&filename, OFlags::RDONLY)?)
-        } else {
-            self.open_with_verity(&filename, &parse_sha256(name)?)
-        }?;
-
+        let image = self.open_image(name)?;
         let mut data = vec![];
         std::fs::File::from(image).read_to_end(&mut data)?;
         Ok(crate::erofs::reader::collect_objects(&data)?)


### PR DESCRIPTION
This moves the implementation out of the library and into the command.  That makes sense, since this is not an operation you'd want to do in any other context.

It also adds a commandline option to pivot a different mount point other than `/sysroot`.  GNOME developer Jelle van der Waa is sitting beside me now and he mentions that Arch (mkinitcpio) uses `/new_root`, for example.