### PR TITLE
Make fs-verity optional

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -26,6 +26,8 @@ jobs:
           - { dir: 'uki', os: 'fedora' }
           - { dir: 'unified', os: 'fedora' }
           - { dir: 'unified-secureboot', os: 'fedora' }
+          - { dir: 'bls', os: 'arch', fsfmt: 'ext4', verity: 'none' }
+          - { dir: 'bls', os: 'arch', fsfmt: 'xfs', verity: 'none' }
       fail-fast: false
 
     steps:
@@ -71,4 +73,6 @@ jobs:
     - name: Run example tests
       run: |
         export PATH="${HOME}/bin:${PATH}"
+        export FS_FORMAT=${{ matrix.example.fsfmt }}
+        export FS_VERITY_MODE=${{ matrix.example.verity }}
         examples/test/run ${{ matrix.example.dir }} ${{ matrix.example.os }}

--- a/crates/cfsctl/src/main.rs
+++ b/crates/cfsctl/src/main.rs
@@ -339,7 +339,7 @@ async fn main() -> Result<()> {
             fs.print_dumpfile()?;
         }
         Command::Mount { name, mountpoint } => {
-            repo.mount(&name, &mountpoint)?;
+            repo.mount_at(&name, &mountpoint)?;
         }
         Command::ImageObjects { name } => {
             let objects = repo.objects_for_image(&name)?;

--- a/crates/cfsctl/src/main.rs
+++ b/crates/cfsctl/src/main.rs
@@ -27,6 +27,12 @@ pub struct App {
     #[clap(long, group = "repopath")]
     system: bool,
 
+    /// Sets the repository to insecure before running any operation and
+    /// prepend '?' to the composefs kernel command line when writing
+    /// boot entry.
+    #[clap(long)]
+    insecure: bool,
+
     #[clap(subcommand)]
     cmd: Command,
 }
@@ -160,7 +166,7 @@ async fn main() -> Result<()> {
 
     let args = App::parse();
 
-    let repo: Repository<Sha256HashValue> = (if let Some(path) = &args.repo {
+    let mut repo: Repository<Sha256HashValue> = (if let Some(path) = &args.repo {
         Repository::open_path(CWD, path)
     } else if args.system {
         Repository::open_system()
@@ -171,6 +177,8 @@ async fn main() -> Result<()> {
     } else {
         Repository::open_user()
     })?;
+
+    repo.set_insecure(args.insecure);
 
     match args.cmd {
         Command::Transaction => {

--- a/crates/cfsctl/src/main.rs
+++ b/crates/cfsctl/src/main.rs
@@ -291,6 +291,7 @@ async fn main() -> Result<()> {
                     &repo,
                     entry,
                     &id,
+                    args.insecure,
                     bootdir,
                     None,
                     entry_id.as_deref(),

--- a/crates/composefs-boot/Cargo.toml
+++ b/crates/composefs-boot/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
 composefs = { workspace = true }
+hex = { version = "0.4.0", default-features = false, features = ["std"] }
 regex-automata = { version = "0.4.4", default-features = false, features=["hybrid", "std", "syntax"] }
 thiserror = { version = "2.0.0", default-features = false }
 zerocopy = { version = "0.8.0", default-features = false, features = ["derive"] }

--- a/crates/composefs-boot/src/bootloader.rs
+++ b/crates/composefs-boot/src/bootloader.rs
@@ -11,7 +11,7 @@ use composefs::{
     tree::{Directory, FileSystem, ImageError, Inode, LeafContent, RegularFile},
 };
 
-use crate::cmdline::split_cmdline;
+use crate::cmdline::{make_cmdline_composefs, split_cmdline};
 
 /// Strips the key (if it matches) plus the following whitespace from a single line in a "Type #1
 /// Boot Loader Specification Entry" file.
@@ -101,9 +101,9 @@ impl BootLoaderEntryFile {
 
     /// Adjusts the kernel command-line arguments by adding a composefs= parameter (if appropriate)
     /// and adding additional arguments, as requested.
-    pub fn adjust_cmdline(&mut self, composefs: Option<&str>, extra: &[&str]) {
+    pub fn adjust_cmdline(&mut self, composefs: Option<&str>, insecure: bool, extra: &[&str]) {
         if let Some(id) = composefs {
-            self.add_cmdline(&format!("composefs={id}"));
+            self.add_cmdline(&make_cmdline_composefs(id, insecure));
         }
 
         for item in extra {

--- a/crates/composefs-boot/src/cmdline.rs
+++ b/crates/composefs-boot/src/cmdline.rs
@@ -38,3 +38,10 @@ pub fn get_cmdline_composefs<ObjectID: FsVerityHashValue>(
         Ok((ObjectID::from_hex(id)?, false))
     }
 }
+
+pub fn make_cmdline_composefs(id: &str, insecure: bool) -> String {
+    match insecure {
+        true => format!("composefs=?{}", id),
+        false => format!("composefs={}", id),
+    }
+}

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -152,7 +152,7 @@ pub fn mount<ObjectID: FsVerityHashValue>(
     let Some(id) = config.get_config_annotation("containers.composefs.fsverity") else {
         bail!("Can only mount sealed containers");
     };
-    repo.mount(id, mountpoint)
+    repo.mount_at(id, mountpoint)
 }
 
 #[cfg(test)]

--- a/crates/composefs-setup-root/src/main.rs
+++ b/crates/composefs-setup-root/src/main.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 
 use composefs::{
     fsverity::{FsVerityHashValue, Sha256HashValue},
-    mount::{composefs_fsmount, mount_at, FsHandle},
+    mount::{mount_at, FsHandle},
     mountcompat::{overlayfs_set_fd, overlayfs_set_lower_and_data_fds, prepare_mount},
     repository::Repository,
 };
@@ -166,8 +166,7 @@ fn open_root_fs(path: &Path) -> Result<OwnedFd> {
 
 fn mount_composefs_image(sysroot: &OwnedFd, name: &str) -> Result<OwnedFd> {
     let repo = Repository::<Sha256HashValue>::open_path(sysroot, "composefs")?;
-    let image = repo.open_image(name)?;
-    composefs_fsmount(image, name, repo.objects_dir()?).context("Failed to mount composefs image")
+    repo.mount(name)
 }
 
 fn mount_subdir(

--- a/crates/composefs/src/mount.rs
+++ b/crates/composefs/src/mount.rs
@@ -1,12 +1,9 @@
 use std::{
-    fs::canonicalize,
     io::Result,
     os::fd::{AsFd, BorrowedFd, OwnedFd},
-    path::Path,
 };
 
 use rustix::{
-    fs::CWD,
     mount::{
         fsconfig_create, fsconfig_set_flag, fsconfig_set_string, fsmount, fsopen, move_mount,
         FsMountFlags, FsOpenFlags, MountAttrFlags, MoveMountFlags,
@@ -94,14 +91,4 @@ pub fn composefs_fsmount(image: OwnedFd, name: &str, basedir: impl AsFd) -> Resu
         FsMountFlags::FSMOUNT_CLOEXEC,
         MountAttrFlags::empty(),
     )?)
-}
-
-pub fn mount_composefs_at(
-    image: OwnedFd,
-    name: &str,
-    basedir: impl AsFd,
-    mountpoint: impl AsRef<Path>,
-) -> Result<()> {
-    let mnt = composefs_fsmount(image, name, basedir)?;
-    Ok(mount_at(mnt, CWD, &canonicalize(mountpoint)?)?)
 }

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -396,7 +396,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
 
     pub fn mount(&self, name: &str) -> Result<OwnedFd> {
         let image = self.open_image(name)?;
-        Ok(composefs_fsmount(image, name, self.objects_dir()?)?)
+        Ok(composefs_fsmount(image, name, self.objects_dir()?, true)?)
     }
 
     pub fn mount_at(&self, name: &str, mountpoint: impl AsRef<Path>) -> Result<()> {

--- a/examples/bls/build
+++ b/examples/bls/build
@@ -56,6 +56,11 @@ podman build \
 BASE_ID="$(sed s/sha256:// tmp/base.iid)"
 
 ${CFSCTL} oci pull containers-storage:${BASE_ID}
+
+if [ "${FS_VERITY_MODE:-repart}" = "none" ]; then
+    CFSCTL="$CFSCTL --insecure"
+fi
+
 ${CFSCTL} oci prepare-boot "${BASE_ID}" --bootdir tmp/efi --cmdline console=ttyS0,115200 --entry-id=example --cmdline rw
 
 ../common/install-systemd-boot

--- a/examples/common/check-config
+++ b/examples/common/check-config
@@ -40,19 +40,19 @@ fi
 #
 # All the tests past this point can be skipped if we're doing after-the-fact
 # verity fixups using the fix-verity script.
-if [ "${FIX_VERITY:-}" = "1" ]; then
+if [ "${FS_VERITY_MODE:-repart}" = "fix" ] || [ "${FS_VERITY_MODE:-repart}" = "none" ]; then
     exit 0
 fi
 
 if ! grep -sq 'fsverity=' "${systemd_repart}"; then
     echo "*** Your systemd-repart doesn't seem to have fs-verity support"
-    echo "*** See the install-patched-tools script, or set FIX_VERITY=1..."
+    echo "*** See the install-patched-tools script, or set FS_VERITY_MODE=fix..."
     exit 1
 fi
 
 if ! grep -sq 'fs-verity support' "${mkfs_ext4}"; then
     echo "*** Your mkfs.ext4 doesn't seem to have fs-verity support"
-    echo "*** See the install-patched-tools script, or set FIX_VERITY=1..."
+    echo "*** See the install-patched-tools script, or set FS_VERITY_MODE=fix..."
     exit 1
 fi
 
@@ -62,6 +62,6 @@ check_metadata() {
 
 if check_metadata "$0"; then
     echo "*** Your working directory doesn't seem to support FS_IOC_READ_VERITY_METADATA"
-    echo "*** You're probably using btrfs on an older kernel version.  Try FIX_VERITY=1..."
+    echo "*** You're probably using btrfs on an older kernel version.  Try FS_VERITY_MODE=fix..."
     exit 1
 fi

--- a/examples/common/repart.d/01-esp.conf
+++ b/examples/common/repart.d/01-esp.conf
@@ -1,6 +1,0 @@
-[Partition]
-Type=esp
-Format=vfat
-CopyFiles=/efi:/
-SizeMinBytes=512M
-SizeMaxBytes=512M

--- a/examples/common/repart.d/02-sysroot.conf
+++ b/examples/common/repart.d/02-sysroot.conf
@@ -1,6 +1,0 @@
-[Partition]
-Type=root
-Format=ext4
-SizeMinBytes=10G
-SizeMaxBytes=10G
-CopyFiles=/sysroot:/:fsverity=copy

--- a/examples/common/run-repart
+++ b/examples/common/run-repart
@@ -7,14 +7,32 @@ chcon -R system_u:object_r:usr_t:s0 tmp/sysroot/composefs
 chcon system_u:object_r:var_t:s0 tmp/sysroot/state/*/var
 chcon system_u:object_r:etc_t:s0 tmp/sysroot/state/*/etc/*
 
-definitions="${0%/*}/repart.d"
+definitions='tmp/repart.d'
+export SYSTEMD_REPART_MKFS_OPTIONS_EXT4='-O verity'
 
-if [ "${FIX_VERITY:-}" = '1' ]; then
-    export SYSTEMD_REPART_MKFS_OPTIONS_EXT4='-O verity'
-    cp -r "${definitions}" tmp/repart.d
-    sed -i 's/:fsverity=copy//' tmp/repart.d/02-sysroot.conf
-    definitions='tmp/repart.d'
+mkdir -p "$definitions"
+
+cat <<EOF > tmp/repart.d/01-esp.conf
+[Partition]
+Type=esp
+Format=vfat
+CopyFiles=/efi:/
+SizeMinBytes=512M
+SizeMaxBytes=512M
+EOF
+
+if [ "${FS_VERITY_MODE:-repart}" = 'repart' ]; then
+    COPY_FILES_FLAG="/sysroot:/:fsverity=copy"
 fi
+
+cat <<EOF > tmp/repart.d/02-sysroot.conf
+[Partition]
+Type=root
+Format=${FS_FORMAT:-ext4}
+SizeMinBytes=10G
+SizeMaxBytes=10G
+CopyFiles=${COPY_FILES_FLAG:-/sysroot:/}
+EOF
 
 # Setting TMPDIR here has a couple of advantages:
 #  - we already have our own temporary directory
@@ -30,6 +48,6 @@ TMPDIR="${PWD}/tmp" systemd-repart \
     --definitions="${definitions}" \
     "$1"
 
-if [ "${FIX_VERITY:-}" = '1' ]; then
+if [ "${FS_VERITY_MODE:-repart}" = 'fix' ]; then
     "${0%/*}/fix-verity/fix-verity" "$1"
 fi

--- a/examples/test/run-tests
+++ b/examples/test/run-tests
@@ -11,7 +11,10 @@ def test_basic(m: testvm.Machine):
     m.execute('! touch /a')
 
     # the content of /sysroot is what we expect
-    assert m.execute('ls /sysroot') == 'composefs\nlost+found\nstate\n'
+    # lost+found is only available on ext4, and this also tests xfs
+    assert [
+        name for name in m.execute('ls /sysroot').splitlines() if name != 'lost+found'
+    ] == ['composefs', 'state']
 
     # make sure /etc and /var persist across a reboot
     m.write('/etc/persists.conf', 'hihi conf')


### PR DESCRIPTION
- adds "insecure" option to repository, allows images which do not have fs-verity enabled
- if `?` is prepended to composefs= cmdline, set repository to insecure
- opportunistically enable fs-verity where appropriate, even if repository is in insecure mode
- add `--insecure` to cfsctl


#87