### PR TITLE
Use u64 for file sizes to handle >4GB on 32-bit

### DIFF
--- a/crates/composefs/src/erofs/format.rs
+++ b/crates/composefs/src/erofs/format.rs
@@ -18,7 +18,7 @@ use zerocopy::{
 /// Number of bits used for block size (12 = 4096 bytes)
 pub const BLOCK_BITS: u8 = 12;
 /// Size of a block in bytes (4096)
-pub const BLOCK_SIZE: usize = 1 << BLOCK_BITS;
+pub const BLOCK_SIZE: u16 = 1 << BLOCK_BITS;
 
 /// Errors that can occur when parsing EROFS format structures
 #[derive(Debug)]


### PR DESCRIPTION
We obviously want to support files >4GB. Now, not many people care about 32 bit nowadays, but I think it's still cleaner to ensure we use u64 more consistently instead of usize - especially we should avoid a silent `as usize` as that will truncate and corrupt instead of cleanly erroring.

Change BLOCK_SIZE from usize to u32 (it's a format constant, not a memory size), and use u64 for size arithmetic in the writer. For conversions from usize to u64, use try_into().unwrap() since anything addressable in memory always fits in u64.

For the reverse direction (u64 to usize for memory allocation), use fallible conversions with proper error messages so 32-bit systems get a clear error instead of silent truncation when encountering large files.

Note a general issue here is IMO in this project we should *never* read the entire contents of a file into memory, so we shouldn't actually need to worry about >4GB on 32 bit either. But I'm not trying to fix that yet, but when we do we can drop some unwraps.

Assisted-by: OpenCode (Opus 4.5)