### PR TITLE
oci/pull: Allow passing in custom ImageProxyConfig

### DIFF
--- a/crates/cfsctl/src/main.rs
+++ b/crates/cfsctl/src/main.rs
@@ -248,7 +248,7 @@ async fn main() -> Result<()> {
             }
             OciCommand::Pull { ref image, name } => {
                 let (sha256, verity) =
-                    composefs_oci::pull(&Arc::new(repo), image, name.as_deref()).await?;
+                    composefs_oci::pull(&Arc::new(repo), image, name.as_deref(), None).await?;
 
                 println!("sha256 {}", hex::encode(sha256));
                 println!("verity {}", verity.to_hex());

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -5,6 +5,7 @@ pub mod tar;
 use std::{collections::HashMap, io::Read, sync::Arc};
 
 use anyhow::{bail, ensure, Context, Result};
+use containers_image_proxy::ImageProxyConfig;
 use oci_spec::image::{Descriptor, ImageConfiguration};
 use sha2::{Digest, Sha256};
 
@@ -61,8 +62,9 @@ pub async fn pull<ObjectID: FsVerityHashValue>(
     repo: &Arc<Repository<ObjectID>>,
     imgref: &str,
     reference: Option<&str>,
+    img_proxy_config: Option<ImageProxyConfig>,
 ) -> Result<(Sha256Digest, ObjectID)> {
-    skopeo::pull(repo, imgref, reference).await
+    skopeo::pull(repo, imgref, reference, img_proxy_config).await
 }
 
 pub fn open_config<ObjectID: FsVerityHashValue>(


### PR DESCRIPTION
Take `img_proxy_config` as an argument to `composefs_oci::pull` enabling callers to override default proxy configuration.

If a custom `skopeo` command is not passed in the config, we add our own.