### PR TITLE
Fix warnings for mismatched_lifetime_syntaxes lint

### DIFF
--- a/crates/composefs/src/dumpfile_parse.rs
+++ b/crates/composefs/src/dumpfile_parse.rs
@@ -131,7 +131,7 @@ pub enum Item<'p> {
 
 /// Unescape a byte array according to the composefs dump file escaping format,
 /// limiting the maximum possible size.
-fn unescape_limited(s: &str, max: usize) -> Result<Cow<[u8]>> {
+fn unescape_limited(s: &str, max: usize) -> Result<Cow<'_, [u8]>> {
     // If there are no escapes, just return the input unchanged. However,
     // it must also be ASCII to maintain a 1-1 correspondence between byte
     // and character.
@@ -179,13 +179,13 @@ fn unescape_limited(s: &str, max: usize) -> Result<Cow<[u8]>> {
 }
 
 /// Unescape a byte array according to the composefs dump file escaping format.
-fn unescape(s: &str) -> Result<Cow<[u8]>> {
+fn unescape(s: &str) -> Result<Cow<'_, [u8]>> {
     unescape_limited(s, usize::MAX)
 }
 
 /// Unescape a string into a Rust `OsStr` which is really just an alias for a byte array,
 /// but we also impose a constraint that it can not have an embedded NUL byte.
-fn unescape_to_osstr(s: &str) -> Result<Cow<OsStr>> {
+fn unescape_to_osstr(s: &str) -> Result<Cow<'_, OsStr>> {
     let v = unescape(s)?;
     if v.contains(&0u8) {
         anyhow::bail!("Invalid embedded NUL");
@@ -201,7 +201,7 @@ fn unescape_to_osstr(s: &str) -> Result<Cow<OsStr>> {
 /// with a few constraints:
 /// - Cannot contain an embedded NUL
 /// - Cannot be empty, or longer than PATH_MAX
-fn unescape_to_path(s: &str) -> Result<Cow<Path>> {
+fn unescape_to_path(s: &str) -> Result<Cow<'_, Path>> {
     let v = unescape_to_osstr(s).and_then(|v| {
         if v.is_empty() {
             anyhow::bail!("Invalid empty path");
@@ -224,7 +224,7 @@ fn unescape_to_path(s: &str) -> Result<Cow<Path>> {
 /// which in particular removes `.` and extra `//`.
 ///
 /// We also deny uplinks `..` and empty paths.
-fn unescape_to_path_canonical(s: &str) -> Result<Cow<Path>> {
+fn unescape_to_path_canonical(s: &str) -> Result<Cow<'_, Path>> {
     let p = unescape_to_path(s)?;
     let mut components = p.components();
     let mut r = std::path::PathBuf::new();

--- a/crates/composefs/src/erofs/reader.rs
+++ b/crates/composefs/src/erofs/reader.rs
@@ -295,7 +295,7 @@ impl<'img> Image<'img> {
         }
     }
 
-    pub fn inode(&self, id: u64) -> InodeType {
+    pub fn inode(&self, id: u64) -> InodeType<'_> {
         let inode_data = &self.inodes[id as usize * 32..];
         if inode_data[0] & 1 != 0 {
             let header = ExtendedInodeHeader::ref_from_bytes(&inode_data[..64]).unwrap();
@@ -340,7 +340,7 @@ impl<'img> Image<'img> {
         DirectoryBlock::ref_from_bytes(self.block(id)).unwrap()
     }
 
-    pub fn root(&self) -> InodeType {
+    pub fn root(&self) -> InodeType<'_> {
         self.inode(self.sb.root_nid.get() as u64)
     }
 }
@@ -358,7 +358,7 @@ impl InodeXAttrs {
              .0
     }
 
-    pub fn local(&self) -> XAttrIter {
+    pub fn local(&self) -> XAttrIter<'_> {
         XAttrIter {
             data: &self.data[self.header.shared_count as usize * 4..],
         }
@@ -414,7 +414,7 @@ impl DirectoryBlock {
         offset as usize / 12
     }
 
-    pub fn entries(&self) -> DirectoryEntries {
+    pub fn entries(&self) -> DirectoryEntries<'_> {
         DirectoryEntries {
             block: self,
             length: self.n_entries(),

--- a/crates/composefs/src/mount.rs
+++ b/crates/composefs/src/mount.rs
@@ -30,7 +30,7 @@ impl FsHandle {
 }
 
 impl AsFd for FsHandle {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.fd.as_fd()
     }
 }

--- a/crates/composefs/src/mountcompat.rs
+++ b/crates/composefs/src/mountcompat.rs
@@ -151,7 +151,7 @@ mod tmpmount {
     }
 
     impl AsFd for TmpMount {
-        fn as_fd(&self) -> BorrowedFd {
+        fn as_fd(&self) -> BorrowedFd<'_> {
             self.fd.as_fd()
         }
     }


### PR DESCRIPTION
Rust 1.89 introduced this new lint[1], fix the handful of places where
it comes up across the repo.

[1] https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
