### PR TITLE
tar: Strip trailing null characters from filenames

### DIFF
--- a/crates/composefs-oci/src/tar.rs
+++ b/crates/composefs-oci/src/tar.rs
@@ -147,6 +147,10 @@ fn path_from_tar(pax: Option<Box<[u8]>>, gnu: Vec<u8>, short: &[u8]) -> PathBuf 
         path.pop(); // this is Vec<u8>, so that's a single char.
     }
 
+    if path.last() == Some(&b'\0') {
+        path.pop();
+    }
+
     PathBuf::from(OsString::from_vec(path))
 }
 


### PR DESCRIPTION
Some file paths end up with trailing null characters which causes issues while building the filesystem tree.

Ex. `/usr/../grpc\0` adds `grpc\0` as the directory name. When it comes to directory `/usr/../grpc/otelgrpc\0` we get the error "Directory 'grpc' not found"