### PR TITLE
Custom toml parsing for `prepare-root.conf`

### DIFF
--- a/src/bin/composefs-setup-root.rs
+++ b/src/bin/composefs-setup-root.rs
@@ -74,7 +74,7 @@ struct Args {
 
     #[arg(
         long,
-        default_value = "/usr/lib/ostree/prepare-root.conf",
+        default_value = "/usr/lib/composefs/setup-root-conf.toml",
         help = "Config path (for testing)"
     )]
     config: PathBuf,


### PR DESCRIPTION
Bootc images have the file "/usr/lib/ostree/prepare-root.conf" with the following contents:

```toml
[composefs]
enable = yes
```

"enable = yes" is not valid toml, so serde panics while parsing.