### PR TITLE
Export function `read_file` as public

### DIFF
--- a/crates/composefs-boot/src/bootloader.rs
+++ b/crates/composefs-boot/src/bootloader.rs
@@ -112,7 +112,7 @@ impl BootLoaderEntryFile {
     }
 }
 
-pub(crate) fn read_file<ObjectID: FsVerityHashValue>(
+pub fn read_file<ObjectID: FsVerityHashValue>(
     file: &RegularFile<ObjectID>,
     repo: &Repository<ObjectID>,
 ) -> Result<Box<[u8]>> {


### PR DESCRIPTION
Since we want to be able to read/write boot entries from bootc