### PR TITLE
fsverity: split `enable_verity` into multiple related functions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
     container:
       image: quay.io/fedora/fedora:41
-      options: "--privileged --pid=host -v /var/tmp:/var/tmp -v /:/run/host"
+      options: "--privileged --pid=host -v /var/tmp:/var/tmp --tmpfs /tmp:rw,exec,nosuid,nodev -v /:/run/host"
 
     steps:
     - run: dnf -y install cargo clippy composefs-devel e2fsprogs rustfmt

--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "mount", "process", "std"] }
 sha2 = { version = "0.10.1", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.0", default-features = false }
-tokio = { version = "1.24.2", default-features = false, features = ["io-util", "rt-multi-thread"] }
+tokio = { version = "1.24.2", default-features = false, features = ["macros", "process", "io-util", "rt-multi-thread"] }
 tempfile = { version = "3.8.0", optional = true, default-features = false }
 xxhash-rust = { version = "0.8.2", default-features = false, features = ["xxh32"] }
 zerocopy = { version = "0.8.0", default-features = false, features = ["derive", "std"] }

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -2,11 +2,18 @@ mod digest;
 mod hashvalue;
 mod ioctl;
 
-use std::{io::Error, os::fd::AsFd};
+use std::{
+    fs::File,
+    io::{Error, Seek},
+    os::fd::{AsFd, OwnedFd},
+};
 
+use rustix::fs::{open, openat, Mode, OFlags};
 use thiserror::Error;
 
 pub use hashvalue::{FsVerityHashValue, Sha256HashValue, Sha512HashValue};
+
+use crate::util::proc_self_fd;
 
 /// Measuring fsverity failed.
 #[derive(Error, Debug)] // can't derive PartialEq because of std::io::Error
@@ -45,6 +52,33 @@ pub enum CompareVerityError {
     DigestMismatch { expected: String, found: String },
 }
 
+/// An owned file descriptor with fsverity enabled.  Used in contexts
+/// where a user-supplied file descriptor may be returned back to the
+/// user directly (`Orig`), or a distinct copy of the file descriptor
+/// (`Copy`) may be returned in place of the original.
+#[derive(Debug)]
+pub enum VerityFd {
+    Orig(OwnedFd),
+    Copy(OwnedFd),
+}
+
+impl VerityFd {
+    pub fn is_orig(&self) -> bool {
+        matches!(self, Self::Orig(_))
+    }
+
+    pub fn is_copy(&self) -> bool {
+        matches!(self, Self::Copy(_))
+    }
+
+    pub fn into_inner(self) -> OwnedFd {
+        match self {
+            Self::Orig(fd) => fd,
+            Self::Copy(fd) => fd,
+        }
+    }
+}
+
 /// Compute the fs-verity digest for a given block of data, in userspace.
 ///
 /// The fs-verity digest is a cryptographic hash over the fs-verity descriptor, which itself
@@ -72,8 +106,114 @@ pub fn compute_verity<H: FsVerityHashValue>(data: &[u8]) -> H {
 ///
 /// It's possible to choose the hash algorithm (via the generic parameter) but the blocksize is
 /// currently hardcoded to 4096.  Salt is not supported.
-pub fn enable_verity<H: FsVerityHashValue>(fd: impl AsFd) -> Result<(), EnableVerityError> {
+pub fn enable_verity_raw<H: FsVerityHashValue>(fd: impl AsFd) -> Result<(), EnableVerityError> {
     ioctl::fs_ioc_enable_verity::<H>(fd)
+}
+
+/// Enable fs-verity on the given file, retrying if file is opened for writing.
+///
+/// This uses `enable_verity_raw()` and is subject to the same restrictions and features.
+///
+/// A common pattern with fsverity files is:
+///
+/// * Open a read-write file descriptor
+/// * Write data to the read-write file descriptor
+/// * Re-open the file descriptor as a new read-only descriptor
+/// * Close the read-write file descriptor
+/// * Enable fsverity on the read-only file descriptor
+///
+/// However, in a multi-threaded program, it is possible that another
+/// thread calls `fork()` while the read-write descriptor is valid,
+/// thus making a copy of the read-write descriptor.  If the forked
+/// process does not close the file descriptor either explicitly or by
+/// calling `exec()` via O_CLOEXEC, then attempting to enable fsverity
+/// on the read-only file descriptor will fail with ETXTBSY.  It is
+/// generally assumed that the file descriptor will be closed rather
+/// quickly under these circumstances, so this function will try to
+/// enable verity three times, pausing for one millisecond between
+/// attempts.
+pub fn enable_verity_with_retry<H: FsVerityHashValue>(
+    fd: impl AsFd,
+) -> Result<(), EnableVerityError> {
+    let mut attempt = 1;
+    loop {
+        match enable_verity_raw::<H>(&fd) {
+            Err(EnableVerityError::FileOpenedForWrite) if attempt < 3 => {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+                attempt += 1;
+            }
+            other => return other,
+        }
+    }
+}
+
+/// Enable fs-verity on the given file.  If the given file cannot be
+/// enabled because it is opened as writable, then a new copy of the
+/// file will be returned instead.  No attempt is made to sync the
+/// copied file contents to disk, it is up to the caller to do so if
+/// desired.
+///
+/// Take special note that in the case where a copied file descriptor
+/// is returned, the returned file is created as a tempfile and is
+/// unlinked.  Presumably the caller should take care to make this
+/// file permanent, using a combination of `linkat` and `renameat` to
+/// replace the original file.
+///
+/// This uses `enable_verity_raw()` and `enable_verity_with_retry()`
+/// and is subject to the same restrictions.
+///
+/// # Arguments:
+/// * `dirfd`: A directory file descriptor, used to determine the placement (via O_TMPFILE) of the new file (if necessary).
+/// * `fd`: The file decriptor to enable verity on
+pub fn enable_verity_maybe_copy<H: FsVerityHashValue>(
+    dirfd: impl AsFd,
+    fd: OwnedFd,
+    mode: Mode,
+) -> Result<VerityFd, EnableVerityError> {
+    match enable_verity_with_retry::<H>(&fd) {
+        Ok(_) => Ok(VerityFd::Orig(fd)),
+        Err(EnableVerityError::FileOpenedForWrite) => {
+            enable_verity_on_copy::<H>(dirfd, fd, mode).map(VerityFd::Copy)
+        }
+        Err(other) => Err(other),
+    }
+}
+
+/// Enable fs-verity on a new copy of `fd`, consuming `fd` and
+/// returning the new copy.  The copy is created via O_TMPFILE
+/// relative to `dirfd`.
+fn enable_verity_on_copy<H: FsVerityHashValue>(
+    dirfd: impl AsFd,
+    fd: OwnedFd,
+    mode: Mode,
+) -> Result<OwnedFd, EnableVerityError> {
+    let mut fd = File::from(fd);
+
+    loop {
+        fd.rewind().map_err(EnableVerityError::Io)?;
+
+        let mut new_rw_fd = File::from(
+            openat(
+                &dirfd,
+                ".",
+                OFlags::CLOEXEC | OFlags::RDWR | OFlags::TMPFILE,
+                mode,
+            )
+            .map_err(|e| EnableVerityError::Io(e.into()))?,
+        );
+
+        std::io::copy(&mut fd, &mut new_rw_fd)?;
+        let new_ro_fd = open(
+            proc_self_fd(&new_rw_fd),
+            OFlags::RDONLY | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .map_err(|e| EnableVerityError::Io(e.into()))?;
+        drop(new_rw_fd);
+        if enable_verity_with_retry::<H>(&new_ro_fd).is_ok() {
+            return Ok(new_ro_fd);
+        }
+    }
 }
 
 /// Measures fs-verity on the given file.
@@ -154,7 +294,10 @@ mod tests {
     };
     use tempfile::tempfile_in;
 
-    use crate::{test::tempfile, util::proc_self_fd};
+    use crate::{
+        test::{tempdir, tempfile},
+        util::proc_self_fd,
+    };
 
     use super::*;
 
@@ -170,6 +313,13 @@ mod tests {
         .unwrap();
         drop(file); // can't enable verity with outstanding writable fds
         fd
+    }
+
+    fn empty_file_in_tmpdir(flags: OFlags, mode: Mode) -> (tempfile::TempDir, OwnedFd) {
+        let tmpdir = tempdir();
+        let path = tmpdir.path().join("empty");
+        let fd = open(path, OFlags::CLOEXEC | OFlags::CREATE | flags, mode).unwrap();
+        (tmpdir, fd)
     }
 
     #[test]
@@ -196,11 +346,11 @@ mod tests {
         let tf = rdonly_file_with(b"hello world");
 
         // first time: success
-        enable_verity::<Sha256HashValue>(&tf).unwrap();
+        enable_verity_with_retry::<Sha256HashValue>(&tf).unwrap();
 
         // second time: fail with "already enabled"
         assert!(matches!(
-            enable_verity::<Sha256HashValue>(&tf).unwrap_err(),
+            enable_verity_with_retry::<Sha256HashValue>(&tf).unwrap_err(),
             EnableVerityError::AlreadyEnabled
         ));
 
@@ -251,7 +401,7 @@ mod tests {
         let tf = tempfile_in("/dev/shm").unwrap();
 
         assert!(matches!(
-            enable_verity::<Sha256HashValue>(&tf).unwrap_err(),
+            enable_verity_with_retry::<Sha256HashValue>(&tf).unwrap_err(),
             EnableVerityError::FilesystemNotSupported
         ));
 
@@ -275,7 +425,7 @@ mod tests {
         let tf = rdonly_file_with(b"hello world");
 
         // Enable with SHA-512 but then try to read with SHA-256
-        enable_verity::<Sha512HashValue>(&tf).unwrap();
+        enable_verity_with_retry::<Sha512HashValue>(&tf).unwrap();
 
         assert!(matches!(
             measure_verity::<Sha256HashValue>(&tf).unwrap_err(),
@@ -298,7 +448,7 @@ mod tests {
         let tf = rdonly_file_with(b"hello world");
 
         // Enable with SHA-256 but then try to read with SHA-512
-        enable_verity::<Sha256HashValue>(&tf).unwrap();
+        enable_verity_with_retry::<Sha256HashValue>(&tf).unwrap();
 
         assert!(matches!(
             measure_verity::<Sha512HashValue>(&tf).unwrap_err(),
@@ -348,7 +498,7 @@ mod tests {
 
         fn assert_kernel_equal<H: FsVerityHashValue>(data: &[u8], expected: H) {
             let fd = rdonly_file_with(data);
-            enable_verity::<H>(&fd).unwrap();
+            enable_verity_with_retry::<H>(&fd).unwrap();
             ensure_verity_equal(&fd, &expected).unwrap();
         }
 
@@ -358,5 +508,44 @@ mod tests {
             assert_kernel_equal(&data, compute_verity::<Sha256HashValue>(&data));
             assert_kernel_equal(&data, compute_verity::<Sha512HashValue>(&data));
         }
+    }
+
+    #[test]
+    fn test_enable_verity_maybe_copy_without_copy() {
+        // Enabling verity on an empty file created without a
+        // read-write file descriptor ever existing should always
+        // succeed and hand us back the original file descriptor.
+        let mode = 0o644.into();
+        let (tempdir, fd) = empty_file_in_tmpdir(OFlags::RDONLY, mode);
+        let tempdir_fd = File::open(tempdir.path()).unwrap();
+        let verity = enable_verity_maybe_copy::<Sha256HashValue>(&tempdir_fd, fd, mode).unwrap();
+        assert!(verity.is_orig());
+    }
+
+    #[test]
+    fn test_enable_verity_maybe_copy_with_copy() {
+        // Here we intentionally try to enable verity on a read-write
+        // file descriptor, which will never work directly, so we
+        // expect to always get back a new copy of the requested file.
+        let mode = 0o644.into();
+        let (tempdir, fd) = empty_file_in_tmpdir(OFlags::RDWR, mode);
+        let tempdir_fd = File::open(tempdir.path()).unwrap();
+        let mut fd = File::from(fd);
+        let _ = fd.write(b"hello world").unwrap();
+        let verity =
+            enable_verity_maybe_copy::<Sha256HashValue>(&tempdir_fd, fd.into(), mode).unwrap();
+
+        // This is not the original fd
+        assert!(verity.is_copy());
+
+        // The new fd has the correct data
+        assert!(ensure_verity_equal(
+            verity.into_inner(),
+            &Sha256HashValue::from_hex(
+                "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+            )
+            .unwrap(),
+        )
+        .is_ok());
     }
 }

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -149,7 +149,7 @@ pub fn enable_verity_maybe_copy<H: FsVerityHashValue>(
     fd: BorrowedFd,
 ) -> Result<Option<OwnedFd>, EnableVerityError> {
     match enable_verity_with_retry::<H>(&fd) {
-        Ok(_) => Ok(None),
+        Ok(()) => Ok(None),
         Err(EnableVerityError::FileOpenedForWrite) => {
             let fd = enable_verity_on_copy::<H>(dirfd, fd)?;
             Ok(Some(fd))

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -21,7 +21,7 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     fsverity::{
-        compute_verity, enable_verity, ensure_verity_equal, measure_verity, CompareVerityError,
+        compute_verity, enable_verity_raw, ensure_verity_equal, measure_verity, CompareVerityError,
         EnableVerityError, FsVerityHashValue, MeasureVerityError,
     },
     mount::{composefs_fsmount, mount_at},
@@ -135,7 +135,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
                     Err(CompareVerityError::Measure(MeasureVerityError::VerityMissing))
                         if self.insecure =>
                     {
-                        match enable_verity::<ObjectID>(&fd) {
+                        match enable_verity_raw::<ObjectID>(&fd) {
                             Ok(()) => {
                                 ensure_verity_equal(&fd, &id)?;
                             }
@@ -170,7 +170,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         )?;
         drop(file);
 
-        match enable_verity::<ObjectID>(&ro_fd) {
+        match enable_verity_raw::<ObjectID>(&ro_fd) {
             Ok(()) => match ensure_verity_equal(&ro_fd, &id) {
                 Ok(()) => {}
                 Err(CompareVerityError::Measure(


### PR DESCRIPTION
`enable_verity_raw` is effectively the same as the previous `enable_verity`, it simply calls the underlying ioctl.

`enable_verity_with_retry` will attempt to enable verity an opinionated three times with a 1ms delay between tries when encountering ETXTBSY.  This is generally enough to work around the delay with CLOEXEC in conjunction with fork()->exec().

`enable_verity_maybe_copy` will take ownership of the file descriptor and attempt to enable verity using `enable_verity_with_retry`.  If successful, it returns `VerityFd::Orig(fd)` to designate that the file descriptor is the same one provided by the caller.  If unsuccessful, it will instead copy the data to a new O_TMPFILE and return that via `VerityFd::Copy(fd)`.  It is up to the caller to reconcile how this new file descriptor is to be persisted into the filesystem.

Resolves: https://github.com/containers/composefs-rs/issues/106