### PR TITLE
repository: don't leak repository fd

### DIFF
--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -76,7 +76,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         let path = path.as_ref();
 
         // O_PATH isn't enough because flock()
-        let repository = openat(dirfd, path, OFlags::RDONLY, Mode::empty())
+        let repository = openat(dirfd, path, OFlags::RDONLY | OFlags::CLOEXEC , Mode::empty())
             .with_context(|| format!("Cannot open composefs repository at {}", path.display()))?;
 
         flock(&repository, FlockOperation::LockShared)


### PR DESCRIPTION
We're leaking fds into the sandbox in flatpak-rs.  Let's fix this obvious one.