### PR TITLE
enable_verity: syncfs and retry on ETXTBSY

### DIFF
--- a/src/fsverity/ioctl.rs
+++ b/src/fsverity/ioctl.rs
@@ -52,6 +52,7 @@ pub(super) fn fs_ioc_enable_verity<H: FsVerityHashValue>(
                 Err(EnableVerityError::FilesystemNotSupported)
             }
             Err(Errno::EXIST) => Err(EnableVerityError::AlreadyEnabled),
+            Err(Errno::TXTBSY) => Err(EnableVerityError::FileOpenedForWrite),
             Err(e) => Err(Error::from(e).into()),
             Ok(_) => Ok(()),
         }


### PR DESCRIPTION
On btrfs, sometimes after the writable fd is closed, attempting to
enable verity will still result in ETXTBSY.  In this case it appears
to be sufficient to call `syncfs()` and retry enabling verity.  This
isn't ideal since it's a lot slower, but better than hard-erroring.

Resolves: #106
Signed-off-by: John Eckersberg <jeckersb@redhat.com>