### PR TITLE
composefs-oci: use chunked reading in tar processing

### DIFF
--- a/crates/composefs/src/splitstream.rs
+++ b/crates/composefs/src/splitstream.rs
@@ -354,6 +354,11 @@ impl<ObjectID: FsVerityHashValue> std::fmt::Debug for SplitStreamWriter<ObjectID
 }
 
 impl<ObjectID: FsVerityHashValue> SplitStreamWriter<ObjectID> {
+    /// Get a reference to the repository.
+    pub fn repo(&self) -> &Repository<ObjectID> {
+        &self.repo
+    }
+
     /// Create a new split stream writer.
     pub fn new(repo: &Arc<Repository<ObjectID>>, content_type: u64) -> Self {
         // SAFETY: we surely can't get an error writing the header to a Vec<u8>


### PR DESCRIPTION
Process tar entries in 1MiB chunks to avoid large memory allocations.