### PR TITLE
Update `composefs-setup-root` to parse composefs-rs config

### DIFF
--- a/src/bin/composefs-setup-root.rs
+++ b/src/bin/composefs-setup-root.rs
@@ -74,7 +74,7 @@ struct Args {
 
     #[arg(
         long,
-        default_value = "/usr/lib/ostree/prepare-root.conf",
+        default_value = "/usr/lib/composefs/setup-root-conf.toml",
         help = "Config path (for testing)"
     )]
     config: PathBuf,


### PR DESCRIPTION
Instead of parsing ostree's toml config, we will have and parse composefs-rs config located at `/usr/lib/composefs/setup-root-conf.toml`