### PR TITLE
cfsctl: Help text improvement and some other quality of life improvements

### DIFF
--- a/crates/cfsctl/Cargo.toml
+++ b/crates/cfsctl/Cargo.toml
@@ -20,7 +20,7 @@ rhel9 = ['composefs/rhel9']
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
-clap = { version = "4.0.1", default-features = false, features = ["std", "help", "usage", "derive"] }
+clap = { version = "4.5.0", default-features = false, features = ["std", "help", "usage", "derive", "wrap_help"] }
 composefs = { workspace = true }
 composefs-boot = { workspace = true }
 composefs-oci = { workspace = true, optional = true }


### PR DESCRIPTION
This PR improves help texts in the cfsctl command line tool, also bumps clap version to enable "wrap_help" feature for better terminal visibility.

Some small code refactoring is also done for tidier command line options management. 