### PR TITLE
examples: pull directly from containers storage

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   fedora:
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     container:
       image: quay.io/fedora/fedora:41
       options: "--privileged --pid=host -v /var/tmp:/var/tmp -v /:/run/host"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rhel9 = ['pre-6.15']
 
 [dependencies]
 anyhow = { version = "1.0.97", default-features = false }
-async-compression = { version = "0.4.22", default-features = false, features = ["tokio", "gzip"] }
+async-compression = { version = "0.4.22", default-features = false, features = ["tokio", "zstd", "gzip"] }
 clap = { version = "4.5.32", default-features = false, features = ["std", "help", "usage", "derive"] }
 containers-image-proxy = "0.7.0"
 env_logger = "0.11.7"

--- a/examples/bls/build
+++ b/examples/bls/build
@@ -34,9 +34,6 @@ case "${os}" in
         ;;
 esac
 
-# https://github.com/containers/buildah/issues/5656
-PODMAN_BUILD="podman build --no-cache"
-
 cargo build --release "${features}"
 
 cp ../../target/release/cfsctl .
@@ -46,7 +43,7 @@ CFSCTL='./cfsctl --repo tmp/sysroot/composefs'
 rm -rf tmp
 mkdir -p tmp/sysroot/composefs
 
-${PODMAN_BUILD} \
+podman build \
     --iidfile=tmp/base.iid \
     -f "${containerfile}" \
     .

--- a/examples/bls/build
+++ b/examples/bls/build
@@ -49,8 +49,7 @@ podman build \
     .
 
 BASE_ID="$(sed s/sha256:// tmp/base.iid)"
-podman save --format oci-archive -o tmp/base.tar "${BASE_ID}"
-${CFSCTL} oci pull oci-archive:tmp/base.tar
+${CFSCTL} oci pull containers-storage:${BASE_ID}
 BASE_IMAGE_FSVERITY="$(${CFSCTL} oci create-image "${BASE_ID}")"
 fsck.erofs "tmp/sysroot/composefs/images/${BASE_IMAGE_FSVERITY}"
 

--- a/examples/uki/build
+++ b/examples/uki/build
@@ -41,8 +41,7 @@ ${PODMAN_BUILD} \
     .
 
 BASE_ID="$(sed s/sha256:// tmp/base.iid)"
-podman save --format oci-archive -o tmp/base.tar "${BASE_ID}"
-${CFSCTL} oci pull oci-archive:tmp/base.tar
+${CFSCTL} oci pull containers-storage:"${BASE_ID}"
 BASE_IMAGE_FSVERITY="$(${CFSCTL} oci create-image "${BASE_ID}")"
 
 ${PODMAN_BUILD} \
@@ -54,8 +53,7 @@ ${PODMAN_BUILD} \
     .
 
 FINAL_ID="$(sed s/sha256:// tmp/final.iid)"
-podman save --format oci-archive -o tmp/final.tar "${FINAL_ID}"
-${CFSCTL} oci pull oci-archive:tmp/final.tar
+${CFSCTL} oci pull containers-storage:"${FINAL_ID}"
 FINAL_IMAGE_FSVERITY="$(${CFSCTL} oci create-image "${FINAL_ID}")"
 fsck.erofs "tmp/sysroot/composefs/images/${FINAL_IMAGE_FSVERITY}"
 

--- a/examples/unified-secureboot/build
+++ b/examples/unified-secureboot/build
@@ -47,8 +47,7 @@ podman build \
     .
 
 IMAGE_ID="$(sed s/sha256:// tmp/iid)"
-podman save --format oci-archive -o tmp/final.tar "${IMAGE_ID}"
-${CFSCTL} oci pull oci-archive:tmp/final.tar
+${CFSCTL} oci pull containers-storage:"${IMAGE_ID}"
 IMAGE_FSVERITY="$(${CFSCTL} oci create-image "${IMAGE_ID}")"
 fsck.erofs "tmp/sysroot/composefs/images/${IMAGE_FSVERITY}"
 

--- a/examples/unified/build
+++ b/examples/unified/build
@@ -29,8 +29,7 @@ podman build \
     .
 
 IMAGE_ID="$(sed s/sha256:// tmp/iid)"
-podman save --format oci-archive -o tmp/final.tar "${IMAGE_ID}"
-${CFSCTL} oci pull oci-archive:tmp/final.tar
+${CFSCTL} oci pull containers-storage:"${IMAGE_ID}"
 IMAGE_FSVERITY="$(${CFSCTL} oci create-image "${IMAGE_ID}")"
 fsck.erofs "tmp/sysroot/composefs/images/${IMAGE_FSVERITY}"
 


### PR DESCRIPTION
Instead of having podman save our container images to a oci-archive and pulling from that, save ourselves a bunch of work (including a gzip compress/decompress cycle) by pulling directly from `containers-storage:`.

In order to accomplish this, the patch series also adds support for uncompressed and zstd-compressed layers and includes a workaround for https://github.com/containers/skopeo/issues/2563