### PR TITLE
Drop support for embedding type1 entries directly in an image

### DIFF
--- a/crates/composefs-boot/src/bootloader.rs
+++ b/crates/composefs-boot/src/bootloader.rs
@@ -524,12 +524,10 @@ initrd /{id}/initramfs.img
 
 /// Represents any type of boot entry found in the filesystem.
 ///
-/// This enum unifies the three types of boot entries that can be discovered:
-/// Type 1 BLS entries, Type 2 UKIs, and traditional vmlinuz/initramfs pairs.
+/// This enum unifies the different types of boot entries that can be discovered:
+/// Type 2 UKIs and traditional vmlinuz/initramfs pairs.
 #[derive(Debug)]
 pub enum BootEntry<ObjectID: FsVerityHashValue> {
-    /// Boot Loader Specification Type 1 entry
-    Type1(Type1Entry<ObjectID>),
     /// Boot Loader Specification Type 2 entry (UKI)
     Type2(Type2Entry<ObjectID>),
     /// Traditional vmlinuz from /usr/lib/modules
@@ -538,27 +536,21 @@ pub enum BootEntry<ObjectID: FsVerityHashValue> {
 
 /// Extracts all boot resources from a filesystem image.
 ///
-/// Scans the filesystem for all types of boot entries: Type 1 BLS entries in
-/// /boot/loader/entries, Type 2 UKIs in /boot/EFI/Linux, and traditional vmlinuz
-/// files in /usr/lib/modules.
+/// Scans the filesystem for all types of boot entries: Type 2 UKIs in
+/// /boot/EFI/Linux and traditional vmlinuz files in /usr/lib/modules.
 ///
 /// # Arguments
 ///
 /// * `image` - The filesystem to scan
-/// * `repo` - The composefs repository
 ///
 /// # Returns
 ///
 /// A vector containing all boot entries found in the filesystem
 pub fn get_boot_resources<ObjectID: FsVerityHashValue>(
     image: &FileSystem<ObjectID>,
-    repo: &Repository<ObjectID>,
 ) -> Result<Vec<BootEntry<ObjectID>>> {
     let mut entries = vec![];
 
-    for e in Type1Entry::load_all(&image.root, repo)? {
-        entries.push(BootEntry::Type1(e));
-    }
     for e in Type2Entry::load_all(&image.root)? {
         entries.push(BootEntry::Type2(e));
     }

--- a/crates/composefs-boot/src/lib.rs
+++ b/crates/composefs-boot/src/lib.rs
@@ -69,7 +69,7 @@ impl<ObjectID: FsVerityHashValue> BootOps<ObjectID> for FileSystem<ObjectID> {
         &mut self,
         repo: &Repository<ObjectID>,
     ) -> Result<Vec<BootEntry<ObjectID>>> {
-        let boot_entries = get_boot_resources(self, repo)?;
+        let boot_entries = get_boot_resources(self)?;
 
         // Get /usr's mtime to use as the canonical mtime for emptied directories.
         // This matches how we handle the root directory in copy_root_metadata_from_usr().

--- a/crates/composefs-boot/src/write_boot.rs
+++ b/crates/composefs-boot/src/write_boot.rs
@@ -140,20 +140,6 @@ pub fn write_boot_simple<ObjectID: FsVerityHashValue>(
     cmdline_extra: &[&str],
 ) -> Result<()> {
     match entry {
-        BootEntry::Type1(mut t1) => {
-            if let Some(name) = entry_id {
-                t1.relocate(boot_subdir, name);
-            }
-            write_t1_simple(
-                t1,
-                boot_partition,
-                boot_subdir,
-                root_id,
-                insecure,
-                cmdline_extra,
-                repo,
-            )?;
-        }
         BootEntry::Type2(mut t2) => {
             if let Some(name) = entry_id {
                 t2.rename(name);


### PR DESCRIPTION
We're not going to use this in bootc and right now we just error if we encounter it, and I am not aware of a good use case.