### PR TITLE
Support for handling sha512-addressed repos in cfsctl and composefs-setup-root

### DIFF
--- a/crates/composefs-setup-root/Cargo.toml
+++ b/crates/composefs-setup-root/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.0.1", default-features = false, features = ["std", "help",
 composefs = { workspace = true }
 composefs-boot = { workspace = true }
 env_logger = { version = "0.11.0", default-features = false }
+hex = { version = "0.4.3", default-features = false }
 rustix = { version = "1.0.0", default-features = false }
 serde = { version = "1.0.145", default-features = false, features = ["derive"] }
 toml = { version = "0.8.0", default-features = false, features = ["parse"] }

--- a/examples/bls/build
+++ b/examples/bls/build
@@ -41,7 +41,7 @@ esac
 
 cp ../../target/release/cfsctl .
 cp ../../target/release/composefs-setup-root extra/usr/lib/dracut/modules.d/37composefs/
-CFSCTL='./cfsctl --repo tmp/sysroot/composefs'
+CFSCTL='./cfsctl --repo tmp/sysroot/composefs --hash sha256'
 
 rm -rf tmp
 rm -rf tmp/efi tmp/sysroot/composefs/images

--- a/examples/uki/build
+++ b/examples/uki/build
@@ -27,7 +27,7 @@ cargo build --release
 
 cp ../../target/release/cfsctl .
 cp ../../target/release/composefs-setup-root extra/usr/lib/dracut/modules.d/37composefs/
-CFSCTL='./cfsctl --repo tmp/sysroot/composefs'
+CFSCTL='./cfsctl --repo tmp/sysroot/composefs --hash sha256'
 
 rm -rf tmp
 rm -rf tmp/efi tmp/sysroot/composefs/images

--- a/examples/unified-secureboot/build
+++ b/examples/unified-secureboot/build
@@ -16,7 +16,7 @@ cargo build --release
 
 cp ../../target/release/cfsctl .
 cp ../../target/release/composefs-setup-root extra/usr/lib/dracut/modules.d/37composefs/
-CFSCTL='./cfsctl --repo tmp/sysroot/composefs'
+CFSCTL='./cfsctl --repo tmp/sysroot/composefs --hash sha256'
 
 rm -rf tmp
 rm -rf tmp/efi tmp/sysroot/composefs/images

--- a/examples/unified/build
+++ b/examples/unified/build
@@ -16,7 +16,7 @@ cargo build --release
 
 cp ../../target/release/cfsctl .
 cp ../../target/release/composefs-setup-root extra/usr/lib/dracut/modules.d/37composefs/
-CFSCTL='./cfsctl --repo tmp/sysroot/composefs'
+CFSCTL='./cfsctl --repo tmp/sysroot/composefs --hash sha256'
 
 rm -rf tmp
 rm -rf tmp/efi tmp/sysroot/composefs/images


### PR DESCRIPTION
This PR changes `cfsctl` to use sha512-addressed composefs repo by default, this confronts to the behavior of bootc, making the two tools compatible with each other. An additional flag `--use-sha256-object-id` is also added to enable `cfsctl` to work with legacy repos.

kernel cmdline parse logic in `composefs-setup-root` is also changed, both sha256 and sha512 length addresses would be attempted before returning an error, improving robustness within initramfs.

Fixes #197 