### PR TITLE
examples: Pass `--hash sha256` to unified examples

### DIFF
--- a/examples/bls/Containerfile
+++ b/examples/bls/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:42
+FROM fedora:43
 RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
     set -eux
 

--- a/examples/uki/Containerfile
+++ b/examples/uki/Containerfile
@@ -13,7 +13,7 @@
 #    arg will be set to the fsverity digest of the container image.  This should
 #    be baked into the UKI.
 
-FROM fedora:42 AS base
+FROM fedora:43 AS base
 RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
     set -eux
 

--- a/examples/unified-secureboot/Containerfile
+++ b/examples/unified-secureboot/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:42 AS base
+FROM fedora:43 AS base
 RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
     set -eux
 
@@ -18,6 +18,8 @@ RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
         systemd-boot-unsigned \
         systemd-ukify \
         util-linux
+
+        rm -vf /var/lib/systemd/random-seed
 EOF
 
 # --- Everything above this line should hopefully stay cached ---
@@ -43,7 +45,7 @@ RUN --mount=type=bind,from=base,target=/mnt/base <<EOF
     set -eux
 
     mkdir -p /tmp/sysroot/composefs
-    COMPOSEFS_FSVERITY="$(cfsctl --repo /tmp/sysroot compute-id --bootable /mnt/base)"
+    COMPOSEFS_FSVERITY="$(cfsctl --repo /tmp/sysroot --hash sha256 compute-id --bootable /mnt/base)"
 
     mkdir -p /etc/kernel /etc/dracut.conf.d
     echo "composefs=${COMPOSEFS_FSVERITY} rw" > /etc/kernel/cmdline

--- a/examples/unified/Containerfile
+++ b/examples/unified/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:42 AS base
+FROM fedora:43 AS base
 RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
     set -eux
 
@@ -16,6 +16,8 @@ RUN --mount=type=cache,target=/var/cache/libdnf5 <<EOF
         systemd-boot-unsigned \
         systemd-ukify \
         util-linux
+
+        rm -vf /var/lib/systemd/random-seed
 EOF
 
 # --- Everything above this line should hopefully stay cached ---
@@ -41,7 +43,7 @@ RUN --mount=type=bind,from=base,target=/mnt/base <<EOF
     set -eux
 
     mkdir -p /tmp/sysroot/composefs
-    COMPOSEFS_FSVERITY="$(cfsctl --repo /tmp/sysroot compute-id --bootable /mnt/base)"
+    COMPOSEFS_FSVERITY="$(cfsctl --repo /tmp/sysroot --hash sha256 compute-id --bootable /mnt/base)"
 
     mkdir -p /etc/kernel /etc/dracut.conf.d
     echo "composefs=${COMPOSEFS_FSVERITY} rw" > /etc/kernel/cmdline


### PR DESCRIPTION
Remove `/var/lib/systemd/random-seed` to prevent `user.` xattr diff
between dumpfile created from mounted fs and oci container

Also update to use fedora 43 for tests