### PR TITLE
examples/bls: use mkinitcpio for initramfs generation

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,6 +19,7 @@ jobs:
           - { dir: 'uki', file: 'Containerfile' }
           - { dir: 'uki', file: 'Containerfile.arch' }
           - { dir: 'bls', file: 'Containerfile' }
+          - { dir: 'bls', file: 'Containerfile.arch' }
           - { dir: 'bls', file: 'Containerfile.ubuntu' }
           - { dir: 'unified', file: 'Containerfile' }
       fail-fast: false

--- a/examples/bls/Containerfile.arch
+++ b/examples/bls/Containerfile.arch
@@ -4,13 +4,14 @@ COPY cfsctl /usr/bin
 RUN <<EOF
     set -eux
     touch /etc/machine-id
-    pacman -Sy --noconfirm skopeo composefs strace dosfstools dracut btrfs-progs
-    curl -O https://pkgbuild.com/~jelle/linux-mainline-6.12rc6-1-x86_64.pkg.tar.zst
-    pacman -U --noconfirm linux-mainline-6.12rc6-1-x86_64.pkg.tar.zst
-    systemctl enable systemd-networkd systemd-resolved
+    echo 'root=/dev/vda2' > /etc/kernel/cmdline
+    pacman -Syu --noconfirm
+    pacman -Sy --noconfirm skopeo composefs strace dosfstools linux mkinitcpio btrfs-progs openssh
+    systemctl enable systemd-networkd systemd-resolved sshd
+    ssh-keygen -A
     passwd -d root
     mkdir /sysroot
-    kernel-install add 6.12.0-rc6-1-mainline /usr/lib/modules/6.12.0-rc6-1-mainline/vmlinuz
+    kernel-install add "$(ls /usr/lib/modules)" /usr/lib/modules/"$(ls /usr/lib/modules)"/vmlinuz
     mkdir /composefs-meta
     mv /boot /composefs-meta
     mkdir /boot

--- a/examples/bls/extra/etc/mkinitcpio.conf
+++ b/examples/bls/extra/etc/mkinitcpio.conf
@@ -1,0 +1,3 @@
+MODULES=(overlay erofs)
+BINARIES=(strace)
+HOOKS=(base udev composefs autodetect microcode modconf kms keyboard keymap block filesystems)

--- a/examples/bls/extra/usr/lib/initcpio/hooks/composefs
+++ b/examples/bls/extra/usr/lib/initcpio/hooks/composefs
@@ -1,0 +1,12 @@
+#!/usr/bin/ash
+
+run_latehook() {
+    local composefs
+
+    composefs="$(getarg composefs)"
+    if [ -z "$composefs" ]; then
+        return 0
+    fi
+
+    /usr/bin/composefs-pivot-sysroot /new_root
+}

--- a/examples/bls/extra/usr/lib/initcpio/install/composefs
+++ b/examples/bls/extra/usr/lib/initcpio/install/composefs
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+build() {
+    add_binary "/usr/lib/dracut/modules.d/37composefs/composefs-pivot-sysroot" "/usr/bin/composefs-pivot-sysroot"
+    add_runscript
+}

--- a/examples/uki/Containerfile.arch
+++ b/examples/uki/Containerfile.arch
@@ -4,8 +4,9 @@ COPY cfsctl /usr/bin
 RUN <<EOF
     set -eux
     touch /etc/machine-id
+    mkdir -p boot/EFI/Linux
     pacman -Syu --noconfirm
-    pacman -Sy --noconfirm skopeo composefs strace dosfstools openssh
+    pacman -Sy --noconfirm skopeo composefs strace dosfstools openssh linux
     systemctl enable systemd-networkd systemd-resolved sshd
     ssh-keygen -A
     passwd -d root
@@ -17,10 +18,9 @@ ARG COMPOSEFS_FSVERITY
 RUN <<EOF
     set -eux
     # systemd-boot-unsigned: ditto
-    # btrfs-progs: dracut wants to include this in the initramfs
-    # ukify: dracut doesn't want to take our cmdline args?
-    pacman -Sy --noconfirm linux dracut btrfs-progs systemd-ukify
-    dracut --kver "$(ls /usr/lib/modules)" --uefi --kernel-cmdline="console=ttyS0,115200 composefs=${COMPOSEFS_FSVERITY} rw"
+    echo "root=/dev/vda2 console=ttyS0,115200 composefs=${COMPOSEFS_FSVERITY} rw" > /etc/kernel/cmdline
+    pacman -Sy --noconfirm systemd-ukify
+    mkinitcpio -p linux
 EOF
 
 # This could (better?) be done from cfsctl...

--- a/examples/uki/extra/etc/mkinitcpio.conf
+++ b/examples/uki/extra/etc/mkinitcpio.conf
@@ -1,0 +1,3 @@
+MODULES=(overlay erofs)
+BINARIES=(strace)
+HOOKS=(base udev composefs autodetect microcode modconf kms keyboard keymap block filesystems)

--- a/examples/uki/extra/etc/mkinitcpio.d/linux.preset
+++ b/examples/uki/extra/etc/mkinitcpio.d/linux.preset
@@ -1,0 +1,10 @@
+ALL_kver="/boot/vmlinuz-linux"
+
+MODULES=(ext4 overlay erofs)
+BINARIES=(fsck.ext4 strace)
+HOOKS=(base udev composefs autodetect microcode modconf kms keyboard keymap consolefont block filesystems fsck)
+
+PRESETS=('default')
+
+default_uki="/boot/EFI/Linux/arch-linux.efi"
+default_options="--splash=/usr/share/systemd/bootctl/splash-arch.bmp"

--- a/examples/uki/extra/usr/lib/initcpio/hooks/composefs
+++ b/examples/uki/extra/usr/lib/initcpio/hooks/composefs
@@ -1,0 +1,12 @@
+#!/usr/bin/ash
+
+run_latehook() {
+    local composefs
+
+    composefs="$(getarg composefs)"
+    if [ -z "$composefs" ]; then
+        return 0
+    fi
+
+    /usr/bin/composefs-pivot-sysroot /new_root
+}

--- a/examples/uki/extra/usr/lib/initcpio/install/composefs
+++ b/examples/uki/extra/usr/lib/initcpio/install/composefs
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+build() {
+    add_binary "/usr/lib/dracut/modules.d/37composefs/composefs-pivot-sysroot" "/usr/bin/composefs-pivot-sysroot"
+    add_runscript
+}


### PR DESCRIPTION
Arch Linux uses dracut-ng which by default runs in `hostonly` mode with no easy way to override this behaviour via kernel-install. `hostonly` mode misses virt_blk, ext4 and other kernel modules we would need to pivot to composefs before `switch_root`.

The default initramfs generator for Arch Linux is `mkinitcpio` which by default is without `systemd` and the root filesystem is mounted on `/new_root` instead of `/sysroot`.

Since there is no systemd in the initramfs the root partition has to be hardcoded in the kernel command line and custom composefs hooks to call composefs-pivot-sysroot. The hooks are GPL2 so they can eventually be upstreamed into `mkinitcpio` itself.