### PR TITLE
tree-wide: Add docs for all `pub` items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.88.0"
 version = "0.3.0"
 
 [workspace.lints.rust]
+missing_docs = "deny"
 missing_debug_implementations = "deny"
 unsafe_code = "deny" # https://github.com/containers/composefs-rs/issues/123
 

--- a/crates/composefs-boot/src/cmdline.rs
+++ b/crates/composefs-boot/src/cmdline.rs
@@ -35,6 +35,16 @@ pub fn get_cmdline_value<'a>(cmdline: &'a str, prefix: &str) -> Option<&'a str> 
     split_cmdline(cmdline).find_map(|item| item.strip_prefix(prefix))
 }
 
+/// Extracts and parses the composefs= parameter from a kernel command line.
+///
+/// # Arguments
+///
+/// * `cmdline` - The kernel command line string
+///
+/// # Returns
+///
+/// A tuple of (hash, insecure_flag) where the hash is the composefs object ID
+/// and insecure_flag indicates whether the '?' prefix was present (making verification optional)
 pub fn get_cmdline_composefs<ObjectID: FsVerityHashValue>(
     cmdline: &str,
 ) -> Result<(ObjectID, bool)> {
@@ -46,6 +56,16 @@ pub fn get_cmdline_composefs<ObjectID: FsVerityHashValue>(
     }
 }
 
+/// Creates a composefs= kernel command line argument.
+///
+/// # Arguments
+///
+/// * `id` - The composefs object ID as a hex string
+/// * `insecure` - If true, prepends '?' to make fs-verity verification optional
+///
+/// # Returns
+///
+/// A string like "composefs=abc123" or "composefs=?abc123" (if insecure)
 pub fn make_cmdline_composefs(id: &str, insecure: bool) -> String {
     match insecure {
         true => format!("composefs=?{id}"),

--- a/crates/composefs-boot/src/lib.rs
+++ b/crates/composefs-boot/src/lib.rs
@@ -38,7 +38,23 @@ use crate::bootloader::{get_boot_resources, BootEntry};
 /// here we can just ignore it.
 const REQUIRED_TOPLEVEL_TO_EMPTY_DIRS: &[&str] = &["boot", "sysroot"];
 
+/// Trait for transforming filesystem images for boot scenarios.
+///
+/// This trait provides functionality to prepare composefs filesystem images for booting by
+/// extracting boot resources and applying necessary transformations like SELinux labeling.
 pub trait BootOps<ObjectID: FsVerityHashValue> {
+    /// Transforms a filesystem image for boot by extracting boot entries and applying SELinux labels.
+    ///
+    /// This method extracts boot resources from the filesystem, empties required top-level
+    /// directories (/boot, /sysroot), and applies SELinux security contexts.
+    ///
+    /// # Arguments
+    ///
+    /// * `repo` - The composefs repository containing filesystem objects
+    ///
+    /// # Returns
+    ///
+    /// A vector of boot entries extracted from the filesystem (Type 1 BLS entries, Type 2 UKIs, etc.)
     fn transform_for_boot(
         &mut self,
         repo: &Repository<ObjectID>,

--- a/crates/composefs-boot/src/os_release.rs
+++ b/crates/composefs-boot/src/os_release.rs
@@ -45,6 +45,10 @@ fn dequote(value: &str) -> Option<String> {
     Some(result)
 }
 
+/// Parsed os-release file information.
+///
+/// Contains key-value pairs from an os-release file with methods to extract
+/// common fields like PRETTY_NAME and VERSION_ID.
 #[derive(Debug)]
 pub struct OsReleaseInfo<'a> {
     map: HashMap<&'a str, &'a str>,

--- a/crates/composefs-boot/src/selabel.rs
+++ b/crates/composefs-boot/src/selabel.rs
@@ -255,6 +255,19 @@ fn parse_config(file: impl Read) -> Result<Option<String>> {
     Ok(None)
 }
 
+/// Applies SELinux security contexts to all files in a filesystem tree.
+///
+/// Reads the SELinux policy from /etc/selinux/config and corresponding policy files,
+/// then labels all filesystem nodes with appropriate security.selinux extended attributes.
+///
+/// # Arguments
+///
+/// * `fs` - The filesystem to label
+/// * `repo` - The composefs repository
+///
+/// # Returns
+///
+/// Ok(()) if labeling succeeds or if no SELinux policy is found
 pub fn selabel<H: FsVerityHashValue>(fs: &mut FileSystem<H>, repo: &Repository<H>) -> Result<()> {
     // if /etc/selinux/config doesn't exist then it's not an error
     let Some(etc_selinux) = fs.root.get_directory_opt("etc/selinux".as_ref())? else {

--- a/crates/composefs-boot/src/uki.rs
+++ b/crates/composefs-boot/src/uki.rs
@@ -61,18 +61,29 @@ struct SectionHeader {
     characteristics: U32,
 }
 
+/// Errors that can occur when parsing UKI files.
 #[derive(Debug, Error, PartialEq)]
 pub enum UkiError {
+    /// The file is not a valid Portable Executable (PE/EFI) format
     #[error("UKI is not valid EFI executable")]
     PortableExecutableError,
+    /// A required PE section is missing from the UKI
     #[error("UKI doesn't contain a '{0}' section")]
     MissingSection(&'static str),
+    /// A PE section contains invalid UTF-8
     #[error("UKI section '{0}' is not UTF-8")]
     UnicodeError(&'static str),
+    /// The .osrel section lacks name information
     #[error("No name information found in .osrel section")]
     NoName,
 }
 
+/// Extracts a text section from a UKI PE file by name.
+///
+/// Parses the PE file format to locate and extract the contents of a named
+/// text section (e.g., ".osrel", ".cmdline"). Returns None if the PE format
+/// is invalid, Some(Ok) with the text content if found and valid UTF-8, or
+/// Some(Err) with the specific error.
 // We use `None` as a way to say `Err(UkiError::PortableExecutableError)` for two reasons:
 //   - .get(..) returns Option<> and using `?` with that is extremely convenient
 //   - the error types returned from FromBytes can't be used with `?` because they try to return a

--- a/crates/composefs-boot/src/write_boot.rs
+++ b/crates/composefs-boot/src/write_boot.rs
@@ -20,6 +20,17 @@ use crate::{
     uki,
 };
 
+/// Writes a Type 1 boot entry to the boot directory.
+///
+/// # Arguments
+///
+/// * `t1` - The Type 1 entry to write
+/// * `bootdir` - Path to the boot directory
+/// * `boot_subdir` - Optional subdirectory to prepend to paths
+/// * `root_id` - The composefs root object ID
+/// * `insecure` - Whether to allow optional fs-verity verification
+/// * `cmdline_extra` - Additional kernel command line arguments
+/// * `repo` - The composefs repository
 pub fn write_t1_simple<ObjectID: FsVerityHashValue>(
     mut t1: Type1Entry<ObjectID>,
     bootdir: &Path,
@@ -57,6 +68,16 @@ pub fn write_t1_simple<ObjectID: FsVerityHashValue>(
     Ok(())
 }
 
+/// Writes a Type 2 boot entry (UKI) to the boot directory.
+///
+/// Validates that the UKI's embedded composefs= parameter matches the expected root_id.
+///
+/// # Arguments
+///
+/// * `t2` - The Type 2 entry to write
+/// * `bootdir` - Path to the boot directory
+/// * `root_id` - The expected composefs root object ID
+/// * `repo` - The composefs repository
 pub fn write_t2_simple<ObjectID: FsVerityHashValue>(
     t2: Type2Entry<ObjectID>,
     bootdir: &Path,

--- a/crates/composefs-http/src/lib.rs
+++ b/crates/composefs-http/src/lib.rs
@@ -237,6 +237,30 @@ impl<ObjectID: FsVerityHashValue> Downloader<ObjectID> {
     }
 }
 
+/// Downloads a composefs splitstream and all its dependencies from an HTTP server.
+///
+/// This function fetches a named splitstream from the specified HTTP URL, recursively
+/// downloads all referenced splitstreams and objects, and verifies their integrity using
+/// fsverity checksums. Downloaded objects are stored in the provided repository.
+///
+/// # Parameters
+///
+/// * `url` - The base HTTP URL where the splitstream repository is hosted
+/// * `name` - The name of the splitstream to download (located under `streams/` on the server)
+/// * `repo` - The repository where downloaded objects will be stored
+///
+/// # Returns
+///
+/// Returns a tuple containing the SHA-256 digest of the splitstream's content and its
+/// fsverity object ID.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The HTTP request fails or returns a non-success status
+/// - Downloaded objects have mismatched fsverity checksums
+/// - Splitstream references contain inconsistent content hashes
+/// - Any I/O operation fails during object storage
 pub async fn download<ObjectID: FsVerityHashValue>(
     url: &str,
     name: &str,

--- a/crates/composefs-oci/src/image.rs
+++ b/crates/composefs-oci/src/image.rs
@@ -21,6 +21,13 @@ use composefs::{
 
 use crate::tar::{TarEntry, TarItem};
 
+/// Processes a single tar entry and adds it to the filesystem.
+///
+/// Handles various tar entry types (regular files, directories, symlinks, hardlinks, devices, fifos)
+/// and implements overlayfs whiteout semantics for proper layer merging. Files named `.wh.<name>`
+/// delete the corresponding file, and `.wh..wh.opq` marks a directory as opaque (clearing all contents).
+///
+/// Returns an error if the entry cannot be processed or added to the filesystem.
 pub fn process_entry<ObjectID: FsVerityHashValue>(
     filesystem: &mut FileSystem<ObjectID>,
     entry: TarEntry<ObjectID>,

--- a/crates/composefs/src/dumpfile.rs
+++ b/crates/composefs/src/dumpfile.rs
@@ -91,6 +91,10 @@ fn write_entry(
     Ok(())
 }
 
+/// Writes a directory entry to the dumpfile format.
+///
+/// Writes the metadata for a directory including path, permissions, ownership,
+/// timestamps, and extended attributes.
 pub fn write_directory(
     writer: &mut impl fmt::Write,
     path: &Path,
@@ -111,6 +115,10 @@ pub fn write_directory(
     )
 }
 
+/// Writes a leaf node (non-directory) entry to the dumpfile format.
+///
+/// Handles all types of leaf nodes including regular files (inline and external),
+/// device files, symlinks, sockets, and FIFOs.
 pub fn write_leaf(
     writer: &mut impl fmt::Write,
     path: &Path,
@@ -206,6 +214,10 @@ pub fn write_leaf(
     }
 }
 
+/// Writes a hardlink entry to the dumpfile format.
+///
+/// Creates a special entry that links the given path to an existing target path
+/// that was already written to the dumpfile.
 pub fn write_hardlink(writer: &mut impl fmt::Write, path: &Path, target: &OsStr) -> fmt::Result {
     write_escaped(writer, path.as_os_str().as_bytes())?;
     write!(writer, " 0 @120000 - - - - 0.0 ")?;
@@ -286,6 +298,10 @@ impl<'a, W: Write, ObjectID: FsVerityHashValue> DumpfileWriter<'a, W, ObjectID> 
     }
 }
 
+/// Writes a complete filesystem tree to the composefs dumpfile format.
+///
+/// Serializes the entire filesystem structure including all directories, files,
+/// metadata, and handles hardlink tracking automatically.
 pub fn write_dumpfile(
     writer: &mut impl Write,
     fs: &FileSystem<impl FsVerityHashValue>,

--- a/crates/composefs/src/erofs/debug.rs
+++ b/crates/composefs/src/erofs/debug.rs
@@ -398,6 +398,9 @@ fn addto<T: Clone + Eq + Ord>(map: &mut BTreeMap<T, usize>, key: &T, count: usiz
     }
 }
 
+/// Dumps unassigned or padding regions in the image
+///
+/// Distinguishes between zero-filled padding and unknown content.
 pub fn dump_unassigned(
     output: &mut impl std::io::Write,
     offset: usize,
@@ -421,6 +424,10 @@ pub fn dump_unassigned(
     Ok(())
 }
 
+/// Dumps a detailed debug view of an EROFS image
+///
+/// Walks the entire image structure, outputting formatted information about
+/// all inodes, blocks, xattrs, and padding. Also produces space usage statistics.
 pub fn debug_img(output: &mut impl std::io::Write, data: &[u8]) -> Result<()> {
     let image = Image::open(data);
     let visited = ImageVisitor::visit_image(&image);

--- a/crates/composefs/src/erofs/writer.rs
+++ b/crates/composefs/src/erofs/writer.rs
@@ -694,6 +694,13 @@ impl Output for FirstPass {
     }
 }
 
+/// Creates an EROFS filesystem image from a composefs tree
+///
+/// This function performs a two-pass generation:
+/// 1. First pass determines the layout and sizes of all structures
+/// 2. Second pass writes the actual image data
+///
+/// Returns the complete EROFS image as a byte array.
 pub fn mkfs_erofs<ObjectID: FsVerityHashValue>(fs: &tree::FileSystem<ObjectID>) -> Box<[u8]> {
     // Create the intermediate representation: flattened inodes and shared xattrs
     let mut inodes = InodeCollector::collect(fs);

--- a/crates/composefs/src/filesystem_ops.rs
+++ b/crates/composefs/src/filesystem_ops.rs
@@ -15,6 +15,11 @@ use crate::{
 };
 
 impl<ObjectID: FsVerityHashValue> FileSystem<ObjectID> {
+    /// Commits this filesystem as an EROFS image to the repository.
+    ///
+    /// Ensures the root directory stat is computed, generates an EROFS filesystem image,
+    /// and writes it to the repository with the optional name. Returns the fsverity digest
+    /// of the committed image.
     pub fn commit_image(
         &mut self,
         repository: &Repository<ObjectID>,
@@ -24,11 +29,19 @@ impl<ObjectID: FsVerityHashValue> FileSystem<ObjectID> {
         repository.write_image(image_name, &mkfs_erofs(self))
     }
 
+    /// Computes the fsverity digest for this filesystem as an EROFS image.
+    ///
+    /// Ensures the root directory stat is computed, generates the EROFS image,
+    /// and returns its fsverity digest without writing to a repository.
     pub fn compute_image_id(&mut self) -> ObjectID {
         self.ensure_root_stat();
         compute_verity(&mkfs_erofs(self))
     }
 
+    /// Prints this filesystem in dumpfile format to stdout.
+    ///
+    /// Ensures the root directory stat is computed and serializes the entire
+    /// filesystem tree to stdout in composefs dumpfile text format.
     pub fn print_dumpfile(&mut self) -> Result<()> {
         self.ensure_root_stat();
         write_dumpfile(&mut std::io::stdout(), self)

--- a/crates/composefs/src/fs.rs
+++ b/crates/composefs/src/fs.rs
@@ -135,7 +135,11 @@ fn write_directory_contents<ObjectID: FsVerityHashValue>(
     Ok(())
 }
 
-// NB: hardlinks not supported
+/// Writes a directory tree from composefs representation to a filesystem path.
+///
+/// Reconstructs the filesystem structure at the specified output directory,
+/// creating directories, files, symlinks, and device nodes as needed. External
+/// file content is read from the repository. Note that hardlinks are not supported.
 pub fn write_to_path<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
     dir: &Directory<ObjectID>,
@@ -145,6 +149,10 @@ pub fn write_to_path<ObjectID: FsVerityHashValue>(
     write_directory_contents(dir, &fd, repo)
 }
 
+/// Helper for reading filesystem trees from disk into composefs representation.
+///
+/// Tracks hardlinks via inode numbers and handles integration with repositories
+/// for storing large file content.
 #[derive(Debug)]
 pub struct FilesystemReader<'repo, ObjectID: FsVerityHashValue> {
     repo: Option<&'repo Repository<ObjectID>>,
@@ -268,6 +276,11 @@ impl<ObjectID: FsVerityHashValue> FilesystemReader<'_, ObjectID> {
         }
     }
 
+    /// Reads a directory from disk into composefs representation.
+    ///
+    /// Recursively reads directory contents, tracking hardlinks and optionally
+    /// reading the directory's own metadata. Large files are stored in the repository
+    /// if one was provided.
     pub fn read_directory(
         &mut self,
         dirfd: impl AsFd,

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -27,27 +27,44 @@ use crate::util::proc_self_fd;
 /// Measuring fsverity failed.
 #[derive(Error, Debug)] // can't derive PartialEq because of std::io::Error
 pub enum MeasureVerityError {
+    /// I/O operation failed.
     #[error("{0}")]
     Io(#[from] Error),
+    /// fs-verity is not enabled on the file.
     #[error("fs-verity is not enabled on file")]
     VerityMissing,
-    #[error("fs-verity is not support by filesystem")]
+    /// The filesystem does not support fs-verity.
+    #[error("fs-verity is not supported by filesystem")]
     FilesystemNotSupported,
+    /// The hash algorithm does not match the expected algorithm.
     #[error("Expected algorithm {expected}, found {found}")]
-    InvalidDigestAlgorithm { expected: u16, found: u16 },
+    InvalidDigestAlgorithm {
+        /// The expected algorithm identifier.
+        expected: u16,
+        /// The actual algorithm identifier found.
+        found: u16,
+    },
+    /// The digest size does not match the expected size.
     #[error("Expected digest size {expected}")]
-    InvalidDigestSize { expected: u16 },
+    InvalidDigestSize {
+        /// The expected digest size in bytes.
+        expected: u16,
+    },
 }
 
 /// Enabling fsverity failed.
 #[derive(Error, Debug)]
 pub enum EnableVerityError {
+    /// I/O operation failed.
     #[error("{0}")]
     Io(#[from] Error),
+    /// The filesystem does not support fs-verity.
     #[error("Filesystem does not support fs-verity")]
     FilesystemNotSupported,
+    /// fs-verity is already enabled on the file.
     #[error("fs-verity is already enabled on file")]
     AlreadyEnabled,
+    /// The file has an open writable file descriptor.
     #[error("File is opened for writing")]
     FileOpenedForWrite,
 }
@@ -55,10 +72,17 @@ pub enum EnableVerityError {
 /// A verity comparison failed.
 #[derive(Error, Debug)]
 pub enum CompareVerityError {
+    /// Failed to measure the fs-verity digest.
     #[error("failed to read verity")]
     Measure(#[from] MeasureVerityError),
+    /// The measured digest does not match the expected digest.
     #[error("Expected digest {expected} but found {found}")]
-    DigestMismatch { expected: String, found: String },
+    DigestMismatch {
+        /// The expected digest as a hex string.
+        expected: String,
+        /// The actual digest found as a hex string.
+        found: String,
+    },
 }
 
 /// Compute the fs-verity digest for a given block of data, in userspace.

--- a/crates/composefs/src/mount.rs
+++ b/crates/composefs/src/mount.rs
@@ -22,12 +22,27 @@ use crate::{
     util::proc_self_fd,
 };
 
+/// A handle to a filesystem context created via the modern mount API.
+///
+/// This represents an open filesystem context (created by `fsopen()`) that can be
+/// configured and then mounted. The handle automatically reads and prints any
+/// error messages from the kernel when dropped.
 #[derive(Debug)]
 pub struct FsHandle {
+    /// The file descriptor for the filesystem context.
     pub fd: OwnedFd,
 }
 
 impl FsHandle {
+    /// Opens a new filesystem context for the specified filesystem type.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the filesystem type (e.g., "erofs", "overlay")
+    ///
+    /// # Returns
+    ///
+    /// Returns a new `FsHandle` that can be configured and mounted.
     pub fn open(name: &str) -> Result<FsHandle> {
         Ok(FsHandle {
             fd: fsopen(name, FsOpenFlags::FSOPEN_CLOEXEC)?,
@@ -54,6 +69,17 @@ impl Drop for FsHandle {
     }
 }
 
+/// Moves a mounted filesystem to a target location.
+///
+/// # Arguments
+///
+/// * `fs_fd` - File descriptor for the mounted filesystem (from `fsmount()`)
+/// * `dirfd` - Directory file descriptor for the target mount point
+/// * `path` - Path relative to `dirfd` where the filesystem should be mounted
+///
+/// # Returns
+///
+/// Returns `Ok(())` on success, or an error if the mount operation fails.
 pub fn mount_at(
     fs_fd: impl AsFd,
     dirfd: impl AsFd,
@@ -68,6 +94,19 @@ pub fn mount_at(
     )
 }
 
+/// Mounts an erofs image file.
+///
+/// Creates a read-only erofs mount from the provided image file descriptor.
+/// On older kernels, this may involve creating a loopback device.
+///
+/// # Arguments
+///
+/// * `image` - File descriptor for the erofs image file
+///
+/// # Returns
+///
+/// Returns a file descriptor for the mounted filesystem, which can be used with
+/// `mount_at()` or other mount operations.
 pub fn erofs_mount(image: OwnedFd) -> Result<OwnedFd> {
     let image = make_erofs_mountable(image)?;
     let erofs = FsHandle::open("erofs")?;
@@ -81,6 +120,23 @@ pub fn erofs_mount(image: OwnedFd) -> Result<OwnedFd> {
     )?)
 }
 
+/// Creates a composefs mount using overlayfs with an erofs image and base directory.
+///
+/// This mounts a composefs image by creating an overlayfs that layers the erofs image
+/// (as the lower layer) over a base directory (as the data layer). The overlayfs is
+/// configured with metacopy and redirect_dir enabled for composefs functionality.
+///
+/// # Arguments
+///
+/// * `image` - File descriptor for the composefs erofs image
+/// * `name` - Name for the mount source (appears as "composefs:{name}")
+/// * `basedir` - File descriptor for the base directory containing the actual file data
+/// * `enable_verity` - Whether to require fs-verity verification for all files
+///
+/// # Returns
+///
+/// Returns a file descriptor for the mounted composefs filesystem, which can be used
+/// with `mount_at()` to attach it to a mount point.
 pub fn composefs_fsmount(
     image: OwnedFd,
     name: &str,

--- a/crates/composefs/src/test.rs
+++ b/crates/composefs/src/test.rs
@@ -1,3 +1,5 @@
+//! Tests
+
 use std::{
     ffi::OsString,
     fs::{create_dir_all, File},
@@ -24,10 +26,12 @@ static TMPDIR: Lazy<OsString> = Lazy::new(|| {
     }
 });
 
+/// Allocate a temporary directory
 pub fn tempdir() -> TempDir {
     TempDir::with_prefix_in("composefs-test-", TMPDIR.as_os_str()).unwrap()
 }
 
-pub fn tempfile() -> File {
+/// Allocate a temporary file
+pub(crate) fn tempfile() -> File {
     tempfile_in(TMPDIR.as_os_str()).unwrap()
 }

--- a/crates/composefs/src/tree.rs
+++ b/crates/composefs/src/tree.rs
@@ -6,19 +6,37 @@ use crate::fsverity::FsVerityHashValue;
 
 pub use crate::generic_tree::{self, ImageError, Stat};
 
+/// Represents a regular file's content storage strategy in composefs.
+///
+/// Files can be stored inline for small content or externally referenced
+/// for larger files using fsverity hashing.
 #[derive(Debug, Clone)]
 pub enum RegularFile<ObjectID: FsVerityHashValue> {
+    /// File content stored inline as raw bytes.
     Inline(Box<[u8]>),
+    /// File stored externally, referenced by fsverity hash and size.
+    ///
+    /// The tuple contains (fsverity hash, file size in bytes).
     External(ObjectID, u64),
 }
 
 // Re-export generic types. Note that we don't need to re-write
 // the generic constraint T: FsVerityHashValue here because it will
 // be transitively enforced.
+
+/// Content of a leaf node in the filesystem tree, specialized for composefs regular files.
 pub type LeafContent<T> = generic_tree::LeafContent<RegularFile<T>>;
+
+/// A leaf node in the filesystem tree (file, symlink, or device), specialized for composefs regular files.
 pub type Leaf<T> = generic_tree::Leaf<RegularFile<T>>;
+
+/// A directory in the filesystem tree, specialized for composefs regular files.
 pub type Directory<T> = generic_tree::Directory<RegularFile<T>>;
+
+/// An inode representing either a directory or a leaf node, specialized for composefs regular files.
 pub type Inode<T> = generic_tree::Inode<RegularFile<T>>;
+
+/// A complete filesystem tree, specialized for composefs regular files.
 pub type FileSystem<T> = generic_tree::FileSystem<RegularFile<T>>;
 
 #[cfg(test)]

--- a/crates/composefs/tests/mkfs.rs
+++ b/crates/composefs/tests/mkfs.rs
@@ -1,3 +1,5 @@
+//! Tests for mkfs
+
 use std::{
     cell::RefCell,
     collections::BTreeMap,


### PR DESCRIPTION
Add `#[deny(missing_docs)]` to enforce this.

Assisted-by: Claude Code