### PR TITLE
add complete (library) support for sha-512

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ thiserror = "2.0.0"
 tokio = "1.24.2"
 toml = "0.8.0"
 xxhash-rust = { version = "0.8.2", features = ["xxh32"] }
-zerocopy = { version = "0.8.0", features = ["derive"] }
+zerocopy = { version = "0.8.0", features = ["derive", "std"] }
 zstd = "0.13.0"
 
 [dev-dependencies]

--- a/src/bin/cfsctl.rs
+++ b/src/bin/cfsctl.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
 
     let args = App::parse();
 
-    let repo = (if let Some(path) = args.repo {
+    let repo: Repository<Sha256HashValue> = (if let Some(path) = args.repo {
         Repository::open_path(CWD, path)
     } else if args.system {
         Repository::open_system()
@@ -193,7 +193,7 @@ fn main() -> Result<()> {
             println!("{}", image_id.to_hex());
         }
         Command::CreateDumpfile { ref path } => {
-            composefs::fs::create_dumpfile(path)?;
+            composefs::fs::create_dumpfile::<Sha256HashValue>(path)?;
         }
         Command::Mount { name, mountpoint } => {
             repo.mount(&name, &mountpoint)?;

--- a/src/bin/composefs-setup-root.rs
+++ b/src/bin/composefs-setup-root.rs
@@ -284,18 +284,23 @@ fn main() -> Result<()> {
     setup_root(args)
 }
 
-#[test]
-fn test_parse() {
-    let failing = ["", "foo", "composefs", "composefs=foo"];
-    for case in failing {
-        assert!(parse_composefs_cmdline(case.as_bytes()).is_err());
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse() {
+        let failing = ["", "foo", "composefs", "composefs=foo"];
+        for case in failing {
+            assert!(parse_composefs_cmdline(case.as_bytes()).is_err());
+        }
+        let digest = "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52";
+        let digest_bytes = hex::decode(digest).unwrap();
+        similar_asserts::assert_eq!(
+            parse_composefs_cmdline(format!("composefs={digest}").as_bytes())
+                .unwrap()
+                .as_slice(),
+            &digest_bytes
+        );
     }
-    let digest = "8b7df143d91c716ecfa5fc1730022f6b421b05cedee8fd52b1fc65a96030ad52";
-    let digest_bytes = hex::decode(digest).unwrap();
-    similar_asserts::assert_eq!(
-        parse_composefs_cmdline(format!("composefs={digest}").as_bytes())
-            .unwrap()
-            .as_slice(),
-        &digest_bytes
-    );
 }

--- a/src/dumpfile.rs
+++ b/src/dumpfile.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use rustix::fs::FileType;
 
 use crate::{
-    fsverity::Sha256HashValue,
+    fsverity::{FsVerityHashValue, Sha256HashValue},
     image::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
 };
 
@@ -66,7 +66,7 @@ fn write_entry(
     write_escaped(writer, content)?;
     write!(writer, " ")?;
     if let Some(id) = digest {
-        write!(writer, "{}", hex::encode(id))?;
+        write!(writer, "{}", id.to_hex())?;
     } else {
         write_empty(writer)?;
     }
@@ -129,7 +129,7 @@ pub fn write_leaf(
             *size,
             nlink,
             0,
-            format!("{:02x}/{}", id[0], hex::encode(&id[1..])),
+            id.to_object_pathname(),
             &[],
             Some(id),
         ),

--- a/src/dumpfile.rs
+++ b/src/dumpfile.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use rustix::fs::FileType;
 
 use crate::{
-    fsverity::{FsVerityHashValue, Sha256HashValue},
+    fsverity::FsVerityHashValue,
     image::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
 };
 
@@ -49,7 +49,7 @@ fn write_entry(
     rdev: u64,
     payload: impl AsRef<OsStr>,
     content: &[u8],
-    digest: Option<&Sha256HashValue>,
+    digest: Option<&str>,
 ) -> fmt::Result {
     let mode = stat.st_mode | ifmt.as_raw_mode();
     let uid = stat.st_uid;
@@ -66,7 +66,7 @@ fn write_entry(
     write_escaped(writer, content)?;
     write!(writer, " ")?;
     if let Some(id) = digest {
-        write!(writer, "{}", id.to_hex())?;
+        write!(writer, "{}", id)?;
     } else {
         write_empty(writer)?;
     }
@@ -131,7 +131,7 @@ pub fn write_leaf(
             0,
             id.to_object_pathname(),
             &[],
-            Some(id),
+            Some(&id.to_hex()),
         ),
         LeafContent::BlockDevice(rdev) => write_entry(
             writer,

--- a/src/dumpfile.rs
+++ b/src/dumpfile.rs
@@ -101,11 +101,11 @@ pub fn write_directory(
     )
 }
 
-pub fn write_leaf<ObjectID: FsVerityHashValue>(
+pub fn write_leaf(
     writer: &mut impl fmt::Write,
     path: &Path,
     stat: &Stat,
-    content: &LeafContent<ObjectID>,
+    content: &LeafContent<impl FsVerityHashValue>,
     nlink: usize,
 ) -> fmt::Result {
     match content {

--- a/src/erofs/composefs.rs
+++ b/src/erofs/composefs.rs
@@ -1,0 +1,33 @@
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+
+use crate::fsverity::FsVerityHashValue;
+
+/* From linux/fs/overlayfs/overlayfs.h struct ovl_metacopy */
+#[derive(Debug, FromBytes, Immutable, KnownLayout, IntoBytes)]
+#[repr(C)]
+pub(super) struct OverlayMetacopy<H: FsVerityHashValue> {
+    version: u8,
+    len: u8,
+    flags: u8,
+    digest_algo: u8,
+    pub(super) digest: H,
+}
+
+impl<H: FsVerityHashValue> OverlayMetacopy<H> {
+    pub(super) fn new(digest: &H) -> Self {
+        Self {
+            version: 0,
+            len: size_of::<Self>() as u8,
+            flags: 0,
+            digest_algo: H::ALGORITHM,
+            digest: digest.clone(),
+        }
+    }
+
+    pub(super) fn valid(&self) -> bool {
+        self.version == 0
+            && self.len == size_of::<Self>() as u8
+            && self.flags == 0
+            && self.digest_algo == H::ALGORITHM
+    }
+}

--- a/src/erofs/mod.rs
+++ b/src/erofs/mod.rs
@@ -1,3 +1,4 @@
+pub mod composefs;
 pub mod debug;
 pub mod format;
 pub mod reader;

--- a/src/erofs/writer.rs
+++ b/src/erofs/writer.rs
@@ -525,7 +525,7 @@ impl<'a, ObjectID: FsVerityHashValue> InodeCollector<'a, ObjectID> {
 
 /// Takes a list of inodes where each inode contains only local xattr values, determines which
 /// xattrs (key, value) pairs appear more than once, and shares them.
-fn share_xattrs<ObjectID: FsVerityHashValue>(inodes: &mut [Inode<ObjectID>]) -> Vec<XAttr> {
+fn share_xattrs(inodes: &mut [Inode<impl FsVerityHashValue>]) -> Vec<XAttr> {
     let mut xattrs: BTreeMap<XAttr, usize> = BTreeMap::new();
 
     // Collect all xattrs from the inodes
@@ -563,9 +563,9 @@ fn share_xattrs<ObjectID: FsVerityHashValue>(inodes: &mut [Inode<ObjectID>]) -> 
     xattrs.into_keys().collect()
 }
 
-fn write_erofs<ObjectID: FsVerityHashValue>(
+fn write_erofs(
     output: &mut impl Output,
-    inodes: &[Inode<ObjectID>],
+    inodes: &[Inode<impl FsVerityHashValue>],
     xattrs: &[XAttr],
 ) {
     // Write composefs header

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -176,7 +176,7 @@ impl FilesystemReader<'_> {
                 st_uid: buf.st_uid,
                 st_gid: buf.st_gid,
                 st_mtim_sec: buf.st_mtime as i64,
-                xattrs: RefCell::new(FilesystemReader::read_xattrs(fd)?),
+                xattrs: RefCell::new(Self::read_xattrs(fd)?),
             },
         ))
     }
@@ -225,7 +225,7 @@ impl FilesystemReader<'_> {
             Mode::empty(),
         )?;
 
-        let (buf, stat) = FilesystemReader::stat(&fd, ifmt)?;
+        let (buf, stat) = Self::stat(&fd, ifmt)?;
 
         // NB: We could check `st_nlink > 1` to find out if we should track a file as a potential
         // hardlink or not, but some filesystems (like fuse-overlayfs) can report this incorrectly.
@@ -249,7 +249,7 @@ impl FilesystemReader<'_> {
             Mode::empty(),
         )?;
 
-        let (_, stat) = FilesystemReader::stat(&fd, FileType::Directory)?;
+        let (_, stat) = Self::stat(&fd, FileType::Directory)?;
         let mut directory = Directory::new(stat);
 
         for item in Dir::read_from(&fd)? {

--- a/src/fsverity/digest.rs
+++ b/src/fsverity/digest.rs
@@ -64,7 +64,7 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
             // We had a complete value, but now we're adding new data.
             // This means that we need to add a new hash layer...
             let mut new_layer = FsVerityLayer::new();
-            new_layer.add_data(value.as_ref());
+            new_layer.add_data(value.as_bytes());
             self.layers.push(new_layer);
         }
 
@@ -76,7 +76,7 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
 
         for layer in self.layers.iter_mut() {
             // We have a layer we need to hash this value into
-            layer.add_data(value.as_ref());
+            layer.add_data(value.as_bytes());
             if layer.remaining != 0 {
                 return;
             }
@@ -97,7 +97,7 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
             for layer in self.layers.iter_mut() {
                 // We have a layer we need to hash this value into
                 if value != H::EMPTY {
-                    layer.add_data(value.as_ref());
+                    layer.add_data(value.as_bytes());
                 }
                 if layer.remaining != (1 << LG_BLKSZ) {
                     // ...but now this layer itself is complete, so get the value of *it*.
@@ -143,7 +143,7 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
         context.update(0u8.to_le_bytes()); /* salt_size */
         context.update([0; 4]); /* reserved */
         context.update(self.n_bytes.to_le_bytes());
-        context.update(self.root_hash());
+        context.update(self.root_hash().as_bytes());
         context.update([0].repeat(64 - size_of::<H>()));
         context.update([0; 32]); /* salt */
         context.update([0; 144]); /* reserved */
@@ -162,12 +162,12 @@ mod tests {
     #[test]
     fn test_digest() {
         assert_eq!(
-            hex::encode(FsVerityHasher::<Sha256HashValue, 12>::hash(b"hello world")),
+            FsVerityHasher::<Sha256HashValue, 12>::hash(b"hello world").to_hex(),
             "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64"
         );
 
         assert_eq!(
-            hex::encode(FsVerityHasher::<Sha512HashValue, 12>::hash(b"hello world")),
+            FsVerityHasher::<Sha512HashValue, 12>::hash(b"hello world").to_hex(),
             "18430270729d162d4e469daca123ae61893db4b0583d8f7081e3bf4f92b88ba514e7982f10733fb6aa895195c5ae8fd2eb2c47a8be05513ce5a0c51a6f570409"
         );
     }

--- a/src/fsverity/hashvalue.rs
+++ b/src/fsverity/hashvalue.rs
@@ -1,0 +1,27 @@
+use sha2::{digest::FixedOutputReset, digest::Output, Digest, Sha256, Sha512};
+
+pub trait FsVerityHashValue
+where
+    Self: Eq + AsRef<[u8]> + Clone,
+    Self: From<Output<Self::Digest>>,
+{
+    type Digest: Digest + FixedOutputReset + std::fmt::Debug;
+    const ALGORITHM: u8;
+    const EMPTY: Self;
+}
+
+pub type Sha256HashValue = [u8; 32];
+
+impl FsVerityHashValue for Sha256HashValue {
+    type Digest = Sha256;
+    const ALGORITHM: u8 = 1;
+    const EMPTY: Self = [0; 32];
+}
+
+pub type Sha512HashValue = [u8; 64];
+
+impl FsVerityHashValue for Sha512HashValue {
+    type Digest = Sha512;
+    const ALGORITHM: u8 = 2;
+    const EMPTY: Self = [0; 64];
+}

--- a/src/fsverity/hashvalue.rs
+++ b/src/fsverity/hashvalue.rs
@@ -1,27 +1,127 @@
+use core::{fmt, hash::Hash};
+
+use hex::FromHexError;
 use sha2::{digest::FixedOutputReset, digest::Output, Digest, Sha256, Sha512};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 pub trait FsVerityHashValue
 where
-    Self: Eq + AsRef<[u8]> + Clone,
+    Self: Clone,
     Self: From<Output<Self::Digest>>,
+    Self: FromBytes + Immutable + IntoBytes + KnownLayout + Unaligned,
+    Self: Hash + Eq,
+    Self: fmt::Debug,
 {
-    type Digest: Digest + FixedOutputReset + std::fmt::Debug;
+    type Digest: Digest + FixedOutputReset + fmt::Debug;
     const ALGORITHM: u8;
     const EMPTY: Self;
+    const ID: &str;
+
+    fn from_hex(hex: impl AsRef<[u8]>) -> Result<Self, FromHexError> {
+        let mut value = Self::EMPTY;
+        hex::decode_to_slice(hex.as_ref(), value.as_mut_bytes())?;
+        Ok(value)
+    }
+
+    fn from_object_dir_and_basename(
+        dirnum: u8,
+        basename: impl AsRef<[u8]>,
+    ) -> Result<Self, FromHexError> {
+        let expected_size = 2 * (size_of::<Self>() - 1);
+        let bytes = basename.as_ref();
+        if bytes.len() != expected_size {
+            return Err(FromHexError::InvalidStringLength);
+        }
+        let mut result = Self::EMPTY;
+        result.as_mut_bytes()[0] = dirnum;
+        hex::decode_to_slice(bytes, &mut result.as_mut_bytes()[1..])?;
+        Ok(result)
+    }
+
+    fn from_object_pathname(pathname: impl AsRef<[u8]>) -> Result<Self, FromHexError> {
+        // We want to the trailing part of "....../xx/yyyyyy" where xxyyyyyy is our hex length
+        let min_size = 2 * size_of::<Self>() + 1;
+        let bytes = pathname.as_ref();
+        if bytes.len() < min_size {
+            return Err(FromHexError::InvalidStringLength);
+        }
+
+        let trailing = &bytes[bytes.len() - min_size..];
+        let mut result = Self::EMPTY;
+        hex::decode_to_slice(&trailing[0..2], &mut result.as_mut_bytes()[0..1])?;
+        if trailing[2] != b'/' {
+            return Err(FromHexError::InvalidHexCharacter {
+                c: trailing[2] as char,
+                index: 2,
+            });
+        }
+        hex::decode_to_slice(&trailing[3..], &mut result.as_mut_bytes()[1..])?;
+        Ok(result)
+    }
+
+    fn to_object_pathname(&self) -> String {
+        format!("{:02x}/{}", self.as_bytes()[0], self.to_object_basename())
+    }
+
+    fn to_object_dir(&self) -> String {
+        format!("{:02x}", self.as_bytes()[0])
+    }
+
+    fn to_object_basename(&self) -> String {
+        hex::encode(&self.as_bytes()[1..])
+    }
+
+    fn to_hex(&self) -> String {
+        hex::encode(self.as_bytes())
+    }
+
+    fn to_id(&self) -> String {
+        format!("{}:{}", Self::ID, self.to_hex())
+    }
 }
 
-pub type Sha256HashValue = [u8; 32];
+impl fmt::Debug for Sha256HashValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sha256:{}", self.to_hex())
+    }
+}
+
+impl fmt::Debug for Sha512HashValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "sha512:{}", self.to_hex())
+    }
+}
+
+#[derive(Clone, Eq, FromBytes, Hash, Immutable, IntoBytes, KnownLayout, PartialEq, Unaligned)]
+#[repr(C)]
+pub struct Sha256HashValue([u8; 32]);
+
+impl From<Output<Sha256>> for Sha256HashValue {
+    fn from(value: Output<Sha256>) -> Self {
+        Self(value.into())
+    }
+}
 
 impl FsVerityHashValue for Sha256HashValue {
     type Digest = Sha256;
     const ALGORITHM: u8 = 1;
-    const EMPTY: Self = [0; 32];
+    const EMPTY: Self = Self([0; 32]);
+    const ID: &str = "sha256";
 }
 
-pub type Sha512HashValue = [u8; 64];
+#[derive(Clone, Eq, FromBytes, Hash, Immutable, IntoBytes, KnownLayout, PartialEq, Unaligned)]
+#[repr(C)]
+pub struct Sha512HashValue([u8; 64]);
+
+impl From<Output<Sha512>> for Sha512HashValue {
+    fn from(value: Output<Sha512>) -> Self {
+        Self(value.into())
+    }
+}
 
 impl FsVerityHashValue for Sha512HashValue {
     type Digest = Sha512;
     const ALGORITHM: u8 = 2;
-    const EMPTY: Self = [0; 64];
+    const EMPTY: Self = Self([0; 64]);
+    const ID: &str = "sha512";
 }

--- a/src/fsverity/mod.rs
+++ b/src/fsverity/mod.rs
@@ -1,36 +1,12 @@
 mod digest;
+mod hashvalue;
 mod ioctl;
 
 use std::{io::Error, os::fd::AsFd};
 
-use sha2::{digest::FixedOutputReset, digest::Output, Digest, Sha256, Sha512};
 use thiserror::Error;
 
-pub trait FsVerityHashValue
-where
-    Self: Eq + AsRef<[u8]> + Clone,
-    Self: From<Output<Self::Digest>>,
-{
-    type Digest: Digest + FixedOutputReset + std::fmt::Debug;
-    const ALGORITHM: u8;
-    const EMPTY: Self;
-}
-
-pub type Sha256HashValue = [u8; 32];
-
-impl FsVerityHashValue for Sha256HashValue {
-    type Digest = Sha256;
-    const ALGORITHM: u8 = 1;
-    const EMPTY: Self = [0; 32];
-}
-
-pub type Sha512HashValue = [u8; 64];
-
-impl FsVerityHashValue for Sha512HashValue {
-    type Digest = Sha512;
-    const ALGORITHM: u8 = 2;
-    const EMPTY: Self = [0; 64];
-}
+pub use hashvalue::{FsVerityHashValue, Sha256HashValue, Sha512HashValue};
 
 /// Measuring fsverity failed.
 #[derive(Error, Debug)] // can't derive PartialEq because of std::io::Error

--- a/src/oci/image.rs
+++ b/src/oci/image.rs
@@ -68,10 +68,7 @@ pub fn compose_filesystem<ObjectID: FsVerityHashValue>(
     Ok(filesystem)
 }
 
-pub fn create_dumpfile<ObjectID: FsVerityHashValue>(
-    repo: &Repository<ObjectID>,
-    layers: &[String],
-) -> Result<()> {
+pub fn create_dumpfile(repo: &Repository<impl FsVerityHashValue>, layers: &[String]) -> Result<()> {
     let filesystem = compose_filesystem(repo, layers)?;
     let mut stdout = std::io::stdout();
     write_dumpfile(&mut stdout, &filesystem)?;

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -212,8 +212,8 @@ impl<'repo, ObjectID: FsVerityHashValue> ImageOp<'repo, ObjectID> {
 
 /// Pull the target image, and add the provided tag. If this is a mountable
 /// image (i.e. not an artifact), it is *not* unpacked by default.
-pub async fn pull<ObjectID: FsVerityHashValue>(
-    repo: &Repository<ObjectID>,
+pub async fn pull(
+    repo: &Repository<impl FsVerityHashValue>,
     imgref: &str,
     reference: Option<&str>,
 ) -> Result<()> {

--- a/src/oci/tar.rs
+++ b/src/oci/tar.rs
@@ -183,11 +183,7 @@ pub fn get_entry<R: Read>(reader: &mut SplitStreamReader<R>) -> Result<Option<Ta
                     );
                     TarItem::Leaf(LeafContent::Regular(RegularFile::External(id, size)))
                 }
-                _ => bail!(
-                    "Unsupported external-chunked entry {:?} {}",
-                    header,
-                    hex::encode(id)
-                ),
+                _ => bail!("Unsupported external-chunked entry {header:?} {id:?}"),
             },
             SplitStreamData::Inline(content) => match header.entry_type() {
                 EntryType::GNULongLink => {

--- a/src/oci/tar.rs
+++ b/src/oci/tar.rs
@@ -43,9 +43,9 @@ async fn read_header_async(reader: &mut (impl AsyncRead + Unpin)) -> Result<Opti
 /// Splits the tar file from tar_stream into a Split Stream.  The store_data function is
 /// responsible for ensuring that "external data" is in the composefs repository and returns the
 /// fsverity hash value of that data.
-pub fn split<ObjectID: FsVerityHashValue>(
+pub fn split(
     tar_stream: &mut impl Read,
-    writer: &mut SplitStreamWriter<ObjectID>,
+    writer: &mut SplitStreamWriter<impl FsVerityHashValue>,
 ) -> Result<()> {
     while let Some(header) = read_header(tar_stream)? {
         // the header always gets stored as inline data
@@ -73,9 +73,9 @@ pub fn split<ObjectID: FsVerityHashValue>(
     Ok(())
 }
 
-pub async fn split_async<ObjectID: FsVerityHashValue>(
+pub async fn split_async(
     mut tar_stream: impl AsyncRead + Unpin,
-    writer: &mut SplitStreamWriter<'_, ObjectID>,
+    writer: &mut SplitStreamWriter<'_, impl FsVerityHashValue>,
 ) -> Result<()> {
     while let Some(header) = read_header_async(&mut tar_stream).await? {
         // the header always gets stored as inline data

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,8 +5,6 @@ use std::{
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-use crate::fsverity::{FsVerityHashValue, Sha256HashValue};
-
 /// Formats a string like "/proc/self/fd/3" for the given fd.  This can be used to work with kernel
 /// APIs that don't directly accept file descriptors.
 ///
@@ -83,14 +81,17 @@ pub(crate) async fn read_exactish_async(
     Ok(true)
 }
 
-/// Parse a string containing a SHA256 digest in hexidecimal form into a Sha256HashValue.
+/// A utility type representing a SHA-256 digest in binary.
+pub type Sha256Digest = [u8; 32];
+
+/// Parse a string containing a SHA256 digest in hexidecimal form into a Sha256Digest.
 ///
 /// The string must contain exactly 64 characters and consist entirely of [0-9a-f], case
 /// insensitive.
 ///
 /// In case of a failure to parse the string, this function returns ErrorKind::InvalidInput.
-pub fn parse_sha256(string: impl AsRef<str>) -> Result<Sha256HashValue> {
-    let mut value = Sha256HashValue::EMPTY;
+pub fn parse_sha256(string: impl AsRef<str>) -> Result<Sha256Digest> {
+    let mut value = [0u8; 32];
     hex::decode_to_slice(string.as_ref(), &mut value)
         .map_err(|source| Error::new(ErrorKind::InvalidInput, source))?;
     Ok(value)

--- a/tests/mkfs.rs
+++ b/tests/mkfs.rs
@@ -13,6 +13,7 @@ use tempfile::NamedTempFile;
 use composefs::{
     dumpfile::write_dumpfile,
     erofs::{debug::debug_img, writer::mkfs_erofs},
+    fsverity::{FsVerityHashValue, Sha256HashValue},
     image::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
 };
 
@@ -50,6 +51,10 @@ fn add_leaf(dir: &mut Directory, name: impl AsRef<OsStr>, content: LeafContent) 
 }
 
 fn simple(fs: &mut FileSystem) {
+    let ext_id = Sha256HashValue::from_hex(
+        "5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a",
+    )
+    .unwrap();
     add_leaf(&mut fs.root, "fifo", LeafContent::Fifo);
     add_leaf(
         &mut fs.root,
@@ -59,7 +64,7 @@ fn simple(fs: &mut FileSystem) {
     add_leaf(
         &mut fs.root,
         "regular-external",
-        LeafContent::Regular(RegularFile::External([0x5a; 32], 1234)),
+        LeafContent::Regular(RegularFile::External(ext_id, 1234)),
     );
     add_leaf(&mut fs.root, "chrdev", LeafContent::CharacterDevice(123));
     add_leaf(&mut fs.root, "blkdev", LeafContent::BlockDevice(123));

--- a/tests/mkfs.rs
+++ b/tests/mkfs.rs
@@ -17,7 +17,7 @@ use composefs::{
     image::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
 };
 
-fn debug_fs<ObjectID: FsVerityHashValue>(mut fs: FileSystem<ObjectID>) -> String {
+fn debug_fs(mut fs: FileSystem<impl FsVerityHashValue>) -> String {
     fs.done();
     let image = mkfs_erofs(&fs);
     let mut output = vec![];
@@ -25,7 +25,7 @@ fn debug_fs<ObjectID: FsVerityHashValue>(mut fs: FileSystem<ObjectID>) -> String
     String::from_utf8(output).unwrap()
 }
 
-fn empty<ObjectID: FsVerityHashValue>(_fs: &mut FileSystem<ObjectID>) {}
+fn empty(_fs: &mut FileSystem<impl FsVerityHashValue>) {}
 
 #[test]
 fn test_empty() {


### PR DESCRIPTION
This rests upon a massive pile of generics, but it seems to be working.

With these changes the library is now fully agnostic to which hash algorithm we use.  I've tested this and it successfully produces erofs images with the metacopy attributes correctly set for verifying the fs-verity validity of files using sha512.  The examples also correctly boot with a sha512 in the `composefs=` cmdline.

The changes to the bin/ commands to support this will come soon: we need to thoughtfully consider what we want to do here at a higher level....

 - [x] remove the last two commits (which are here just for demo purposes)
 - [x] decide what we want to do about sha256/sha512 or both: for now we stick with SHA-256 by default.  *edit*: We can enable support for SHA-512 in the commandline tools in future commits.
 - [x] consider that we're essentially producing an incompatible repository format (with differently named objects, images, different image content, different splitstream content, everything) and figure out how we want to handle that from a compat standpoint.  *edit*: punt.