### PR TITLE
examples: install patched mke2fs from upstream

### DIFF
--- a/examples/common/install-patched-tools
+++ b/examples/common/install-patched-tools
@@ -14,10 +14,11 @@ git clone -b repart-verity https://github.com/allisonkarlitskaya/systemd
 	cp _build/src/shared/*.so "${install_path}/src/shared"
 )
 
-git clone -b verity https://github.com/allisonkarlitskaya/e2fsprogs
+git clone https://github.com/tytso/e2fsprogs
 (
 	cd e2fsprogs
-	./configure
+        git checkout dd0c4efa173203484f0cd612f97eb19181240a33
+	./configure --disable-fuse2fs
 	make -j$(nproc)
 	cp misc/mke2fs "${install_path}/mkfs.ext4"
 )


### PR DESCRIPTION
The fs-verity-enablement patches for mke2fs finally got merged.  Use the upstream branch from install-patched-tools.