### PR TITLE
boot: Empty /sysroot too

### DIFF
--- a/crates/composefs-boot/src/lib.rs
+++ b/crates/composefs-boot/src/lib.rs
@@ -13,6 +13,24 @@ use composefs::{fsverity::FsVerityHashValue, repository::Repository, tree::FileS
 
 use crate::bootloader::{get_boot_resources, BootEntry};
 
+/// These directories are required to exist in images.
+/// They may have content in the container, but we don't
+/// want to expose them in the final merged root.
+///
+/// # /boot
+///
+/// This is how sealed UKIs are handled; the UKI in /boot has the composefs
+/// digest, so we can't include it in the rendered image.
+///
+/// # /sysroot
+///
+/// See https://github.com/containers/composefs-rs/issues/164
+/// Basically there is only content here in ostree-container cases,
+/// and us traversing there for SELinux labeling will cause problems.
+/// The ostree-container code special cases it in a different way, but
+/// here we can just ignore it.
+const REQUIRED_TOPLEVEL_TO_EMPTY_DIRS: &[&str] = &["boot", "sysroot"];
+
 pub trait BootOps<ObjectID: FsVerityHashValue> {
     fn transform_for_boot(
         &mut self,
@@ -26,9 +44,11 @@ impl<ObjectID: FsVerityHashValue> BootOps<ObjectID> for FileSystem<ObjectID> {
         repo: &Repository<ObjectID>,
     ) -> Result<Vec<BootEntry<ObjectID>>> {
         let boot_entries = get_boot_resources(self, repo)?;
-        let boot = self.root.get_directory_mut("boot".as_ref())?;
-        boot.stat.st_mtim_sec = 0;
-        boot.clear();
+        for d in REQUIRED_TOPLEVEL_TO_EMPTY_DIRS {
+            let d = self.root.get_directory_mut(d.as_ref())?;
+            d.stat.st_mtim_sec = 0;
+            d.clear();
+        }
 
         selabel::selabel(self, repo)?;
 


### PR DESCRIPTION
This aids our compatibility with existing ostree-containers.

Closes: https://github.com/containers/composefs-rs/issues/164