### PR TITLE
Update return type of `oci::pull`

### DIFF
--- a/src/bin/cfsctl.rs
+++ b/src/bin/cfsctl.rs
@@ -228,7 +228,10 @@ async fn main() -> Result<()> {
                 println!("{}", image_id.to_id());
             }
             OciCommand::Pull { ref image, name } => {
-                oci::pull(&Arc::new(repo), image, name.as_deref()).await?
+                let (sha256, verity) = oci::pull(&Arc::new(repo), image, name.as_deref()).await?;
+
+                println!("sha256 {}", hex::encode(sha256));
+                println!("verity {}", verity.to_hex());
             }
             OciCommand::Seal {
                 ref config_name,

--- a/src/oci/mod.rs
+++ b/src/oci/mod.rs
@@ -238,7 +238,7 @@ pub async fn pull(
     repo: &Arc<Repository<impl FsVerityHashValue>>,
     imgref: &str,
     reference: Option<&str>,
-) -> Result<()> {
+) -> Result<(Sha256Digest, impl FsVerityHashValue)> {
     let op = Arc::new(ImageOp::new(repo, imgref).await?);
     let (sha256, id) = op
         .pull()
@@ -248,9 +248,7 @@ pub async fn pull(
     if let Some(name) = reference {
         repo.name_stream(sha256, name)?;
     }
-    println!("sha256 {}", hex::encode(sha256));
-    println!("verity {}", id.to_hex());
-    Ok(())
+    Ok((sha256, id))
 }
 
 pub fn open_config<ObjectID: FsVerityHashValue>(


### PR DESCRIPTION
Move the printing of SHA256 and verity from the library to cfsctl binary.