### PR TITLE
composefs: fix feature flags of once_cell

### DIFF
--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -20,7 +20,7 @@ test = []
 anyhow = { version = "1.0.87", default-features = false }
 hex = { version = "0.4.0", default-features = false, features = ["std"] }
 log = { version = "0.4.8", default-features = false }
-once_cell = { version = "1.21.3", default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "mount", "process", "std"] }
 sha2 = { version = "0.10.1", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.0", default-features = false }


### PR DESCRIPTION
We use once_cell because https://github.com/rust-lang/rust/issues/109737

once_cell has a large number of potential locking backends for `no_std` environments.  We were randomly using `critical-section`, which itself requires specifying a backend, which we weren't doing.  So far, we've been protected by this by the fact that we also have once_cell as a transient dependency (via tempfile).

Fix this to just use `std` so that we get locking via the stdlib.