### PR TITLE
Add multithread `cfsctl oci pull`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ hex = "0.4.0"
 indicatif = { version = "0.17.0", features = ["tokio"] }
 log = "0.4.8"
 oci-spec = "0.7.0"
+once_cell = { version = "1.21.3", default-features = false }
 regex-automata = { version = "0.4.4", default-features = false }
 rustix = { version = "1.0.0", features = ["fs", "mount", "process"] }
 serde = "1.0.145"
@@ -41,7 +42,6 @@ zstd = "0.13.0"
 
 [dev-dependencies]
 insta = "1.42.2"
-once_cell = "1.21.3"
 similar-asserts = "1.7.0"
 test-with = { version = "0.14", default-features = false, features = ["executable", "runtime"] }
 tokio-test = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rhel9 = ['pre-6.15']
 anyhow = { version = "1.0.87", default-features = false }
 async-compression = { version = "0.4.0", default-features = false, features = ["tokio", "zstd", "gzip"] }
 clap = { version = "4.0.1", default-features = false, features = ["std", "help", "usage", "derive"] }
-containers-image-proxy = "0.7.0"
+containers-image-proxy = "0.7.1"
 env_logger = "0.11.0"
 hex = "0.4.0"
 indicatif = { version = "0.17.0", features = ["tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ sha2 = "0.10.1"
 tar = { version = "0.4.38", default-features = false }
 tempfile = "3.8.0"
 thiserror = "2.0.0"
-tokio = "1.24.2"
+tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
 toml = "0.8.0"
 xxhash-rust = { version = "0.8.2", features = ["xxh32"] }
 zerocopy = { version = "0.8.0", features = ["derive", "std"] }

--- a/src/bin/cfsctl.rs
+++ b/src/bin/cfsctl.rs
@@ -106,7 +106,8 @@ enum Command {
     },
 }
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     env_logger::init();
 
     let args = App::parse();
@@ -158,12 +159,7 @@ fn main() -> Result<()> {
                 println!("{}", image_id.to_hex());
             }
             OciCommand::Pull { ref image, name } => {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("Failed to build tokio runtime");
-                // And invoke the async_main
-                runtime.block_on(async move { oci::pull(&repo, image, name.as_deref()).await })?;
+                oci::pull(&repo, image, name.as_deref()).await?
             }
             OciCommand::Seal { verity, ref name } => {
                 let (sha256, verity) = oci::seal(

--- a/src/bin/cfsctl.rs
+++ b/src/bin/cfsctl.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
@@ -141,7 +141,7 @@ async fn main() -> Result<()> {
         Command::Oci { cmd: oci_cmd } => match oci_cmd {
             OciCommand::ImportLayer { name, sha256 } => {
                 let object_id = oci::import_layer(
-                    &repo,
+                    &Arc::new(repo),
                     &parse_sha256(sha256)?,
                     name.as_deref(),
                     &mut std::io::stdin(),
@@ -159,11 +159,11 @@ async fn main() -> Result<()> {
                 println!("{}", image_id.to_hex());
             }
             OciCommand::Pull { ref image, name } => {
-                oci::pull(&repo, image, name.as_deref()).await?
+                oci::pull(&Arc::new(repo), image, name.as_deref()).await?
             }
             OciCommand::Seal { verity, ref name } => {
                 let (sha256, verity) = oci::seal(
-                    &repo,
+                    &Arc::new(repo),
                     name,
                     verity.map(Sha256HashValue::from_hex).transpose()?.as_ref(),
                 )?;

--- a/src/bin/composefs-setup-root.rs
+++ b/src/bin/composefs-setup-root.rs
@@ -169,7 +169,7 @@ fn open_root_fs(path: &Path) -> Result<OwnedFd> {
 fn mount_composefs_image(sysroot: &OwnedFd, name: &str) -> Result<OwnedFd> {
     let repo = Repository::<Sha256HashValue>::open_path(sysroot, "composefs")?;
     let image = repo.open_image(name)?;
-    composefs_fsmount(image, name, repo.object_dir()?).context("Failed to mount composefs image")
+    composefs_fsmount(image, name, repo.objects_dir()?).context("Failed to mount composefs image")
 }
 
 fn mount_subdir(

--- a/src/fsverity/hashvalue.rs
+++ b/src/fsverity/hashvalue.rs
@@ -7,6 +7,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 pub trait FsVerityHashValue
 where
     Self: Clone,
+    Self: Send + Sync + 'static,
     Self: From<Output<Self::Digest>>,
     Self: FromBytes + Immutable + IntoBytes + KnownLayout + Unaligned,
     Self: Hash + Eq,

--- a/src/fsverity/hashvalue.rs
+++ b/src/fsverity/hashvalue.rs
@@ -7,11 +7,11 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 pub trait FsVerityHashValue
 where
     Self: Clone,
-    Self: Send + Sync + 'static,
     Self: From<Output<Self::Digest>>,
     Self: FromBytes + Immutable + IntoBytes + KnownLayout + Unaligned,
     Self: Hash + Eq,
     Self: fmt::Debug,
+    Self: Send + Sync + Unpin + 'static,
 {
     type Digest: Digest + FixedOutputReset + fmt::Debug;
     const ALGORITHM: u8;

--- a/src/fsverity/hashvalue.rs
+++ b/src/fsverity/hashvalue.rs
@@ -60,15 +60,15 @@ where
     }
 
     fn to_object_pathname(&self) -> String {
-        format!("{:02x}/{}", self.as_bytes()[0], self.to_object_basename())
+        format!(
+            "{:02x}/{}",
+            self.as_bytes()[0],
+            hex::encode(&self.as_bytes()[1..])
+        )
     }
 
     fn to_object_dir(&self) -> String {
         format!("{:02x}", self.as_bytes()[0])
-    }
-
-    fn to_object_basename(&self) -> String {
-        hex::encode(&self.as_bytes()[1..])
     }
 
     fn to_hex(&self) -> String {

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -105,7 +105,7 @@ impl<'repo, ObjectID: FsVerityHashValue> ImageOp<'repo, ObjectID> {
 
         if let Some(layer_id) = self.repo.check_stream(layer_sha256)? {
             self.progress
-                .println(format!("Already have layer {layer_sha256:?}"))?;
+                .println(format!("Already have layer {}", hex::encode(layer_sha256)))?;
             Ok(layer_id)
         } else {
             // Otherwise, we need to fetch it...

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -136,7 +136,13 @@ impl<ObjectID: FsVerityHashValue> ImageOp<ObjectID> {
                 other => bail!("Unsupported layer media type {:?}", other),
             };
             let layer_id = self.repo.write_stream(splitstream, None)?;
-            driver.await?;
+
+            // We intentionally explicitly ignore this, even though we're supposed to check it.
+            // See https://github.com/containers/containers-image-proxy-rs/issues/80 for discussion
+            // about why.  Note: we only care about the uncompressed layer tar, and we checksum it
+            // ourselves.
+            drop(driver);
+
             Ok(layer_id)
         }
     }

--- a/src/oci/tar.rs
+++ b/src/oci/tar.rs
@@ -94,7 +94,7 @@ pub async fn split_async(
         if header.entry_type() == EntryType::Regular && actual_size > INLINE_CONTENT_MAX {
             // non-empty regular file: store the data in the object store
             let padding = buffer.split_off(actual_size);
-            writer.write_external(&buffer, padding)?;
+            writer.write_external_async(buffer, padding).await?;
         } else {
             // else: store the data inline in the split stream
             writer.write_inline(&buffer);

--- a/src/oci/tar.rs
+++ b/src/oci/tar.rs
@@ -75,7 +75,7 @@ pub fn split(
 
 pub async fn split_async(
     mut tar_stream: impl AsyncRead + Unpin,
-    writer: &mut SplitStreamWriter<'_, impl FsVerityHashValue>,
+    writer: &mut SplitStreamWriter<impl FsVerityHashValue>,
 ) -> Result<()> {
     while let Some(header) = read_header_async(&mut tar_stream).await? {
         // the header always gets stored as inline data

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -106,6 +106,11 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         })
     }
 
+    pub async fn ensure_object_async(self: &Arc<Self>, data: Vec<u8>) -> Result<ObjectID> {
+        let self_ = Arc::clone(self);
+        tokio::task::spawn_blocking(move || self_.ensure_object(&data)).await?
+    }
+
     pub fn ensure_object(&self, data: &[u8]) -> Result<ObjectID> {
         let dirfd = self.objects_dir()?;
         let id: ObjectID = compute_verity(data);

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -5,6 +5,7 @@ use std::{
     io::{Read, Write},
     os::fd::{AsFd, OwnedFd},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use anyhow::{bail, ensure, Context, Result};
@@ -173,7 +174,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     /// You should write the data to the returned object and then pass it to .store_stream() to
     /// store the result.
     pub fn create_stream(
-        &self,
+        self: &Arc<Self>,
         sha256: Option<Sha256Digest>,
         maps: Option<DigestMap<ObjectID>>,
     ) -> SplitStreamWriter<ObjectID> {
@@ -285,7 +286,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     /// On success, the object ID of the new object is returned.  It is expected that this object
     /// ID will be used when referring to the stream from other linked streams.
     pub fn ensure_stream(
-        &self,
+        self: &Arc<Self>,
         sha256: &Sha256Digest,
         callback: impl FnOnce(&mut SplitStreamWriter<ObjectID>) -> Result<()>,
         reference: Option<&str>,

--- a/src/splitstream.rs
+++ b/src/splitstream.rs
@@ -155,6 +155,15 @@ impl<ObjectID: FsVerityHashValue> SplitStreamWriter<ObjectID> {
         self.write_reference(&id, padding)
     }
 
+    pub async fn write_external_async(&mut self, data: Vec<u8>, padding: Vec<u8>) -> Result<()> {
+        if let Some((ref mut sha256, ..)) = self.sha256 {
+            sha256.update(&data);
+            sha256.update(&padding);
+        }
+        let id = self.repo.ensure_object_async(data).await?;
+        self.write_reference(&id, padding)
+    }
+
     pub fn done(mut self) -> Result<ObjectID> {
         self.flush_inline(vec![])?;
 


### PR DESCRIPTION
For images with a large number of layers (as is the case for most bootc images) this is a massive win.  I used this as a test:

```sh
skopeo copy docker://quay.io/fedora/fedora-silverblue:42 oci:$HOME/oci/silverblue-42
```

and then

```sh
cfsctl oci pull oci:$HOME/oci/silverblue-42
```

And noticed an improvement from ~90s to ~9s.

Unfortunately the situation isn't much improved for images with a small number of layers (as is the case in our own `examples/` directory).