### PR TITLE
Fix clippy lint for `is_multiple_of`

### DIFF
--- a/crates/composefs/src/erofs/reader.rs
+++ b/crates/composefs/src/erofs/reader.rs
@@ -416,7 +416,7 @@ impl DirectoryBlock {
         let first = self.get_entry_header(0);
         let offset = first.name_offset.get();
         assert!(offset != 0);
-        assert!(offset % 12 == 0);
+        assert!(offset.is_multiple_of(12));
         offset as usize / 12
     }
 


### PR DESCRIPTION
This started showing up in CI, apparently somewhere along the way the
modulo operator became frowned up...

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
