### PR TITLE
fsverity: Add nicer error variant for ETXTBSY

### DIFF
--- a/crates/composefs/src/fsverity/ioctl.rs
+++ b/crates/composefs/src/fsverity/ioctl.rs
@@ -54,6 +54,7 @@ pub(super) fn fs_ioc_enable_verity<H: FsVerityHashValue>(
                 Err(EnableVerityError::FilesystemNotSupported)
             }
             Err(Errno::EXIST) => Err(EnableVerityError::AlreadyEnabled),
+            Err(Errno::TXTBSY) => Err(EnableVerityError::FileOpenedForWrite),
             Err(e) => Err(Error::from(e).into()),
             Ok(_) => Ok(()),
         }

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -30,6 +30,8 @@ pub enum EnableVerityError {
     FilesystemNotSupported,
     #[error("fs-verity is already enabled on file")]
     AlreadyEnabled,
+    #[error("File is opened for writing")]
+    FileOpenedForWrite,
 }
 
 /// A verity comparison failed.


### PR DESCRIPTION
Reviving the more sane part of #120.

We should provide a clearer error variant here instead of just passing
ETXTBSY through to the caller.

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
