### PR TITLE
oci: Parallelize object storage within tar layers

### DIFF
--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
 async-compression = { version = "0.4.0", default-features = false, features = ["tokio", "zstd", "gzip"] }
+bytes = { version = "1", default-features = false }
 composefs = { workspace = true }
 containers-image-proxy = { version = "0.9.0", default-features = false }
 hex = { version = "0.4.0", default-features = false }
@@ -22,6 +23,7 @@ rustix = { version = "1.0.0", features = ["fs"] }
 sha2 = { version = "0.10.1", default-features = false }
 tar = { version = "0.4.38", default-features = false }
 tokio = { version = "1.24.2", features = ["rt-multi-thread"] }
+tokio-util = { version = "0.7", default-features = false, features = ["io"] }
 
 [dev-dependencies]
 similar-asserts = "1.7.0"

--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "mount", "process", "std"] }
 sha2 = { version = "0.10.1", default-features = false, features = ["std"] }
 thiserror = { version = "2.0.0", default-features = false }
-tokio = { version = "1.24.2", default-features = false, features = ["macros", "process", "io-util", "rt-multi-thread"] }
+tokio = { version = "1.24.2", default-features = false, features = ["macros", "process", "io-util", "rt-multi-thread", "sync"] }
 tempfile = { version = "3.8.0", optional = true, default-features = false }
 xxhash-rust = { version = "0.8.2", default-features = false, features = ["xxh32"] }
 zerocopy = { version = "0.8.0", default-features = false, features = ["derive", "std"] }

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -8,6 +8,8 @@ mod digest;
 mod hashvalue;
 mod ioctl;
 
+pub use digest::FsVerityHasher;
+
 use std::{
     fs::File,
     io::{Error, Seek},


### PR DESCRIPTION
Add parallel object storage when processing tar archives. Large files are streamed to O_TMPFILE via a channel, and fs-verity digests are computed in background blocking tasks. This avoids blocking the async runtime while allowing multiple files to be processed concurrently.

Key components:

- FsVerityHasher: Made public for incremental digest computation from files on disk without loading them entirely into memory.

- Repository:
  - create_object_tmpfile(): Create O_TMPFILE for streaming writes
  - finalize_object_tmpfile(): Compute verity, enable it, link to objects/
  - write_semaphore(): Shared semaphore limiting concurrent writes
  - register_stream(): Register stored object as named stream (with sync)

- SplitStreamBuilder: Collects inline data and pending external object handles, resolves ObjectIDs at finalization with proper deduplication.

- split_async(): Now takes AsyncBufRead, streams via channel to blocking tasks, uses repository's shared semaphore for backpressure.

For a 2GB tar (10,000 files × 200KB), achieves ~7x speedup: ~980ms → ~140ms (~14 GB/s throughput).

Assisted-by: OpenCode (Opus 4.5)