### PR TITLE
fsverity: call sync_data (fdatasync) in test code

### DIFF
--- a/src/fsverity/mod.rs
+++ b/src/fsverity/mod.rs
@@ -181,6 +181,7 @@ mod tests {
     fn rdonly_file_with(data: &[u8]) -> OwnedFd {
         let mut file = tempfile();
         file.write_all(data).unwrap();
+        file.sync_data().unwrap();
         let fd = open(
             proc_self_fd(&file),
             OFlags::RDONLY | OFlags::CLOEXEC,


### PR DESCRIPTION
This partially fixes #106.

There's a race between the read-write file descriptor being closed,
and the subsequent ioctl to enable fsverify on the read-only copy.
Sometimes the ioctl will return ETXTBSY.  Syncing the data here seems
to be sufficient to resolve this race, but *only* on ext4.  On btrfs,
this is not sufficient.  I *can* fix this on btrfs by doing a
`syncfs()`, but we are trying to avoid doing that here.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
