### PR TITLE
examples: add bootc/ directory

### DIFF
--- a/examples/bootc/build
+++ b/examples/bootc/build
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -eux
+
+cd "${0%/*}"
+image="${1:-docker://quay.io/fedora/fedora-bootc:42}"
+
+cargo build --release
+cp ../../target/release/cfsctl .
+mkdir -p initrd/usr/bin
+cp ../../target/release/composefs-setup-root initrd/usr/bin
+
+# rm -rf tmp
+../common/install-systemd-boot
+
+mkdir -p tmp/sysroot/composefs
+./cfsctl --repo tmp/sysroot/composefs oci pull "${image}" image
+./cfsctl --repo tmp/sysroot/composefs oci prepare-boot refs/image --bootdir tmp/efi --cmdline rw --cmdline console=ttyS0,115200 --cmdline enforcing=0 --cmdline root=/dev/vda2 --entry-id example
+
+(
+    cd initrd
+    find -print0 | cpio --null -ov --format=newc
+) | gzip -9 > tmp/efi/composefs-setup-root.img
+
+echo 'initrd /composefs-setup-root.img' >> tmp/efi/loader/entries/example.conf
+
+../common/make-image bootc-efi.qcow2

--- a/examples/bootc/initrd/usr/bin/.gitignore
+++ b/examples/bootc/initrd/usr/bin/.gitignore
@@ -1,0 +1,1 @@
+/composefs-setup-root

--- a/examples/bootc/initrd/usr/lib/systemd/system/composefs-setup-root.service
+++ b/examples/bootc/initrd/usr/lib/systemd/system/composefs-setup-root.service
@@ -1,0 +1,34 @@
+# Copyright (C) 2013 Colin Walters <walters@verbum.org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <https://www.gnu.org/licenses/>.
+
+[Unit]
+DefaultDependencies=no
+ConditionKernelCommandLine=composefs
+ConditionPathExists=/etc/initrd-release
+After=sysroot.mount
+Requires=sysroot.mount
+Before=initrd-root-fs.target
+Before=initrd-switch-root.target
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/composefs-setup-root
+StandardInput=null
+StandardOutput=journal
+StandardError=journal+console
+RemainAfterExit=yes

--- a/examples/bootc/initrd/usr/lib/systemd/system/initrd-root-fs.target.wants/composefs-setup-root.service
+++ b/examples/bootc/initrd/usr/lib/systemd/system/initrd-root-fs.target.wants/composefs-setup-root.service
@@ -1,0 +1,1 @@
+../composefs-setup-root.service

--- a/src/bin/composefs-setup-root.rs
+++ b/src/bin/composefs-setup-root.rs
@@ -74,7 +74,7 @@ struct Args {
 
     #[arg(
         long,
-        default_value = "/usr/lib/ostree/prepare-root.conf",
+        default_value = "/usr/lib/composefs/setup-root.conf",
         help = "Config path (for testing)"
     )]
     config: PathBuf,


### PR DESCRIPTION
This builds a bootable image from a stock bootc image.

It works by appending composefs-setup-root to the existing initramfs by using a second initrd line in the boot loader entry.

This is an evil little hack but it was kinda fun and maybe we have some sort of use for this sort of thing in the short-term.  I'm not sure this is worth merging....