### PR TITLE
Use automatic links in docstrings

### DIFF
--- a/src/fsverity/mod.rs
+++ b/src/fsverity/mod.rs
@@ -74,7 +74,7 @@ pub enum CompareVerityError {
 /// It's possible to choose the hash algorithm (via the generic parameter) but the blocksize is
 /// currently hardcoded to 4096.  Salt is not supported.
 ///
-/// See https://www.kernel.org/doc/html/latest/filesystems/fsverity.html#file-digest-computation
+/// See <https://www.kernel.org/doc/html/latest/filesystems/fsverity.html#file-digest-computation>
 ///
 /// # Arguments:
 ///

--- a/src/uki.rs
+++ b/src/uki.rs
@@ -152,8 +152,8 @@ fn get_value(map: &HashMap<&str, &str>, keys: &[&str]) -> Option<String> {
 /// to "ID" and/or "VERSION" if they are not present).
 ///
 /// For more information, see:
-///  - https://uapi-group.org/specifications/specs/boot_loader_specification/
-///  - https://www.freedesktop.org/software/systemd/man/latest/os-release.html
+///  - <https://uapi-group.org/specifications/specs/boot_loader_specification/>
+///  - <https://www.freedesktop.org/software/systemd/man/latest/os-release.html>
 ///
 /// # Arguments
 ///


### PR DESCRIPTION
Otherwise `cargo doc` will complain with `warning: this URL is not a hyperlink`

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
