### PR TITLE
Cargo.toml: list actual minimum dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,27 +17,27 @@ rhel9 = ['pre-6.15']
 'pre-6.15' = []
 
 [dependencies]
-anyhow = { version = "1.0.97", default-features = false }
-async-compression = { version = "0.4.22", default-features = false, features = ["tokio", "zstd", "gzip"] }
-clap = { version = "4.5.32", default-features = false, features = ["std", "help", "usage", "derive"] }
+anyhow = { version = "1.0.87", default-features = false }
+async-compression = { version = "0.4.0", default-features = false, features = ["tokio", "zstd", "gzip"] }
+clap = { version = "4.0.1", default-features = false, features = ["std", "help", "usage", "derive"] }
 containers-image-proxy = "0.7.0"
-env_logger = "0.11.7"
-hex = "0.4.3"
-indicatif = { version = "0.17.11", features = ["tokio"] }
-log = "0.4.27"
-oci-spec = "0.7.1"
-regex-automata = { version = "0.4.9", default-features = false }
-rustix = { version = "1.0.3", features = ["fs", "mount", "process"] }
-serde = "1.0.219"
-sha2 = "0.10.8"
-tar = { version = "0.4.44", default-features = false }
-tempfile = "3.19.1"
-thiserror = "2.0.12"
-tokio = "1.44.1"
-toml = "0.8.20"
-xxhash-rust = { version = "0.8.15", features = ["xxh32"] }
-zerocopy = { version = "0.8.24", features = ["derive"] }
-zstd = "0.13.3"
+env_logger = "0.11.0"
+hex = "0.4.0"
+indicatif = { version = "0.17.0", features = ["tokio"] }
+log = "0.4.8"
+oci-spec = "0.7.0"
+regex-automata = { version = "0.4.4", default-features = false }
+rustix = { version = "1.0.0", features = ["fs", "mount", "process"] }
+serde = "1.0.145"
+sha2 = "0.10.1"
+tar = { version = "0.4.38", default-features = false }
+tempfile = "3.8.0"
+thiserror = "2.0.0"
+tokio = "1.24.2"
+toml = "0.8.0"
+xxhash-rust = { version = "0.8.2", features = ["xxh32"] }
+zerocopy = { version = "0.8.0", features = ["derive"] }
+zstd = "0.13.0"
 
 [dev-dependencies]
 insta = "1.42.2"


### PR DESCRIPTION
In 72d8b71465c6 ("Cargo.toml: update all the things") we randomly raised all of our dependencies to the latest versions, mostly because I don't know what I'm doing when it comes to these things.  That was a mistake: trying to use the latest version of composefs-rs from bootc causes all kinds of dependency conflicts now.

So let's try and do the opposite and try to list the minimum version that:
 - is semver compatible with the latest version (so we get updates)
 - doesn't break

I tried playing with automated tooling for this but it wasn't easy to get it working without a nightly toolchain (which I don't have setup), and I was also interested in exploring the actual reasons for the requirements, so I went with a simple manual process: I dropped all of the version numbers in [dependencies] (but not [dev-dependencies]) to their lowest semver-compatible version and added "=" in front.

Then I adjusted upwards for yanked releases:
 - sha2 0.10.0 -> 0.10.1
 - tempfile 3.0.0 -> 3.0.2
 - tokio 1.0.0 -> 1.0.1
 - xxhash-rust 0.8.0 -> 0.8.2

Then (because of '=' dependencies) I needed to make adjustments for conflicts with dependencies specified by other packages:
 - log 0.4.0 -> log 0.4.8 to satisfy an env_logger dependency
 - regex-automata 0.4.0 -> 0.4.4 for regex (via oci-spec)
 - serde 1.0.0 -> 1.0.145 for toml
 - tokio 1.0.1 -> 1.24.2 for async-compression

Then I actually tried to build and run unit tests to determine which versions were actually required in this crate, and bumped some more things:
 - anyhow 1.0.0 -> 1.0.87 to support the automatic conversions we require via use of `?`
 - clap 4.0.0 -> 4.0.1 was the first version with #[clap(version)]
 - tar 0.4.0 -> 0.4.38 for PaxExtensions::new()
 - tempfile 3.0.2 -> 3.8.0 for tempfile_in()

After that, I ran the examples and everything there seemed to work properly without additional changes, so I dropped the '=' signs and finished by checking that it was now possible to once again consume composefs-rs from bootc without a bunch of unnecessary version changes on that side.