### PR TITLE
repository: open_path: include path in error context

### DIFF
--- a/src/repository.rs
+++ b/src/repository.rs
@@ -47,9 +47,11 @@ impl Repository {
     }
 
     pub fn open_path(dirfd: impl AsFd, path: impl AsRef<Path>) -> Result<Repository> {
+        let path = path.as_ref();
+
         // O_PATH isn't enough because flock()
-        let repository = openat(dirfd, path.as_ref(), OFlags::RDONLY, Mode::empty())
-            .context("Cannot open composefs repository")?;
+        let repository = openat(dirfd, path, OFlags::RDONLY, Mode::empty())
+            .with_context(|| format!("Cannot open composefs repository at {}", path.display()))?;
 
         flock(&repository, FlockOperation::LockShared)
             .context("Cannot lock composefs repository")?;


### PR DESCRIPTION
It was not immediately obvious to me where the default repository was
expected to be located.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
