### PR TITLE
ci: Drop ubuntu/bls

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,7 +22,11 @@ jobs:
           - { dir: 'bls', os: 'fedora-compat' }
           - { dir: 'bls', os: 'rawhide' }
           - { dir: 'bls', os: 'rhel9' }
-          - { dir: 'bls', os: 'ubuntu' }
+          # This one is currently failing, needs debugging
+          # https://github.com/containers/composefs-rs/pull/168#pullrequestreview-3088673152
+          # We believe it's mount API changes causing /sysroot to be mounted
+          # at the wrong place.
+          # - { dir: 'bls', os: 'ubuntu' }
           - { dir: 'uki', os: 'arch' }
           - { dir: 'uki', os: 'fedora' }
           - { dir: 'unified', os: 'fedora' }


### PR DESCRIPTION
Not sure why this is failing, but we're not gating on it right now and it's annoying to have to look each time at the red X.