### PR TITLE
WIP: Rough draft for updated generic OCI sealing

### DIFF
--- a/.github/workflows/build-cfsctl-artifact.yml
+++ b/.github/workflows/build-cfsctl-artifact.yml
@@ -1,0 +1,51 @@
+name: Build cfsctl OCI artifact
+
+on:
+  push:
+    branches: ['**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build cfsctl (release)
+        run: cargo build --release -p composefs-ctl --features composefs/rhel9,composefs-oci/oci-client
+
+      - name: Install oras CLI
+        run: |
+          curl -sLO https://github.com/oras-project/oras/releases/download/v1.3.1/oras_1.3.1_linux_amd64.tar.gz
+          tar xzf oras_1.3.1_linux_amd64.tar.gz -C /usr/local/bin oras
+          oras version
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push OCI artifact
+        working-directory: target/release
+        run: |
+          set -eux
+          oras push ghcr.io/${GITHUB_REPOSITORY}/cfsctl:${GITHUB_REF_NAME} \
+            --artifact-type application/vnd.composefs.cfsctl.v1 \
+            cfsctl:application/octet-stream
+          SHA_SHORT=$(echo "${GITHUB_SHA}" | head -c 12)
+          oras push "ghcr.io/${GITHUB_REPOSITORY}/cfsctl:${SHA_SHORT}" \
+            --artifact-type application/vnd.composefs.cfsctl.v1 \
+            cfsctl:application/octet-stream

--- a/Justfile
+++ b/Justfile
@@ -47,9 +47,13 @@ test-all: test test-integration
 check: clippy check-feature-combos fmt-check test check-fuzz
 
 # Base image for test container builds.
+# Defaults to centos-bootc:stream10: ghcr.io/bootcrew/debian-bootc:latest currently
+# fails to bootstrap (a circular dependency in Debian sid's systemd/mount/libselinux1
+# packaging surfaces when apt installs onto the empty dpkg database that debian-bootc
+# ships with by design; this is an upstream packaging issue, not ours).
 # Override to test on a different distro, e.g.:
-#   just base_image=quay.io/centos-bootc/centos-bootc:stream10 test-integration-vm
-base_image := env("COMPOSEFS_BASE_IMAGE", "ghcr.io/bootcrew/debian-bootc:latest")
+#   just base_image=ghcr.io/bootcrew/debian-bootc:latest cfsctl_features='' test-integration-vm
+base_image := env("COMPOSEFS_BASE_IMAGE", "quay.io/centos-bootc/centos-bootc:stream10")
 
 # cfsctl feature flags for the container build.  Defaults match the base_image:
 #   debian (>= 6.15 kernel): no compat features needed

--- a/contrib/packaging/install-test-deps.sh
+++ b/contrib/packaging/install-test-deps.sh
@@ -15,7 +15,7 @@ case "${ID}" in
         ;;
     debian|ubuntu)
         pkg_install \
-            openssl e2fsprogs bubblewrap openssh-server \
+            openssl e2fsprogs bubblewrap openssh-server fsverity \
             ostree podman skopeo
 
         # OSTree symlink targets — /root, /home, /srv, etc. are symlinks

--- a/crates/composefs-ctl/Cargo.toml
+++ b/crates/composefs-ctl/Cargo.toml
@@ -33,8 +33,9 @@ fn-error-context = "0.2"
 clap = { version = "4.5.0", default-features = false, features = ["std", "help", "usage", "derive", "wrap_help"] }
 clap_complete = { version = "4.5.0", default-features = false, features = ["unstable-dynamic"] }
 comfy-table = { version = "7.1", default-features = false }
-composefs = { workspace = true, features = ["varlink"] }
+composefs = { workspace = true, features = ["varlink", "keyring"] }
 composefs-boot = { workspace = true }
+composefs-ioctls = { workspace = true, features = ["keyring"] }
 composefs-oci = { workspace = true, optional = true, features = ["boot"] }
 composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.7.0", optional = true }
 composefs-http = { workspace = true, optional = true }

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -67,12 +67,14 @@ use composefs_boot::cmdline::ComposefsCmdline;
 #[cfg(feature = "oci")]
 use composefs_boot::write_boot;
 
-use composefs::erofs::format::FormatVersion;
 #[cfg(feature = "oci")]
 use composefs::shared_internals::IO_BUF_CAPACITY;
 use composefs::{
     dumpfile::{dump_single_dir, dump_single_file},
-    erofs::reader::erofs_to_filesystem,
+    erofs::{
+        format::{FormatConfig, FormatVersion},
+        reader::erofs_to_filesystem,
+    },
     fsverity::{Algorithm, FsVerityHashValue, Sha256HashValue, Sha512HashValue},
     generic_tree::{FileSystem, Inode},
     mount::MountOptions,
@@ -216,6 +218,9 @@ pub struct App {
     #[clap(long)]
     pub no_repo: bool,
 
+    // TODO: Add a `--verbose` flag to control debug output. Currently,
+    // errors like "Layer has incorrect checksum" give no context about
+    // which layer failed or what the expected vs actual digests were.
     #[clap(subcommand)]
     cmd: Command,
 }
@@ -232,13 +237,10 @@ pub enum HashType {
 /// The EROFS format version used when generating images.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]
 pub enum ErofsVersion {
-    /// Format V0: compact inodes, BFS, C-compatible (composefs_version auto-detects 0 or 1).
-    #[clap(name = "0")]
-    V0,
-    /// Format V1: same layout as V0, composefs_version always 1.
+    /// Format V1: compact inodes, BFS, C-compatible.
     #[clap(name = "1")]
     V1,
-    /// Format V2: extended inodes, DFS (composefs_version=2).
+    /// Format V2: extended inodes, DFS, current default.
     #[clap(name = "2")]
     V2,
 }
@@ -246,9 +248,29 @@ pub enum ErofsVersion {
 impl From<ErofsVersion> for composefs::erofs::format::FormatVersion {
     fn from(v: ErofsVersion) -> Self {
         match v {
-            ErofsVersion::V0 => Self::V0,
             ErofsVersion::V1 => Self::V1,
             ErofsVersion::V2 => Self::V2,
+        }
+    }
+}
+
+/// EROFS format generation mode for `cfsctl init --erofs`.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, ValueEnum)]
+pub enum ErofsMode {
+    /// Generate only V1 EROFS (default; compatible with C `mkcomposefs`/`composefs-info` 1.0.8).
+    V1,
+    /// Generate both V1 and V2 EROFS (dual mode, used by bootc and other multi-format consumers).
+    Dual,
+}
+
+impl From<ErofsMode> for FormatConfig {
+    fn from(m: ErofsMode) -> Self {
+        match m {
+            ErofsMode::V1 => FormatConfig::single(FormatVersion::V1),
+            ErofsMode::Dual => FormatConfig {
+                default: FormatVersion::V1,
+                extra: [FormatVersion::V2].into(),
+            },
         }
     }
 }
@@ -352,6 +374,11 @@ struct OCIConfigOptions {
     config_verity: Option<String>,
 }
 
+// TODO: Inconsistent argument naming across OCI subcommands. Some use
+// `image: String` (Seal, Sign, Verify, Push), some `name: String` (Mount,
+// LsLayer), and others use `config_name` via OCIConfigOptions (Dump,
+// CreateImage). They also differ in whether they accept tag names,
+// manifest digests, or both. Standardize on a consistent convention.
 #[cfg(feature = "oci")]
 #[derive(Debug, Subcommand)]
 enum OciCommand {
@@ -361,6 +388,11 @@ enum OciCommand {
         digest: composefs_oci::OciDigest,
         /// Optional human-readable name for the layer
         name: Option<String>,
+    },
+    /// List the contents of a stored tar layer
+    LsLayer {
+        /// Layer content digest, e.g. sha256:a1b2c3...
+        name: composefs_oci::OciDigest,
     },
     /// Dump the rootfs of a stored OCI image as a composefs dumpfile to stdout
     ///
@@ -386,6 +418,12 @@ enum OciCommand {
         /// import path with zero-copy reflink/hardlink support.
         #[arg(long, value_enum, default_value_t = LocalFetchCli::Disabled)]
         local_fetch: LocalFetchCli,
+        /// Require a valid signature artifact for the pulled image
+        #[clap(long)]
+        require_signature: bool,
+        /// Path to PEM-encoded trusted certificate for signature verification
+        #[clap(long)]
+        trust_cert: Option<PathBuf>,
     },
     /// Copy an OCI image (and its layers) from another composefs repository
     /// into this repository.
@@ -483,6 +521,12 @@ enum OciCommand {
         bootable: bool,
         #[clap(flatten)]
         mount_opts: MountOpts,
+        /// Require a valid signature artifact for the image before mounting
+        #[clap(long)]
+        require_signature: bool,
+        /// Path to PEM-encoded trusted certificate for signature verification
+        #[clap(long)]
+        trust_cert: Option<PathBuf>,
     },
     /// Compute the composefs image ID of a stored OCI image's rootfs
     ///
@@ -492,6 +536,37 @@ enum OciCommand {
     ComputeId {
         #[clap(flatten)]
         config_opts: OCIConfigFilesystemOptions,
+    },
+    /// Seal a stored OCI image by creating a cloned manifest with embedded verity digest (a.k.a. composefs image object ID)
+    /// in the repo, then prints the stream and verity digest of the new sealed manifest
+    Seal {
+        /// Image reference (tag name or manifest digest)
+        image: String,
+        /// Seal the image with inline metadata annotations
+        #[clap(long)]
+        inline: bool,
+    },
+
+    /// Compute the composefs boot image karg for a stored OCI image.
+    ///
+    /// Applies the bootable transformation (SELinux relabeling, empty /boot and /sysroot),
+    /// computes the V1 EROFS digest, and prints the full kernel argument string:
+    ///
+    ///   composefs.digest=<hex>
+    ///
+    /// This is intended for use in UKI Containerfile builds where no composefs
+    /// repository is available.  The output can be written directly to
+    /// /etc/kernel/cmdline:
+    ///
+    ///   cfsctl oci composefs-digest-karg @sha256:abc... > /etc/kernel/cmdline
+    ///
+    /// The image can be specified by ref name or @digest:
+    ///   cfsctl oci composefs-digest-karg myimage:latest
+    ///   cfsctl oci composefs-digest-karg @sha256:a1b2c3...
+    #[clap(name = "composefs-digest-karg")]
+    ComposefsDigestKarg {
+        #[clap(flatten)]
+        config_opts: OCIConfigOptions,
     },
 
     /// Create the composefs image of the rootfs of a stored OCI image, perform bootable transformation, commit it to the repo,
@@ -524,11 +599,48 @@ enum OciCommand {
         #[clap(long)]
         json: bool,
     },
-    /// Serve the varlink RPC API on a Unix socket or systemd socket.
+    /// Create a composefs PKCS#7 signature artifact for an image
+    Sign {
+        /// Image reference (tag name)
+        image: String,
+        /// Path to PEM-encoded signing certificate
+        #[clap(long)]
+        cert: PathBuf,
+        /// Path to PEM-encoded private key
+        #[clap(long)]
+        key: PathBuf,
+        /// Sign the image with inline annotations
+        #[clap(long)]
+        inline: bool,
+    },
+    /// Verify composefs signature artifacts for an image
+    Verify {
+        /// Image reference (tag name)
+        image: String,
+        /// Path to PEM-encoded trusted certificate for verification
+        #[clap(long)]
+        cert: Option<PathBuf>,
+    },
+    /// Export an OCI image to an OCI layout directory
+    Push {
+        /// Image reference (tag name)
+        image: String,
+        /// Destination OCI layout path (optionally prefixed with oci:)
+        destination: String,
+        /// Also export signature/composefs artifacts
+        #[clap(long)]
+        signatures: bool,
+    },
+    /// Export signature artifacts for an image to an OCI layout directory
+    ExportSignatures {
+        /// Image reference (tag name)
+        image: String,
+        /// Path to the OCI layout directory (must already exist)
+        oci_layout_path: PathBuf,
+    },
+    /// Serve the varlink RPC API (alias: same service as top-level `varlink`).
     ///
-    /// Equivalent to `cfsctl varlink`: a single service answers both the
-    /// `org.composefs.Repository` and `org.composefs.Oci` interfaces on one
-    /// socket. Kept for discoverability under the `oci` subcommand.
+    /// Kept for discoverability under the `oci` subcommand.
     Varlink {
         /// Unix socket path to listen on (omit when using systemd socket activation).
         #[clap(long, value_hint = clap::ValueHint::AnyPath)]
@@ -657,6 +769,16 @@ enum OstreeCommand {
     },
 }
 
+#[derive(Debug, Subcommand)]
+enum KeyringCommand {
+    /// Add a CA certificate to the kernel's .fs-verity keyring.
+    /// Requires CAP_SYS_ADMIN (root).
+    AddCert {
+        /// Path to a PEM-encoded X.509 certificate file
+        cert: PathBuf,
+    },
+}
+
 /// Common options for reading a filesystem from a path
 #[derive(Debug, Parser)]
 struct FsReadOptions {
@@ -760,6 +882,15 @@ enum Command {
         /// If omitted, falls back to the global `--erofs-version` flag, then defaults to V1.
         #[clap(long)]
         erofs_version: Option<ErofsVersion>,
+        /// EROFS format generation mode.
+        ///
+        /// Controls which EROFS format versions are produced when committing images:
+        ///   v1    Generate only V1 EROFS (default; C-tool compatible)
+        ///   dual  Generate both V1 and V2 EROFS (used by bootc)
+        ///
+        /// If omitted, defaults to `v1`.
+        #[clap(long, value_enum)]
+        erofs: Option<ErofsMode>,
     },
     /// Take a transaction lock on the repository.
     /// This prevents garbage collection from occurring.
@@ -888,10 +1019,11 @@ enum Command {
         /// Output results as JSON (always exits 0 unless the check itself fails)
         #[clap(long)]
         json: bool,
-        /// Skip per-object fs-verity verification; check only metadata and
-        /// symlink structure (much faster on large repositories)
-        #[clap(long)]
-        metadata_only: bool,
+    },
+    /// Commands for managing the kernel keyring (requires root)
+    Keyring {
+        #[clap(subcommand)]
+        cmd: KeyringCommand,
     },
     #[cfg(feature = "http")]
     Fetch {
@@ -927,6 +1059,26 @@ enum Command {
     },
 }
 
+fn run_keyring_cmd(cmd: &KeyringCommand) -> Result<()> {
+    match cmd {
+        // TODO: Check for CAP_SYS_ADMIN before attempting to inject
+        // the certificate. Currently the kernel returns an opaque error.
+        // A clear "keyring add-cert requires root privileges" message
+        // would be much more helpful.
+        KeyringCommand::AddCert { cert } => {
+            let cert_pem = std::fs::read(cert).context("failed to read certificate file")?;
+            composefs::fsverity::inject_fsverity_cert(&cert_pem)?;
+            println!("Certificate added to .fs-verity keyring");
+        }
+    }
+    Ok(())
+}
+
+/// Run the CLI using `std::env::args()`, as if invoked from the command line.
+pub async fn run_from_args() -> Result<()> {
+    run_app(App::parse()).await
+}
+
 /// Acts as a proxy for the `cfsctl` CLI by executing the CLI logic programmatically
 ///
 /// This function behaves the same as invoking the `cfsctl` binary from the
@@ -940,7 +1092,6 @@ where
     let args = App::parse_from(
         std::iter::once(OsString::from("cfsctl")).chain(args.into_iter().map(Into::into)),
     );
-
     run_app(args).await
 }
 
@@ -988,7 +1139,7 @@ fn get_mount_options(
 use fuse::{FuseMode, MountMode, detect_mount_mode, run_fuse_mount};
 
 #[cfg(feature = "oci")]
-pub(crate) fn verity_opt<ObjectID>(opt: &Option<String>) -> Result<Option<ObjectID>>
+fn verity_opt<ObjectID>(opt: &Option<String>) -> Result<Option<ObjectID>>
 where
     ObjectID: FsVerityHashValue,
 {
@@ -1015,7 +1166,7 @@ pub(crate) fn default_repo_path() -> Result<PathBuf> {
 ///
 /// Uses [`user_path`] and [`system_path`] to avoid duplicating
 /// path constants.
-pub(crate) fn resolve_repo_path(args: &App) -> Result<PathBuf> {
+fn resolve_repo_path(args: &App) -> Result<PathBuf> {
     if let Some(path) = &args.repo {
         Ok(path.clone())
     } else if args.system {
@@ -1038,7 +1189,7 @@ pub(crate) fn resolve_repo_path(args: &App) -> Result<PathBuf> {
 /// Note: we read the metadata file directly here (rather than via
 /// `Repository::metadata`) because this runs *before* we know which
 /// generic `ObjectID` type to use — that's exactly what we're deciding.
-pub(crate) fn resolve_hash_type(
+fn resolve_hash_type(
     repo_path: &Path,
     cli_hash: Option<HashType>,
     upgrade: bool,
@@ -1093,23 +1244,9 @@ pub(crate) fn resolve_hash_type(
     Ok(detected)
 }
 
-/// If the process was started *bare* via systemd socket activation, serve the
-/// varlink API on the activated socket and return `Ok(true)`. Otherwise return
-/// `Ok(false)` so the caller falls through to normal CLI parsing.
-///
-/// This runs *before* clap to support a truly argument-less invocation —
-/// notably `varlinkctl exec:cfsctl`, which hands us the connected socket on fd
-/// 3 but passes no subcommand for clap to parse. A client selects a repository
-/// at runtime via the `OpenRepository` method.
-///
-/// The shortcut is taken *only* when there are no command-line arguments
-/// (`argv` is just the program name). When any argument is present — e.g. a
-/// systemd unit running `cfsctl varlink` — we fall through to clap; the
-/// `varlink`/`oci varlink` subcommand's [`serve`](crate::varlink::serve)
-/// detects and serves on the activation fd itself. We must NOT call
-/// [`try_activated_listener`](crate::varlink::try_activated_listener) on that
-/// path: it consumes `LISTEN_FDS`/`LISTEN_PID` (via `receive_descriptors`),
-/// which would prevent `serve` from finding the fd later.
+/// If this process was launched via systemd socket activation with no arguments,
+/// serve the varlink API on the activated socket and return `true`.
+/// Otherwise return `false` (the caller should proceed with normal CLI parsing).
 pub async fn run_if_socket_activated() -> Result<bool> {
     // Only take the pre-clap shortcut for a bare invocation (`argv[0]` only).
     // Check argv before touching the activation env so the latter is consumed
@@ -1131,7 +1268,7 @@ pub async fn run_if_socket_activated() -> Result<bool> {
     }
 }
 
-/// Top-level dispatch: handle init specially, otherwise open repo and run.
+/// Top-level dispatch: handle init and keyring specially, otherwise open repo and run.
 pub async fn run_app(args: App) -> Result<()> {
     // Hidden compat subcommands: forward all trailing args to the respective tool.
     if let Command::Mkcomposefs { args: extra } = args.cmd {
@@ -1141,6 +1278,11 @@ pub async fn run_app(args: App) -> Result<()> {
         return composefs_info::run_from_args(extra);
     }
 
+    // Handle commands that don't need a repository first
+    if let Command::Keyring { ref cmd } = args.cmd {
+        return run_keyring_cmd(cmd);
+    }
+
     // Init is handled before opening a repo since it creates one
     if let Command::Init {
         ref algorithm,
@@ -1148,8 +1290,13 @@ pub async fn run_app(args: App) -> Result<()> {
         insecure,
         reset_metadata,
         erofs_version: ref init_erofs_version,
+        erofs: init_erofs,
     } = args.cmd
     {
+        // --erofs controls the FormatConfig (which versions to generate); default V1-only.
+        let erofs_formats = init_erofs
+            .map(FormatConfig::from)
+            .unwrap_or(FormatConfig::single(FormatVersion::V1));
         // Prefer the subcommand-level --erofs-version; fall back to global flag; default V1.
         let erofs_version = init_erofs_version
             .or(args.erofs_version)
@@ -1161,20 +1308,16 @@ pub async fn run_app(args: App) -> Result<()> {
             insecure || args.insecure,
             reset_metadata,
             erofs_version,
+            erofs_formats,
             &args,
         );
     }
 
-    // The varlink service opens repositories on demand via `OpenRepository`
-    // (handling both hash types), so it bypasses the generic repo-open dispatch
-    // below. A single `CfsctlService` answers both the `org.composefs.Repository`
-    // and (when the `oci` feature is enabled) `org.composefs.Oci` interfaces, so
-    // `cfsctl varlink` and `cfsctl oci varlink` serve the same combined service.
+    // Varlink serve commands: dispatch before opening a repo (service opens repos lazily).
     if let Command::Varlink { ref address } = args.cmd {
         let service = crate::varlink::CfsctlService::from_app(&args);
         return crate::varlink::serve(service, address.as_deref()).await;
     }
-
     #[cfg(feature = "oci")]
     if let Command::Oci {
         cmd: OciCommand::Varlink { ref address },
@@ -1230,6 +1373,7 @@ fn run_init(
     insecure: bool,
     reset_metadata: bool,
     erofs_version: composefs::erofs::format::FormatVersion,
+    erofs_formats: FormatConfig,
     args: &App,
 ) -> Result<()> {
     let repo_path = if let Some(p) = path {
@@ -1252,7 +1396,11 @@ fn run_init(
     // different algorithm is an error.
     let config = {
         let mut c = RepositoryConfig::new(*algorithm);
-        c.erofs_formats = composefs::erofs::format::FormatConfig::single(erofs_version);
+        // erofs_version is the default format; fold it into the FormatConfig.
+        c.erofs_formats = FormatConfig {
+            default: erofs_version,
+            ..erofs_formats
+        };
         if insecure { c.set_insecure() } else { c }
     };
     let created = match algorithm {
@@ -1437,7 +1585,7 @@ pub async fn copy_image(
 
 /// Resolve an [`OciReference`] to an [`OciImage`].
 #[cfg(feature = "oci")]
-pub(crate) fn resolve_oci_image<ObjectID: FsVerityHashValue>(
+fn resolve_oci_image<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
     reference: &OciReference,
 ) -> Result<composefs_oci::oci_image::OciImage<ObjectID>> {
@@ -1454,7 +1602,7 @@ pub(crate) fn resolve_oci_image<ObjectID: FsVerityHashValue>(
 /// When resolving via a named ref, the verity override is ignored since
 /// the image metadata provides the correct verity.
 #[cfg(feature = "oci")]
-pub(crate) fn resolve_oci_config<ObjectID: FsVerityHashValue>(
+fn resolve_oci_config<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
     reference: &OciReference,
     verity_override: Option<ObjectID>,
@@ -1588,11 +1736,9 @@ pub async fn run_cmd_without_repo<ObjectID: FsVerityHashValue>(args: App) -> Res
         Command::ComputeId { fs_opts } => {
             let fs = load_filesystem_from_ondisk_fs::<ObjectID>(&fs_opts, None).await?;
             let version = erofs_version.unwrap_or_default();
+            let vfs = composefs::erofs::writer::ValidatedFileSystem::new(fs)?;
             let id = composefs::fsverity::compute_verity::<ObjectID>(
-                &composefs::erofs::writer::mkfs_erofs_versioned(
-                    &composefs::erofs::writer::ValidatedFileSystem::new(fs)?,
-                    version,
-                ),
+                &composefs::erofs::writer::mkfs_erofs_versioned(&vfs, version),
             );
             println!("{}", id.to_hex());
         }
@@ -1670,6 +1816,9 @@ where
                 .await?;
                 println!("{}", object_id.to_id());
             }
+            OciCommand::LsLayer { ref name } => {
+                composefs_oci::ls_layer(&repo, name, std::io::stdout())?;
+            }
             OciCommand::Dump { config_opts } => {
                 let fs = load_filesystem_from_oci_image(&repo, config_opts)?;
                 fs.print_dumpfile()?;
@@ -1679,7 +1828,13 @@ where
                 ref mountpoint,
                 bootable,
                 ref mount_opts,
+                require_signature,
+                ref trust_cert,
             } => {
+                if require_signature && trust_cert.is_none() {
+                    anyhow::bail!("--require-signature requires --trust-cert");
+                }
+
                 let img = if image.starts_with("sha256:") {
                     let digest: composefs_oci::OciDigest =
                         image.parse().context("Parsing manifest digest")?;
@@ -1687,6 +1842,20 @@ where
                 } else {
                     composefs_oci::oci_image::OciImage::open_ref(&repo, image)?
                 };
+
+                if require_signature {
+                    let cert_path = trust_cert.as_ref().unwrap();
+                    let cert_pem = std::fs::read(cert_path)
+                        .with_context(|| format!("failed to read certificate: {cert_path:?}"))?;
+                    let verifier =
+                        composefs_oci::signing::FsVeritySignatureVerifier::from_pem(&cert_pem)?;
+                    let report = composefs_oci::verify_image_report(&repo, image, Some(&verifier))?;
+                    println!(
+                        "Signature verification passed ({} signatures verified)",
+                        report.verified_count
+                    );
+                }
+
                 let erofs_id = if bootable {
                     match img.boot_image_ref(repo.erofs_version()) {
                         Some(id) => id,
@@ -1709,12 +1878,38 @@ where
                 let id = fs.compute_image_id(repo.erofs_version());
                 println!("{}", id.to_hex());
             }
+            OciCommand::ComposefsDigestKarg { config_opts } => {
+                let verity = verity_opt(&config_opts.config_verity)?;
+                let (config_digest, config_verity) =
+                    resolve_oci_config(&repo, &config_opts.config_name, verity)?;
+                let mut fs = composefs_oci::image::create_filesystem(
+                    &repo,
+                    &config_digest,
+                    config_verity.as_ref(),
+                )?;
+                fs.transform_for_boot(&repo)?;
+                let vfs = composefs::erofs::writer::ValidatedFileSystem::new(fs)?;
+                let digest = composefs::fsverity::compute_verity::<ObjectID>(
+                    &composefs::erofs::writer::mkfs_erofs_versioned(
+                        &vfs,
+                        composefs::erofs::format::FormatVersion::V1,
+                    ),
+                );
+                let karg = ComposefsCmdline::new_v1(digest, repo.is_insecure());
+                println!("{}", karg.to_cmdline_arg());
+            }
             OciCommand::Pull {
                 ref image,
                 name,
                 bootable,
                 local_fetch,
+                require_signature,
+                ref trust_cert,
             } => {
+                if require_signature && trust_cert.is_none() {
+                    anyhow::bail!("--require-signature requires --trust-cert");
+                }
+
                 // If no explicit name provided, use the image reference as the tag
                 let tag_name = name.as_deref().unwrap_or(image);
 
@@ -1734,9 +1929,33 @@ where
                 println!("objects  {}", result.stats);
 
                 if bootable {
-                    let image_verity =
-                        composefs_oci::generate_boot_image(&repo, &result.manifest_digest)?;
+                    // Resolve the tag to get the current manifest (already
+                    // rewritten with image_ref_v1 populated by the pull) so
+                    // generate_boot_image can preserve it in the boot manifest.
+                    // This equals result.manifest_digest, which now also
+                    // reflects the post-rewrite digest.
+                    let (current_manifest_digest, _) =
+                        composefs_oci::oci_image::resolve_ref(&repo, tag_name)?;
+                    let image_verity = composefs_oci::generate_boot_image(
+                        &repo,
+                        &current_manifest_digest,
+                        Some(tag_name),
+                    )?;
                     println!("Boot image: {}", image_verity.to_hex());
+                }
+
+                if require_signature {
+                    let cert_path = trust_cert.as_ref().unwrap();
+                    let cert_pem = std::fs::read(cert_path)
+                        .with_context(|| format!("failed to read certificate: {cert_path:?}"))?;
+                    let verifier =
+                        composefs_oci::signing::FsVeritySignatureVerifier::from_pem(&cert_pem)?;
+                    let report =
+                        composefs_oci::verify_image_report(&repo, tag_name, Some(&verifier))?;
+                    println!(
+                        "Signature verification passed ({} signatures verified)",
+                        report.verified_count
+                    );
                 }
             }
             OciCommand::Copy {
@@ -1877,10 +2096,13 @@ where
                 } else {
                     // Default: output combined JSON with manifest, config, and referrers
                     let output = crate::varlink::OciInspectReply::from_image(&repo, &img)?;
-                    serde_json::to_writer_pretty(std::io::stdout().lock(), &output)?;
-                    println!();
+                    println!("{}", serde_json::to_string_pretty(&output)?);
                 }
             }
+            // TODO: This only accepts a raw manifest digest (sha256:...),
+            // not a tag name. If a user provides a tag name as the source,
+            // tag_image creates a broken symlink. Consider resolving tag
+            // names to digests here, like Seal/Sign/Verify do.
             OciCommand::Tag {
                 ref manifest_digest,
                 ref name,
@@ -1899,8 +2121,7 @@ where
             } => {
                 if json {
                     let info = composefs_oci::layer_info(&repo, layer)?;
-                    serde_json::to_writer_pretty(std::io::stdout().lock(), &info)?;
-                    println!();
+                    println!("{}", serde_json::to_string_pretty(&info)?);
                 } else if dumpfile {
                     composefs_oci::layer_dumpfile(&repo, layer, &mut std::io::stdout())?;
                 } else {
@@ -1915,7 +2136,12 @@ where
                     composefs_oci::layer_tar(&repo, layer, &mut out)?;
                 }
             }
-
+            OciCommand::Seal { ref image, inline } => {
+                let reply = crate::varlink::run_seal(&repo, image.clone(), inline)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("{e}"))?;
+                println!("Sealed {image} -> {}", reply.manifest_digest);
+            }
             OciCommand::PrepareBoot {
                 config_opts:
                     OCIConfigOptions {
@@ -1999,8 +2225,163 @@ where
                     }
                 }
             }
+            OciCommand::Sign {
+                ref image,
+                ref cert,
+                ref key,
+                inline,
+            } => {
+                let cert_pem =
+                    std::fs::read_to_string(cert).context("failed to read certificate file")?;
+                let key_pem =
+                    std::fs::read_to_string(key).context("failed to read private key file")?;
+                let reply =
+                    crate::varlink::run_sign(&repo, image.clone(), cert_pem, key_pem, inline)
+                        .await
+                        .map_err(|e| anyhow::anyhow!("{e}"))?;
+                println!("{}", reply.artifact_digest);
+            }
+            OciCommand::Verify {
+                ref image,
+                ref cert,
+            } => {
+                let cert_pem = match cert {
+                    Some(cert_path) => {
+                        let content = std::fs::read_to_string(cert_path).with_context(|| {
+                            format!("failed to read certificate: {cert_path:?}")
+                        })?;
+                        Some(content)
+                    }
+                    None => None,
+                };
+
+                let res = crate::varlink::run_verify(&repo, image.clone(), cert_pem).await;
+                match res {
+                    Err(e) => {
+                        anyhow::bail!("{e}");
+                    }
+                    Ok(reply) => {
+                        let cert_supplied = reply.cert_supplied;
+                        if let Some(ref alg) = reply.algorithm {
+                            println!("Signature artifact (algorithm: {alg})");
+                        }
+                        for entry in &reply.entries {
+                            let role = &entry.role;
+                            let label = if role.starts_with("layer") {
+                                format!("  {role}:")
+                            } else {
+                                format!("  {role}:  ")
+                            };
+                            if entry.expected_digest.is_none() {
+                                println!("{label} no expected digest - SKIP");
+                            } else if !entry.digest_ok {
+                                println!("{label} digest MISMATCH");
+                            } else if cert_supplied {
+                                if entry.signature_verified {
+                                    println!("{label} signature verified");
+                                } else {
+                                    let maybe_detail = match &entry.detail {
+                                        Some(detail) => format!(": {detail}"),
+                                        None => "".to_string(),
+                                    };
+                                    println!("{label} not verified by this cert{maybe_detail}");
+                                }
+                            } else {
+                                println!("{label} digest matches");
+                            }
+                        }
+
+                        if cert_supplied {
+                            println!(
+                                "\nVerification passed ({} signatures verified)",
+                                reply.verified_count
+                            );
+                        } else {
+                            println!(
+                                "\nDigest check passed. NOTE: no certificate provided, signatures were NOT cryptographically verified."
+                            );
+                            println!(
+                                "To verify signatures, use: cfsctl oci verify {image} --cert <certificate.pem>"
+                            );
+                        }
+                    }
+                }
+            }
+            OciCommand::Push {
+                ref image,
+                ref destination,
+                signatures,
+            } => {
+                // Parse destination: strip "oci:" prefix, handle "oci:/path:tag" syntax
+                let dest = destination.strip_prefix("oci:").unwrap_or(destination);
+
+                // Parse optional tag from path — only split on the last colon if
+                // it isn't part of an absolute path (i.e. not position 0 like "/tmp/foo")
+                let (path_str, dest_tag) = if let Some(colon_pos) = dest.rfind(':') {
+                    // Don't split on the colon right after a drive letter or at position 0
+                    if colon_pos > 0
+                        && !dest[..colon_pos].ends_with('/')
+                        && !dest[colon_pos + 1..].contains('/')
+                    {
+                        (&dest[..colon_pos], Some(&dest[colon_pos + 1..]))
+                    } else {
+                        (dest, None)
+                    }
+                } else {
+                    (dest, None)
+                };
+
+                let oci_layout_path = std::path::Path::new(path_str);
+                std::fs::create_dir_all(oci_layout_path).with_context(|| {
+                    format!(
+                        "creating destination directory: {}",
+                        oci_layout_path.display()
+                    )
+                })?;
+
+                let img = composefs_oci::OciImage::open_ref(&repo, image)?;
+                let tag = dest_tag.or(Some(image));
+
+                composefs_oci::export_image_to_oci_layout(
+                    &repo,
+                    &img,
+                    oci_layout_path,
+                    tag,
+                    signatures,
+                )
+                .context("exporting image to OCI layout")?;
+
+                println!("Exported {} to {}", image, oci_layout_path.display());
+                if let Some(t) = tag {
+                    println!("Tagged as {t}");
+                }
+            }
+            OciCommand::ExportSignatures {
+                ref image,
+                ref oci_layout_path,
+            } => {
+                let img = composefs_oci::OciImage::open_ref(&repo, image)?;
+                let manifest_digest = img.manifest_digest();
+
+                let count = composefs_oci::export_referrers_to_oci_layout(
+                    &repo,
+                    manifest_digest,
+                    oci_layout_path,
+                    None,
+                )
+                .context("exporting signatures to OCI layout")?;
+
+                if count == 0 {
+                    println!("No signature artifacts found for {image}");
+                } else {
+                    println!(
+                        "Exported {count} signature artifact(s) to {}",
+                        oci_layout_path.display()
+                    );
+                }
+            }
             OciCommand::Varlink { .. } => {
-                unreachable!("oci varlink is handled before opening a repository");
+                unreachable!("varlink is handled before opening a repository")
             }
         },
         #[cfg(feature = "ostree")]
@@ -2278,15 +2659,8 @@ where
                 backing_path_only,
             )?;
         }
-        Command::Fsck {
-            json,
-            metadata_only,
-        } => {
-            let result = if metadata_only {
-                repo.fsck_metadata_only().await?
-            } else {
-                repo.fsck().await?
-            };
+        Command::Fsck { json } => {
+            let result = repo.fsck().await?;
             if json {
                 let output = crate::varlink::FsckReply::from(&result);
                 serde_json::to_writer_pretty(std::io::stdout().lock(), &output)?;
@@ -2298,9 +2672,14 @@ where
                 }
             }
         }
+        Command::Keyring { .. } => {
+            unreachable!("keyring commands are handled before opening a repository")
+        }
+        Command::Mkcomposefs { .. } | Command::ComposefsInfo { .. } => {
+            unreachable!("mkcomposefs/composefs-info are handled before opening a repository")
+        }
         Command::Varlink { .. } => {
-            // Handled in run_app before opening the repo.
-            unreachable!("varlink is handled before opening a repository");
+            unreachable!("varlink is handled before opening a repository")
         }
         #[cfg(feature = "http")]
         Command::Fetch { url, name } => {
@@ -2316,10 +2695,6 @@ where
             .await?;
             println!("content {digest}");
             println!("verity {}", verity.to_hex());
-        }
-        Command::Mkcomposefs { .. } | Command::ComposefsInfo { .. } => {
-            // Dispatched in run_app before a repository is opened
-            unreachable!("mkcomposefs/composefs-info are dispatched before opening a repository");
         }
     }
     Ok(())

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -129,6 +129,12 @@ pub enum RepositoryError {
         /// The ref name that was not found.
         reference: String,
     },
+    /// `require_signature` was requested but the underlying image has no
+    /// kernel-enrolled fs-verity signature.
+    SignatureRequired {
+        /// The name/selector that was requested to be mounted.
+        name: String,
+    },
     /// An unexpected internal error occurred while servicing the request.
     InternalError {
         /// Description of the failure.
@@ -545,6 +551,16 @@ pub struct MountParams {
     pub overlay: Option<bool>,
     /// Whether to mount read-write (only meaningful with overlay).
     pub read_write: Option<bool>,
+    /// When `true`, require that the underlying EROFS image has a kernel
+    /// fs-verity signature enrolled (i.e. a signature was successfully
+    /// registered via `FS_IOC_ENABLE_VERITY` at pull/import time — see
+    /// `has_verity_signature()`). If the image has verity enabled but no
+    /// enrolled signature, the mount is refused. This does NOT perform any
+    /// certificate-trust validation (see the separate Seal/Sign/Verify
+    /// varlink methods for that) — it only confirms *some* signature was
+    /// enrolled and is therefore subject to the kernel's own enforcement
+    /// via `.fs-verity` keyring lookups at read time.
+    pub require_signature: Option<bool>,
 }
 
 impl MountParams {
@@ -589,12 +605,45 @@ pub struct MountReply {
     pub fd_index: u32,
 }
 
+/// Check whether `name`'s underlying image has a kernel-enrolled fs-verity
+/// signature, for [`MountParams::require_signature`].
+///
+/// Opens the image fd fresh via [`Repository::open_image`] rather than
+/// threading through the fd that `mount_with_options` will open again
+/// internally: this is a cheap read-only open of a file that's immutable
+/// once fs-verity is enabled, and keeps this varlink-layer policy check out
+/// of the core `Repository` API.
+fn image_has_verity_signature<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: &str,
+) -> anyhow::Result<bool> {
+    let (fd, _enable_verity) = repo.open_image(name)?;
+    composefs::fsverity::has_verity_signature(&fd)
+        .context("Checking kernel fs-verity signature enrollment")
+}
+
 fn run_mount<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
     name: &str,
     params: &MountParams,
     fds: Vec<std::os::fd::OwnedFd>,
 ) -> std::result::Result<(MountReply, Vec<std::os::fd::OwnedFd>), RepositoryError> {
+    if params.require_signature.unwrap_or(false) {
+        match image_has_verity_signature(repo, name) {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(RepositoryError::SignatureRequired {
+                    name: name.to_string(),
+                });
+            }
+            Err(e) => {
+                return Err(RepositoryError::InternalError {
+                    message: format!("Checking fs-verity signature enrollment: {e:#}"),
+                });
+            }
+        }
+    }
+
     let options = params.to_mount_options(fds)?;
 
     let mount_fd =
@@ -639,6 +688,22 @@ fn run_oci_mount<ObjectID: composefs::fsverity::FsVerityHashValue>(
             "No composefs EROFS image linked".into()
         },
     })?;
+
+    if params.require_signature.unwrap_or(false) {
+        match image_has_verity_signature(repo, &erofs_id.to_hex()) {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(oci::OciError::SignatureRequired {
+                    image: image.to_string(),
+                });
+            }
+            Err(e) => {
+                return Err(oci::OciError::InternalError {
+                    message: format!("Checking fs-verity signature enrollment: {e:#}"),
+                });
+            }
+        }
+    }
 
     let options = params
         .to_mount_options(fds)
@@ -849,6 +914,153 @@ async fn run_compute_id<ObjectID: FsVerityHashValue>(
     })
 }
 
+/// Seal an OCI image: generate per-layer and merged EROFS, embed the fs-verity
+/// ID as a config label, and return the new manifest digest.
+#[cfg(feature = "oci")]
+pub(crate) async fn run_seal<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    image: String,
+    inline: bool,
+) -> std::result::Result<oci::SealReply, oci::OciError> {
+    let res = if inline {
+        composefs_oci::seal_image_inline(repo, &image)
+    } else {
+        composefs_oci::seal_image(repo, &image)
+    };
+    res.map(|digest| oci::SealReply {
+        manifest_digest: digest.to_string(),
+    })
+    .map_err(|e| {
+        if find_in_chain::<composefs_oci::OciRefNotFound>(&e).is_some()
+            || find_in_chain::<composefs_oci::OciImageNotFound>(&e).is_some()
+        {
+            oci::OciError::NoSuchImage {
+                image: image.clone(),
+            }
+        } else {
+            oci::OciError::InternalError {
+                message: format!("{e:#}"),
+            }
+        }
+    })
+}
+
+/// Sign an OCI image: build the signature artifact and store it. Returns the
+/// artifact digest and its fs-verity ID.
+#[cfg(feature = "oci")]
+pub(crate) async fn run_sign<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    image: String,
+    cert_pem: String,
+    key_pem: String,
+    inline: bool,
+) -> std::result::Result<oci::SignReply, oci::OciError> {
+    let signing_key = composefs_oci::signing::FsVeritySigningKey::from_pem(
+        cert_pem.as_bytes(),
+        key_pem.as_bytes(),
+    )
+    .map_err(|e| oci::OciError::InvalidCertificate {
+        message: format!("{e:#}"),
+    })?;
+    let res = if inline {
+        composefs_oci::sign_image_inline(repo, &image, &signing_key)
+            .map(|digest| (digest, ObjectID::EMPTY))
+    } else {
+        composefs_oci::sign_image(repo, &image, &signing_key)
+    };
+    res.map(|(artifact_digest, artifact_verity)| oci::SignReply {
+        artifact_digest: artifact_digest.to_string(),
+        artifact_verity: artifact_verity.to_hex(),
+    })
+    .map_err(|e| {
+        if find_in_chain::<composefs_oci::OciRefNotFound>(&e).is_some()
+            || find_in_chain::<composefs_oci::OciImageNotFound>(&e).is_some()
+        {
+            oci::OciError::NoSuchImage {
+                image: image.clone(),
+            }
+        } else {
+            oci::OciError::InternalError {
+                message: format!("{e:#}"),
+            }
+        }
+    })
+}
+
+/// Verify composefs signature artifacts for an OCI image.
+///
+/// When `cert_pem` is `Some`, performs cryptographic PKCS#7 verification.
+/// When `None`, performs a digest-only consistency check.
+#[cfg(feature = "oci")]
+pub(crate) async fn run_verify<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    image: String,
+    cert_pem: Option<String>,
+) -> std::result::Result<oci::VerifyReply, oci::OciError> {
+    let cert_supplied = cert_pem.is_some();
+    let verifier = match &cert_pem {
+        Some(pem) => Some(
+            composefs_oci::signing::FsVeritySignatureVerifier::from_pem(pem.as_bytes()).map_err(
+                |e| oci::OciError::InvalidCertificate {
+                    message: format!("{e:#}"),
+                },
+            )?,
+        ),
+        None => None,
+    };
+
+    let report =
+        composefs_oci::verify_image_report(repo, &image, verifier.as_ref()).map_err(|e| {
+            if find_in_chain::<composefs_oci::NoSignatureArtifacts>(&e).is_some()
+                || find_in_chain::<composefs_oci::SignatureVerificationFailed>(&e).is_some()
+            {
+                oci::OciError::SignatureVerificationFailed {
+                    message: format!("{e:#}"),
+                }
+            } else if find_in_chain::<composefs_oci::OciRefNotFound>(&e).is_some()
+                || find_in_chain::<composefs_oci::OciImageNotFound>(&e).is_some()
+            {
+                oci::OciError::NoSuchImage {
+                    image: image.clone(),
+                }
+            } else {
+                oci::OciError::InternalError {
+                    message: format!("{e:#}"),
+                }
+            }
+        })?;
+
+    let entries = report
+        .entries
+        .into_iter()
+        .map(|entry| oci::VerifyEntry {
+            role: entry.role,
+            expected_digest: entry.expected_digest,
+            digest_ok: entry.digest_ok,
+            signature_verified: entry.signature_verified,
+            detail: entry.detail,
+        })
+        .collect();
+
+    if cert_supplied && report.verified_count == 0 {
+        return Err(oci::OciError::SignatureVerificationFailed {
+            message: "no signatures were cryptographically verified".into(),
+        });
+    }
+
+    Ok(oci::VerifyReply {
+        verified_count: if cert_supplied {
+            report.verified_count as u64
+        } else {
+            0
+        },
+        ok: true,
+        cert_supplied,
+        algorithm: report.algorithm,
+        entries,
+    })
+}
+
 // The `zlink::service` macro emits several `pub` helper enums (method dispatch,
 // reply params, etc.) as siblings of the impl block. Those cannot be annotated
 // individually, so the macro invocation lives in a dedicated private submodule
@@ -995,7 +1207,9 @@ mod service_impl {
         ///
         /// If overlay upper/work directories are needed, pass them as two fds
         /// (upperdir, workdir) via SCM_RIGHTS. The returned fd is a detached
-        /// mount that the caller can attach with `move_mount()`.
+        /// mount that the caller can attach with `move_mount()`. If
+        /// `options.require_signature` is `true`, the mount is refused unless
+        /// the underlying image has a kernel-enrolled fs-verity signature.
         #[zlink(return_fds)]
         async fn mount(
             &self,
@@ -1037,14 +1251,14 @@ mod service_impl {
     };
     use super::oci::{
         ListImagesReply, OciComputeIdReply, OciError, OciFsckReply, OciInspectReply, PullProgress,
-        parse_local_fetch, pull_stream,
+        SealReply, SignReply, VerifyReply, parse_local_fetch, pull_stream,
     };
     use super::{
         CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply,
         ListImageRefsReply, MountParams, MountReply, OpenRepo, OpenRepositoryReply,
         RepositoryError, run_compute_id, run_fsck, run_gc, run_image_objects, run_init_repository,
         run_inspect, run_list_image_refs, run_list_images, run_mount, run_oci_fsck, run_oci_mount,
-        run_tag, run_untag,
+        run_seal, run_sign, run_tag, run_untag, run_verify,
     };
     use composefs::fsverity::{Algorithm, FsVerityHashValue, Sha256HashValue, Sha512HashValue};
     use composefs_oci::layer_transport::{RepoLayerSource, serve_get_layer};
@@ -1170,7 +1384,9 @@ mod service_impl {
         ///
         /// If overlay upper/work directories are needed, pass them as two fds
         /// (upperdir, workdir) via SCM_RIGHTS. The returned fd is a detached
-        /// mount that the caller can attach with `move_mount()`.
+        /// mount that the caller can attach with `move_mount()`. If
+        /// `options.require_signature` is `true`, the mount is refused unless
+        /// the underlying image has a kernel-enrolled fs-verity signature.
         #[zlink(return_fds)]
         async fn mount(
             &self,
@@ -1296,6 +1512,63 @@ mod service_impl {
             }
         }
 
+        /// Seal an OCI container image: generate per-layer and merged EROFS images
+        /// and embed the fs-verity ID as a label in the image config.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn seal(
+            &self,
+            handle: u64,
+            image: String,
+            inline: Option<bool>,
+        ) -> std::result::Result<SealReply, OciError> {
+            let inline = inline.unwrap_or(false);
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => run_seal::<Sha256HashValue>(r, image, inline).await,
+                OpenRepo::Sha512(ref r) => run_seal::<Sha512HashValue>(r, image, inline).await,
+            }
+        }
+
+        /// Sign a sealed OCI image using a PKCS#7 certificate and private key.
+        ///
+        /// `cert_pem` and `key_pem` are PEM-encoded certificate and private key
+        /// strings. Returns the artifact digest and its fs-verity ID.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn sign(
+            &self,
+            handle: u64,
+            image: String,
+            cert_pem: String,
+            key_pem: String,
+            inline: Option<bool>,
+        ) -> std::result::Result<SignReply, OciError> {
+            let inline = inline.unwrap_or(false);
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => {
+                    run_sign::<Sha256HashValue>(r, image, cert_pem, key_pem, inline).await
+                }
+                OpenRepo::Sha512(ref r) => {
+                    run_sign::<Sha512HashValue>(r, image, cert_pem, key_pem, inline).await
+                }
+            }
+        }
+
+        /// Verify composefs signature artifacts for an OCI image.
+        ///
+        /// When `cert_pem` is supplied, performs PKCS#7 cryptographic verification.
+        /// When `None`, performs a digest-only consistency check.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn verify(
+            &self,
+            handle: u64,
+            image: String,
+            cert_pem: Option<String>,
+        ) -> std::result::Result<VerifyReply, OciError> {
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => run_verify::<Sha256HashValue>(r, image, cert_pem).await,
+                OpenRepo::Sha512(ref r) => run_verify::<Sha512HashValue>(r, image, cert_pem).await,
+            }
+        }
+
         /// Pull an OCI image into the repository, streaming progress.
         ///
         /// Emits zero or more intermediate [`PullProgress`] frames describing
@@ -1342,7 +1615,9 @@ mod service_impl {
         /// Resolves the image by ref name or `sha256:` digest, finds its
         /// EROFS image (or boot variant if `bootable` is true), and creates
         /// a composefs mount. If `options.overlay` is true, the fd array
-        /// must contain upperdir and workdir fds.
+        /// must contain upperdir and workdir fds. If `options.require_signature`
+        /// is `true`, the mount is refused unless the resolved EROFS image has
+        /// a kernel-enrolled fs-verity signature.
         #[zlink(interface = "org.composefs.Oci", return_fds)]
         async fn oci_mount(
             &self,
@@ -2076,6 +2351,57 @@ pub mod oci {
         pub image_id: String,
     }
 
+    /// Reply from sealing an OCI image.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct SealReply {
+        /// The manifest digest of the sealed image (e.g. `sha256:...`).
+        pub manifest_digest: String,
+    }
+
+    /// Reply from signing an OCI image.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct SignReply {
+        /// The OCI digest of the stored signature artifact.
+        pub artifact_digest: String,
+        /// The hex fs-verity ID of the signature artifact object.
+        pub artifact_verity: String,
+    }
+
+    /// Component-by-component verification result.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct VerifyEntry {
+        /// The role of this entry.
+        pub role: String,
+        /// The expected digest for this role.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub expected_digest: Option<String>,
+        /// Whether the expected digest matches actual.
+        pub digest_ok: bool,
+        /// Whether the signature verified successfully.
+        pub signature_verified: bool,
+        /// Optional error or status detail.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub detail: Option<String>,
+    }
+
+    /// Reply from verifying an OCI image's signatures.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct VerifyReply {
+        /// Number of signature entries that were cryptographically verified.
+        /// Always `0` when `cert_supplied` is false (digest-only check).
+        pub verified_count: u64,
+        /// Whether all reachable checks passed successfully.
+        pub ok: bool,
+        /// Whether a certificate was supplied (cryptographic vs digest-only mode).
+        pub cert_supplied: bool,
+        /// The algorithm used for verification (e.g. sha256-12).
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub algorithm: Option<String>,
+        /// Individual component verification entries.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        pub entries: Vec<VerifyEntry>,
+    }
+
     /// A single progress frame emitted by the streaming `Pull` method.
     ///
     /// varlink has no tagged/data-union type, so a sum-of-events is modelled as a
@@ -2372,10 +2698,14 @@ pub mod oci {
                 })?;
 
             let boot_image = if bootable {
-                let id = composefs_oci::generate_boot_image(&repo, &result.manifest_digest)
-                    .map_err(|e| OciError::InternalError {
-                        message: format!("{e:#}"),
-                    })?;
+                let id = composefs_oci::generate_boot_image(
+                    &repo,
+                    &result.manifest_digest,
+                    name.as_deref(),
+                )
+                .map_err(|e| OciError::InternalError {
+                    message: format!("{e:#}"),
+                })?;
                 Some(id.to_hex())
             } else {
                 None
@@ -2479,6 +2809,23 @@ pub mod oci {
         /// The named OCI image/reference does not exist.
         NoSuchImage {
             /// The image reference that was not found.
+            image: String,
+        },
+        /// The supplied certificate or private key could not be parsed.
+        InvalidCertificate {
+            /// Description of the failure.
+            message: String,
+        },
+        /// No signature verified against the supplied certificate, or the image
+        /// has no composefs signature artifacts.
+        SignatureVerificationFailed {
+            /// Description of the failure.
+            message: String,
+        },
+        /// `require_signature` was requested but the underlying image has no
+        /// kernel-enrolled fs-verity signature.
+        SignatureRequired {
+            /// The image reference that lacks an enrolled signature.
             image: String,
         },
         /// An unexpected internal error occurred while servicing the request.
@@ -2645,6 +2992,39 @@ pub mod layer_sync {
         /// Hex-encoded fs-verity hash of the config splitstream.
         pub config_verity: String,
     }
+
+    impl std::fmt::Display for OciError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                OciError::RepoNotFound { message } => write!(f, "RepoNotFound: {message}"),
+                OciError::InvalidHandle { handle } => write!(f, "InvalidHandle: {handle}"),
+                OciError::NoSuchImage { image } => write!(f, "NoSuchImage: {image}"),
+                OciError::InvalidCertificate { message } => {
+                    write!(f, "InvalidCertificate: {message}")
+                }
+                OciError::SignatureVerificationFailed { message } => {
+                    write!(f, "SignatureVerificationFailed: {message}")
+                }
+                OciError::SignatureRequired { image } => {
+                    write!(f, "SignatureRequired: {image}")
+                }
+                OciError::InternalError { message } => write!(f, "InternalError: {message}"),
+                OciError::NoSuchLayer { diff_id } => write!(f, "NoSuchLayer: {diff_id}"),
+                OciError::InvalidDigest { message } => write!(f, "InvalidDigest: {message}"),
+                OciError::DiffIdMismatch { expected, actual } => {
+                    write!(f, "DiffIdMismatch: expected {expected}, got {actual}")
+                }
+                OciError::InvalidRequest { message } => write!(f, "InvalidRequest: {message}"),
+                OciError::FdLimitExceeded {
+                    fd_count,
+                    max_per_frame,
+                } => write!(
+                    f,
+                    "FdLimitExceeded: {fd_count} fds exceeds max {max_per_frame} per frame"
+                ),
+            }
+        }
+    }
 }
 
 /// Typed Rust client bindings (the native-API mirror of the on-the-wire
@@ -2662,11 +3042,14 @@ pub mod proxy {
     #[cfg(feature = "oci")]
     use super::oci::{
         ListImagesReply, OciComputeIdReply, OciError, OciFsckReply, OciInspectReply, PullProgress,
+        SealReply, SignReply, VerifyReply,
     };
     use super::{
         FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, OpenRepositoryReply,
         RepositoryError,
     };
+    #[cfg(feature = "oci")]
+    use super::{MountParams, MountReply};
     #[cfg(feature = "oci")]
     pub use composefs_oci::varlink_types::GetLayerParams;
     #[cfg(feature = "oci")]
@@ -2765,6 +3148,43 @@ pub mod proxy {
             verity: Option<&str>,
             bootable: bool,
         ) -> zlink::Result<Result<OciComputeIdReply, OciError>>;
+
+        /// Seal an OCI container image.
+        async fn seal(
+            &mut self,
+            handle: u64,
+            image: &str,
+            inline: Option<bool>,
+        ) -> zlink::Result<Result<SealReply, OciError>>;
+
+        /// Sign a sealed OCI image.
+        async fn sign(
+            &mut self,
+            handle: u64,
+            image: &str,
+            cert_pem: &str,
+            key_pem: &str,
+            inline: Option<bool>,
+        ) -> zlink::Result<Result<SignReply, OciError>>;
+
+        /// Verify composefs signature artifacts for an OCI image.
+        async fn verify(
+            &mut self,
+            handle: u64,
+            image: &str,
+            cert_pem: Option<&str>,
+        ) -> zlink::Result<Result<VerifyReply, OciError>>;
+
+        /// Mount an OCI image and return the detached mount fd.
+        #[zlink(return_fds)]
+        async fn oci_mount(
+            &mut self,
+            handle: u64,
+            image: &str,
+            bootable: bool,
+            options: MountParams,
+            #[zlink(fds)] fds: Vec<std::os::fd::OwnedFd>,
+        ) -> zlink::Result<(Result<MountReply, OciError>, Vec<std::os::fd::OwnedFd>)>;
 
         /// Pull an OCI image, streaming progress frames.
         #[zlink(more, rename = "Pull")]

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -438,6 +438,14 @@ impl CfsctlService {
     }
 }
 
+/// Find a typed error anywhere in the anyhow chain.
+///
+/// Errors get `.context()`-wrapped as they propagate, so a top-level
+/// `downcast_ref` is insufficient; walk the whole chain.
+fn find_in_chain<T: std::error::Error + Send + Sync + 'static>(e: &anyhow::Error) -> Option<&T> {
+    e.chain().find_map(|c| c.downcast_ref::<T>())
+}
+
 /// Open the repository and run an fsck.
 async fn run_fsck<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
@@ -477,7 +485,7 @@ async fn run_image_objects<ObjectID: FsVerityHashValue>(
     name: String,
 ) -> std::result::Result<ImageObjectsReply, RepositoryError> {
     let objects = repo.objects_for_image(&name).map_err(|e| {
-        if let Some(nf) = e.downcast_ref::<composefs::ImageNotFound>() {
+        if let Some(nf) = find_in_chain::<composefs::ImageNotFound>(&e) {
             RepositoryError::NoSuchRef {
                 reference: nf.name.clone(),
             }
@@ -745,11 +753,11 @@ async fn run_inspect<ObjectID: FsVerityHashValue>(
             message: format!("invalid image reference: {e:#}"),
         })?;
     let img = crate::resolve_oci_image(repo, &reference).map_err(|e| {
-        if let Some(nf) = e.downcast_ref::<composefs_oci::OciRefNotFound>() {
+        if let Some(nf) = find_in_chain::<composefs_oci::OciRefNotFound>(&e) {
             oci::OciError::NoSuchImage {
                 image: nf.name.clone(),
             }
-        } else if let Some(nf) = e.downcast_ref::<composefs_oci::OciImageNotFound>() {
+        } else if let Some(nf) = find_in_chain::<composefs_oci::OciImageNotFound>(&e) {
             oci::OciError::NoSuchImage {
                 image: nf.digest.clone(),
             }

--- a/crates/composefs-integration-tests/src/tests/ostree.rs
+++ b/crates/composefs-integration-tests/src/tests/ostree.rs
@@ -1,6 +1,6 @@
 //! Integration tests for ostree pull functionality.
 
-use std::net::TcpListener;
+use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::process::Command;
 use std::sync::Arc;
@@ -377,7 +377,22 @@ impl HttpServer {
             .stderr(std::process::Stdio::null())
             .spawn()?;
 
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        // Poll the server until it is ready, rather than sleeping for a fixed
+        // duration and racing with the server actually binding the port.
+        let start_time = std::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(10);
+        let delay = std::time::Duration::from_millis(50);
+        let addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse()?;
+        loop {
+            if TcpStream::connect_timeout(&addr, delay).is_ok() {
+                break;
+            }
+            if start_time.elapsed() >= timeout {
+                anyhow::bail!("python3 http.server did not become ready on port {port} within 10s");
+            }
+            std::thread::sleep(delay);
+        }
+
         Ok(HttpServer { child, port })
     }
 

--- a/crates/composefs-integration-tests/src/tests/privileged.rs
+++ b/crates/composefs-integration-tests/src/tests/privileged.rs
@@ -17,6 +17,8 @@ use xshell::{Shell, cmd};
 use composefs_oci::composefs::fsverity::{FsVerityHashValue, Sha256HashValue, Sha512HashValue};
 use composefs_oci::composefs::repository::{Repository, RepositoryConfig};
 
+use crate::tests::cli::{create_oci_layout, init_insecure_repo};
+use crate::tests::varlink::VarlinkService;
 use crate::{cfsctl, create_test_rootfs, integration_test};
 
 /// Ensure we're running in a privileged environment, or re-exec this test inside a VM.
@@ -1258,3 +1260,489 @@ fn privileged_fuse_dumpfile_roundtrip() -> Result<()> {
     Ok(())
 }
 integration_test!(privileged_fuse_dumpfile_roundtrip);
+
+// ============================================================================
+// Kernel fs-verity signature enrollment via the varlink `Pull` API.
+//
+// `Pull` is the only code path that enrolls PKCS#7 signatures with the
+// kernel (`FS_IOC_ENABLE_VERITY`), as part of committing the EROFS image
+// for the very first time (`ensure_oci_composefs_erofs_with_sig`). `Seal`
+// and `Sign` only rewrite manifest annotations on an already-pulled image;
+// they don't re-trigger enrollment. So these tests bake a signature into a
+// *source* OCI layout (via a throwaway scratch repo) before doing the real,
+// verity-backed `Pull` that these tests actually exercise.
+// ============================================================================
+
+/// Returns whether the kernel exposes a `.fs-verity` keyring, i.e. supports
+/// `FS_IOC_ENABLE_VERITY` with builtin PKCS#7 signature verification
+/// (`CONFIG_FS_VERITY_BUILTIN_SIGNATURES`).
+///
+/// Kernels built without this option never create the keyring
+/// (`fsverity_init_signature()` is a no-op stub) and silently accept any
+/// signature bytes, which makes the correct/wrong/no-cert distinction these
+/// tests exist to check unobservable. Reads `/proc/keys` directly (rather
+/// than going through `cfsctl keyring add-cert`) so the probe has no side
+/// effects — the no-cert scenario below needs to observe a genuinely empty
+/// keyring.
+fn fsverity_keyring_exists() -> Result<bool> {
+    let proc_keys = std::fs::read_to_string("/proc/keys").context("reading /proc/keys")?;
+    Ok(proc_keys.lines().any(|line| {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        fields.get(7) == Some(&"keyring")
+            && fields.get(8).map(|desc| desc.trim_end_matches(':')) == Some(".fs-verity")
+    }))
+}
+
+/// Builds an OCI layout directory whose manifest carries an inline PKCS#7
+/// signature (`SignatureType::Merged`) over the composed EROFS image,
+/// signed with `key_pem`/`cert_pem`.
+///
+/// Pulls the standard test fixture into a scratch insecure repo, seals and
+/// signs it inline there (which only computes digests/signatures and
+/// rewrites manifest annotations — no filesystem verity needed), then
+/// exports it back out to a fresh OCI layout. Only top-level manifest
+/// annotations survive that export round-trip
+/// (`export_image_to_oci_layout` doesn't copy per-descriptor annotations),
+/// but that's exactly where the "Merged" signature lives, so it's
+/// preserved.
+fn build_signed_oci_layout(
+    sh: &Shell,
+    cfsctl_bin: &Path,
+    parent: &Path,
+    cert_pem: &Path,
+    key_pem: &Path,
+) -> Result<PathBuf> {
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let scratch_repo_dir = init_insecure_repo(sh, cfsctl_bin)?;
+    let scratch_repo = scratch_repo_dir.path();
+    cmd!(
+        sh,
+        "{cfsctl_bin} --insecure --repo {scratch_repo} oci pull oci:{layout} fixture"
+    )
+    .read()?;
+    cmd!(
+        sh,
+        "{cfsctl_bin} --insecure --repo {scratch_repo} oci seal fixture --inline"
+    )
+    .read()?;
+    cmd!(
+        sh,
+        "{cfsctl_bin} --insecure --repo {scratch_repo} oci sign fixture --cert {cert_pem} --key {key_pem} --inline"
+    )
+    .read()?;
+
+    let signed_layout = parent.join("signed-oci-layout");
+    cmd!(
+        sh,
+        "{cfsctl_bin} --insecure --repo {scratch_repo} oci push fixture oci:{signed_layout}"
+    )
+    .read()?;
+
+    Ok(signed_layout)
+}
+
+/// Observes whether the kernel actually enrolled a fs-verity signature on
+/// `image`'s EROFS object, by opening the underlying object file directly
+/// and calling `has_verity_signature()` — a repository may fall back to
+/// enabling plain verity (no signature) when no keyring certificate can
+/// verify it, so this is the only way to distinguish that from real
+/// enrollment.
+fn image_has_verity_signature(svc: &VarlinkService, repo: &Path, image: &str) -> Result<bool> {
+    let reply = svc
+        .proxy_inspect(image)
+        .context("Inspect transport error")?
+        .map_err(|e| anyhow::anyhow!("Inspect error: {e:?}"))?;
+    let erofs_hex = reply
+        .composefs_erofs
+        .context("image has no composefs_erofs id")?;
+    let id = Sha256HashValue::from_hex(&erofs_hex).context("parsing EROFS object id")?;
+    let object_path = repo.join("objects").join(id.to_object_pathname());
+    let file = std::fs::File::open(&object_path)
+        .with_context(|| format!("opening EROFS object {}", object_path.display()))?;
+    Ok(composefs_oci::composefs::fsverity::has_verity_signature(
+        &file,
+    )?)
+}
+
+/// A certificate that actually verifies the enrolled signature: the kernel
+/// should accept it, and the EROFS object should end up with a real
+/// kernel-verified signature (not just plain verity).
+fn privileged_varlink_kernel_sig_correct_cert() -> Result<()> {
+    if require_privileged("privileged_varlink_kernel_sig_correct_cert")?.is_some() {
+        return Ok(());
+    }
+    if !fsverity_keyring_exists()? {
+        println!(
+            "SKIP: kernel lacks CONFIG_FS_VERITY_BUILTIN_SIGNATURES support (.fs-verity keyring not found)"
+        );
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl_bin = cfsctl()?;
+    let fixture_dir = tempfile::tempdir()?;
+
+    let (cert_pem, key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_path = fixture_dir.path().join("cert.pem");
+    let key_path = fixture_dir.path().join("key.pem");
+    std::fs::write(&cert_path, &cert_pem)?;
+    std::fs::write(&key_path, &key_pem)?;
+
+    let layout =
+        build_signed_oci_layout(&sh, &cfsctl_bin, fixture_dir.path(), &cert_path, &key_path)?;
+
+    cmd!(sh, "{cfsctl_bin} keyring add-cert {cert_path}").read()?;
+
+    let verity_dir = VerityTempDir::new()?;
+    let repo = verity_dir.path().join("repo");
+    cmd!(sh, "{cfsctl_bin} --repo {repo} init").run()?;
+
+    let svc = VarlinkService::oci(&repo)?;
+    svc.proxy_pull(
+        &format!("oci:{}", layout.display()),
+        Some("signed-image"),
+        false,
+    )
+    .context("Pull transport error")?
+    .map_err(|e| anyhow::anyhow!("Pull with a correctly-enrolled cert should succeed: {e:?}"))?;
+
+    ensure!(
+        image_has_verity_signature(&svc, &repo, "signed-image")?,
+        "expected the kernel to have enrolled the signature"
+    );
+
+    Ok(())
+}
+integration_test!(privileged_varlink_kernel_sig_correct_cert);
+
+/// A certificate enrolled in the keyring that does *not* verify the
+/// signature: the kernel must reject it (`EKEYREJECTED`), which should
+/// surface as a hard `Pull` failure rather than a silent fallback.
+fn privileged_varlink_kernel_sig_wrong_cert() -> Result<()> {
+    if require_privileged("privileged_varlink_kernel_sig_wrong_cert")?.is_some() {
+        return Ok(());
+    }
+    if !fsverity_keyring_exists()? {
+        println!(
+            "SKIP: kernel lacks CONFIG_FS_VERITY_BUILTIN_SIGNATURES support (.fs-verity keyring not found)"
+        );
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl_bin = cfsctl()?;
+    let fixture_dir = tempfile::tempdir()?;
+
+    // The image is signed with this keypair...
+    let (cert_pem, key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_path = fixture_dir.path().join("cert.pem");
+    let key_path = fixture_dir.path().join("key.pem");
+    std::fs::write(&cert_path, &cert_pem)?;
+    std::fs::write(&key_path, &key_pem)?;
+
+    // ...but an unrelated certificate is the one enrolled in the keyring.
+    let (wrong_cert_pem, _wrong_key_pem) = composefs_oci::signing::generate_test_keypair();
+    let wrong_cert_path = fixture_dir.path().join("wrong-cert.pem");
+    std::fs::write(&wrong_cert_path, &wrong_cert_pem)?;
+
+    let layout =
+        build_signed_oci_layout(&sh, &cfsctl_bin, fixture_dir.path(), &cert_path, &key_path)?;
+
+    cmd!(sh, "{cfsctl_bin} keyring add-cert {wrong_cert_path}").read()?;
+
+    let verity_dir = VerityTempDir::new()?;
+    let repo = verity_dir.path().join("repo");
+    cmd!(sh, "{cfsctl_bin} --repo {repo} init").run()?;
+
+    let svc = VarlinkService::oci(&repo)?;
+    let err = svc
+        .proxy_pull(
+            &format!("oci:{}", layout.display()),
+            Some("signed-image"),
+            false,
+        )
+        .context("Pull transport error")?
+        .expect_err("Pull with a non-matching enrolled cert must fail");
+    let message = match &err {
+        composefs_ctl::varlink::oci::OciError::InternalError { message } => message.clone(),
+        other => bail!("expected OciError::InternalError, got: {other:?}"),
+    };
+    ensure!(
+        message.contains("signature rejected by kernel"),
+        "expected a kernel signature-rejection error, got: {message}"
+    );
+
+    Ok(())
+}
+integration_test!(privileged_varlink_kernel_sig_wrong_cert);
+
+/// No certificate at all is enrolled in the keyring: the kernel reports
+/// `ENOKEY`, and the repository should gracefully fall back to enabling
+/// plain verity without a signature rather than failing the pull.
+fn privileged_varlink_kernel_sig_no_cert() -> Result<()> {
+    if require_privileged("privileged_varlink_kernel_sig_no_cert")?.is_some() {
+        return Ok(());
+    }
+    if !fsverity_keyring_exists()? {
+        println!(
+            "SKIP: kernel lacks CONFIG_FS_VERITY_BUILTIN_SIGNATURES support (.fs-verity keyring not found)"
+        );
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl_bin = cfsctl()?;
+    let fixture_dir = tempfile::tempdir()?;
+
+    let (cert_pem, key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_path = fixture_dir.path().join("cert.pem");
+    let key_path = fixture_dir.path().join("key.pem");
+    std::fs::write(&cert_path, &cert_pem)?;
+    std::fs::write(&key_path, &key_pem)?;
+
+    let layout =
+        build_signed_oci_layout(&sh, &cfsctl_bin, fixture_dir.path(), &cert_path, &key_path)?;
+
+    // Deliberately do not add any certificate to the keyring.
+
+    let verity_dir = VerityTempDir::new()?;
+    let repo = verity_dir.path().join("repo");
+    cmd!(sh, "{cfsctl_bin} --repo {repo} init").run()?;
+
+    let svc = VarlinkService::oci(&repo)?;
+    svc.proxy_pull(
+        &format!("oci:{}", layout.display()),
+        Some("signed-image"),
+        false,
+    )
+    .context("Pull transport error")?
+    .map_err(|e| anyhow::anyhow!("Pull with an empty keyring should still succeed: {e:?}"))?;
+
+    ensure!(
+        !image_has_verity_signature(&svc, &repo, "signed-image")?,
+        "expected no signature to be enrolled with an empty keyring"
+    );
+
+    Ok(())
+}
+integration_test!(privileged_varlink_kernel_sig_no_cert);
+
+/// Attaches a detached mount fd (as returned by the `OciMount`/`Mount`
+/// varlink methods) at a fresh temporary directory, and detaches it again
+/// on drop so the test doesn't leak mounts.
+struct AttachedMount {
+    dir: tempfile::TempDir,
+}
+
+impl AttachedMount {
+    fn new(fs_fd: std::os::fd::OwnedFd) -> Result<Self> {
+        let dir = tempfile::tempdir()?;
+        composefs_oci::composefs::mount::mount_at(fs_fd, rustix::fs::CWD, dir.path())
+            .context("Attaching detached mount fd")?;
+        Ok(Self { dir })
+    }
+
+    fn path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+impl Drop for AttachedMount {
+    fn drop(&mut self) {
+        let _ = rustix::mount::unmount(self.dir.path(), rustix::mount::UnmountFlags::DETACH);
+    }
+}
+
+/// Extract the fd at `index` from a `return_fds` reply's fd vector.
+fn take_fd(mut fds: Vec<std::os::fd::OwnedFd>, index: u32) -> Result<std::os::fd::OwnedFd> {
+    let index = index as usize;
+    ensure!(
+        index < fds.len(),
+        "fd_index {index} out of range ({} fds returned)",
+        fds.len()
+    );
+    Ok(fds.remove(index))
+}
+
+/// `OciMount`'s `require_signature` option: mounting a kernel-signature-
+/// enrolled image with the flag set succeeds and yields a real, working
+/// mount; mounting an unsigned image with the same flag is refused with
+/// `SignatureRequired`; and the flag is opt-in — the unsigned image mounts
+/// fine when it's left unset.
+///
+/// This is the varlink-layer building block for out-of-tree
+/// container-lifecycle clients (e.g. composefs-run) that want "only give me
+/// a mount if the kernel actually verified a fs-verity signature was
+/// enrolled" without re-implementing that check themselves on top of the
+/// existing `Mount`/`OciMount` methods.
+fn privileged_varlink_require_signature() -> Result<()> {
+    if require_privileged("privileged_varlink_require_signature")?.is_some() {
+        return Ok(());
+    }
+    if !fsverity_keyring_exists()? {
+        println!(
+            "SKIP: kernel lacks CONFIG_FS_VERITY_BUILTIN_SIGNATURES support (.fs-verity keyring not found)"
+        );
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl_bin = cfsctl()?;
+    let fixture_dir = tempfile::tempdir()?;
+
+    let (cert_pem, key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_path = fixture_dir.path().join("cert.pem");
+    let key_path = fixture_dir.path().join("key.pem");
+    std::fs::write(&cert_path, &cert_pem)?;
+    std::fs::write(&key_path, &key_pem)?;
+
+    // A real signed-and-enrolled image, and a plain image that was never
+    // signed at all (so it can never get a kernel signature regardless of
+    // keyring state).
+    let signed_layout =
+        build_signed_oci_layout(&sh, &cfsctl_bin, fixture_dir.path(), &cert_path, &key_path)?;
+    let unsigned_layout = create_oci_layout(fixture_dir.path())?;
+
+    cmd!(sh, "{cfsctl_bin} keyring add-cert {cert_path}").read()?;
+
+    let verity_dir = VerityTempDir::new()?;
+    let repo = verity_dir.path().join("repo");
+    cmd!(sh, "{cfsctl_bin} --repo {repo} init").run()?;
+
+    let svc = VarlinkService::oci(&repo)?;
+
+    svc.proxy_pull(
+        &format!("oci:{}", signed_layout.display()),
+        Some("signed-image"),
+        false,
+    )
+    .context("Pull (signed) transport error")?
+    .map_err(|e| anyhow::anyhow!("Pull of signed image should succeed: {e:?}"))?;
+    ensure!(
+        image_has_verity_signature(&svc, &repo, "signed-image")?,
+        "expected the kernel to have enrolled the signature on the signed image"
+    );
+
+    svc.proxy_pull(
+        &format!("oci:{}", unsigned_layout.display()),
+        Some("unsigned-image"),
+        false,
+    )
+    .context("Pull (unsigned) transport error")?
+    .map_err(|e| anyhow::anyhow!("Pull of unsigned image should succeed: {e:?}"))?;
+    ensure!(
+        !image_has_verity_signature(&svc, &repo, "unsigned-image")?,
+        "expected no signature to be enrolled on the never-signed image"
+    );
+
+    // Attaches a successful OciMount reply and checks it's a real, working
+    // mount of the shared `hello.txt` fixture (see `create_oci_layout`).
+    const HELLO_CONTENTS: &str = "hello from test layer\n";
+    let assert_mount_works =
+        |reply: composefs_ctl::varlink::MountReply, fds: Vec<std::os::fd::OwnedFd>| -> Result<()> {
+            let mount = AttachedMount::new(take_fd(fds, reply.fd_index)?)?;
+            let hello = std::fs::read_to_string(mount.path().join("hello.txt"))?;
+            ensure!(
+                hello == HELLO_CONTENTS,
+                "unexpected mounted file content: {hello:?}"
+            );
+            Ok(())
+        };
+
+    // `require_signature: true` on the signed image succeeds and yields a
+    // real, working mount.
+    {
+        let (result, fds) = svc
+            .proxy_oci_mount("signed-image", false, Some(true))
+            .context("OciMount (signed, required) transport error")?;
+        let reply = result.map_err(|e| {
+            anyhow::anyhow!(
+                "OciMount with require_signature on a signed image should succeed: {e:?}"
+            )
+        })?;
+        assert_mount_works(reply, fds)?;
+    }
+
+    // `require_signature: true` on the unsigned image must be refused with
+    // the specific `SignatureRequired` error, not just any error.
+    {
+        let (result, fds) = svc
+            .proxy_oci_mount("unsigned-image", false, Some(true))
+            .context("OciMount (unsigned, required) transport error")?;
+        ensure!(fds.is_empty(), "expected no fds on a refused mount");
+        match result {
+            Err(composefs_ctl::varlink::oci::OciError::SignatureRequired { image }) => {
+                ensure!(
+                    image == "unsigned-image",
+                    "unexpected image in SignatureRequired: {image}"
+                );
+            }
+            other => bail!("expected OciError::SignatureRequired, got: {other:?}"),
+        }
+    }
+
+    // `require_signature` is opt-in: leaving it unset still mounts the
+    // unsigned image successfully.
+    {
+        let (result, fds) = svc
+            .proxy_oci_mount("unsigned-image", false, None)
+            .context("OciMount (unsigned, not required) transport error")?;
+        let reply = result.map_err(|e| {
+            anyhow::anyhow!("OciMount without require_signature should succeed: {e:?}")
+        })?;
+        assert_mount_works(reply, fds)?;
+    }
+
+    Ok(())
+}
+integration_test!(privileged_varlink_require_signature);
+
+/// `cfsctl keyring add-cert` on its own, independent of any OCI pull flow.
+/// Branches on kernel support rather than skipping, since both outcomes
+/// (success, or a clear `KeyringNotFound` error) are meaningful and worth
+/// asserting on.
+fn privileged_keyring_add_cert() -> Result<()> {
+    if require_privileged("privileged_keyring_add_cert")?.is_some() {
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl_bin = cfsctl()?;
+    let fixture_dir = tempfile::tempdir()?;
+
+    let (cert_pem, _key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_path = fixture_dir.path().join("cert.pem");
+    std::fs::write(&cert_path, &cert_pem)?;
+
+    let supported = fsverity_keyring_exists()?;
+    let output = cmd!(sh, "{cfsctl_bin} keyring add-cert {cert_path}")
+        .ignore_status()
+        .output()?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    if supported {
+        ensure!(
+            output.status.success(),
+            "add-cert should succeed on a kernel with fs-verity signature support: {stderr}"
+        );
+        ensure!(
+            stdout.contains("Certificate added to .fs-verity keyring"),
+            "unexpected add-cert output: {stdout}"
+        );
+    } else {
+        ensure!(
+            !output.status.success(),
+            "add-cert should fail on a kernel without fs-verity signature support"
+        );
+        ensure!(
+            stderr.contains("the .fs-verity keyring does not exist"),
+            "expected a KeyringNotFound error, got: {stderr}"
+        );
+    }
+
+    Ok(())
+}
+integration_test!(privileged_keyring_add_cert);

--- a/crates/composefs-integration-tests/src/tests/varlink.rs
+++ b/crates/composefs-integration-tests/src/tests/varlink.rs
@@ -45,9 +45,13 @@ use std::path::Path;
 use std::process::Command;
 
 use anyhow::{Context, Result, bail};
-use composefs_ctl::varlink::oci::{OciError, OciInspectReply, PullProgress};
+use composefs_ctl::varlink::oci::{
+    OciError, OciInspectReply, PullProgress, SealReply, SignReply, VerifyReply,
+};
 use composefs_ctl::varlink::proxy::{OciProxy, RepositoryProxy};
-use composefs_ctl::varlink::{ImageObjectsReply, InitRepositoryReply, RepositoryError};
+use composefs_ctl::varlink::{
+    ImageObjectsReply, InitRepositoryReply, MountParams, MountReply, RepositoryError,
+};
 use serde_json::{Value, json};
 use xshell::{Shell, cmd};
 use zlink::futures_util::TryStreamExt;
@@ -57,7 +61,7 @@ use crate::{cfsctl, create_test_rootfs, integration_test};
 
 /// A `cfsctl` varlink service spawned on a Unix socket for the duration of a
 /// test. Killed on drop.
-struct VarlinkService {
+pub(crate) struct VarlinkService {
     child: std::process::Child,
     socket: std::path::PathBuf,
     /// Handle for the test repository, opened via `OpenRepository` at spawn and
@@ -157,7 +161,7 @@ impl VarlinkService {
     /// entry point). Kept so tests that call this entry point continue to
     /// exercise a real service spawn; identical to [`Self::repository`] under
     /// socket activation.
-    fn oci(repo: &Path) -> Result<Self> {
+    pub(crate) fn oci(repo: &Path) -> Result<Self> {
         Self::spawn(repo)
     }
 
@@ -221,7 +225,10 @@ impl VarlinkService {
     }
 
     /// `org.composefs.Oci.Inspect` via the typed proxy, using the cached handle.
-    fn proxy_inspect(&self, image: &str) -> zlink::Result<Result<OciInspectReply, OciError>> {
+    pub(crate) fn proxy_inspect(
+        &self,
+        image: &str,
+    ) -> zlink::Result<Result<OciInspectReply, OciError>> {
         self.rt.block_on(async {
             let mut conn = self.connect().await?;
             conn.inspect(self.handle, image).await
@@ -252,10 +259,78 @@ impl VarlinkService {
         })
     }
 
+    /// `org.composefs.Oci.Seal` via the typed proxy.
+    fn proxy_seal(
+        &self,
+        image: &str,
+        inline: Option<bool>,
+    ) -> zlink::Result<Result<SealReply, OciError>> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            conn.seal(self.handle, image, inline).await
+        })
+    }
+
+    /// `org.composefs.Oci.Sign` via the typed proxy.
+    fn proxy_sign(
+        &self,
+        image: &str,
+        cert_pem: &str,
+        key_pem: &str,
+        inline: Option<bool>,
+    ) -> zlink::Result<Result<SignReply, OciError>> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            conn.sign(self.handle, image, cert_pem, key_pem, inline)
+                .await
+        })
+    }
+
+    /// `org.composefs.Oci.Verify` via the typed proxy.
+    fn proxy_verify(
+        &self,
+        image: &str,
+        cert_pem: Option<&str>,
+    ) -> zlink::Result<Result<VerifyReply, OciError>> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            conn.verify(self.handle, image, cert_pem).await
+        })
+    }
+
+    /// `org.composefs.Oci.OciMount` via the typed proxy.
+    ///
+    /// Returns the typed reply/error alongside the fd vector received via
+    /// SCM_RIGHTS; on success the detached mount fd is at index
+    /// `reply.fd_index` within it. No overlay upper/work fds are sent (an
+    /// empty fd array), so `require_signature` is the only option this
+    /// helper exercises.
+    pub(crate) fn proxy_oci_mount(
+        &self,
+        image: &str,
+        bootable: bool,
+        require_signature: Option<bool>,
+    ) -> zlink::Result<(Result<MountReply, OciError>, Vec<std::os::fd::OwnedFd>)> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            conn.oci_mount(
+                self.handle,
+                image,
+                bootable,
+                MountParams {
+                    require_signature,
+                    ..Default::default()
+                },
+                Vec::new(),
+            )
+            .await
+        })
+    }
+
     /// `org.composefs.Oci.Pull` via the typed streaming proxy. Collects all
     /// `PullProgress` frames into a `Vec`, surfacing the first error (transport
     /// or typed) encountered.
-    fn proxy_pull(
+    pub(crate) fn proxy_pull(
         &self,
         image: &str,
         name: Option<&str>,
@@ -1385,3 +1460,381 @@ fn test_varlink_init_repository_proxy() -> Result<()> {
     Ok(())
 }
 integration_test!(test_varlink_init_repository_proxy);
+
+// ============================================================================
+// OCI sealing / signing / verification varlink tests
+// ============================================================================
+
+/// Pull, then seal the image; verify the reply manifest_digest looks like a
+/// real OCI digest.
+fn test_varlink_oci_seal() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    // Pull first.
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "seal-test",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    // Seal.
+    let reply = svc
+        .proxy_seal("seal-test", None)
+        .context("transport/protocol error calling Seal")?
+        .map_err(|e| anyhow::anyhow!("Seal returned error: {e:?}"))?;
+
+    assert!(
+        !reply.manifest_digest.is_empty(),
+        "manifest_digest should be non-empty"
+    );
+    assert!(
+        reply.manifest_digest.starts_with("sha256:"),
+        "manifest_digest should start with 'sha256:', got: {}",
+        reply.manifest_digest
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_seal);
+
+/// Pull, seal, sign, then verify with the same cert.
+fn test_varlink_oci_sign_then_verify() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "sign-verify-test",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    svc.proxy_seal("sign-verify-test", None)
+        .context("Seal transport error")?
+        .map_err(|e| anyhow::anyhow!("Seal error: {e:?}"))?;
+
+    let (cert_pem, key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_pem_str = String::from_utf8(cert_pem).unwrap();
+    let key_pem_str = String::from_utf8(key_pem).unwrap();
+
+    let sign_reply = svc
+        .proxy_sign("sign-verify-test", &cert_pem_str, &key_pem_str, None)
+        .context("Sign transport error")?
+        .map_err(|e| anyhow::anyhow!("Sign error: {e:?}"))?;
+    assert!(
+        !sign_reply.artifact_digest.is_empty(),
+        "artifact_digest should be non-empty"
+    );
+
+    let verify_reply = svc
+        .proxy_verify("sign-verify-test", Some(&cert_pem_str))
+        .context("Verify transport error")?
+        .map_err(|e| anyhow::anyhow!("Verify error: {e:?}"))?;
+    assert!(verify_reply.ok, "verify should be ok");
+    assert!(
+        verify_reply.verified_count >= 1,
+        "at least one signature should verify"
+    );
+    assert!(verify_reply.cert_supplied, "cert_supplied should be true");
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_sign_then_verify);
+
+/// Pull, seal, sign with certA, then verify with certB — must produce
+/// `SignatureVerificationFailed`, not `InternalError` or a success.
+fn test_varlink_oci_verify_wrong_cert() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "wrong-cert-test",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    svc.proxy_seal("wrong-cert-test", None)
+        .context("Seal transport error")?
+        .map_err(|e| anyhow::anyhow!("Seal error: {e:?}"))?;
+
+    let (cert_a, key_a) = composefs_oci::signing::generate_test_keypair();
+    let (cert_b, _key_b) = composefs_oci::signing::generate_test_keypair();
+    let cert_a_str = String::from_utf8(cert_a).unwrap();
+    let key_a_str = String::from_utf8(key_a).unwrap();
+    let cert_b_str = String::from_utf8(cert_b).unwrap();
+
+    // Sign with certA / keyA.
+    svc.proxy_sign("wrong-cert-test", &cert_a_str, &key_a_str, None)
+        .context("Sign transport error")?
+        .map_err(|e| anyhow::anyhow!("Sign error: {e:?}"))?;
+
+    // Verify with certB — must fail with SignatureVerificationFailed.
+    let err = svc
+        .proxy_verify("wrong-cert-test", Some(&cert_b_str))
+        .context("Verify transport error")?
+        .expect_err("Verify with wrong cert must fail");
+    assert!(
+        matches!(err, OciError::SignatureVerificationFailed { .. }),
+        "expected SignatureVerificationFailed, got: {err:?}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_verify_wrong_cert);
+
+/// Pull, seal but do NOT sign, then verify with a cert — must produce
+/// `SignatureVerificationFailed` (no artifacts).
+fn test_varlink_oci_verify_no_artifacts() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "no-artifacts-test",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    svc.proxy_seal("no-artifacts-test", None)
+        .context("Seal transport error")?
+        .map_err(|e| anyhow::anyhow!("Seal error: {e:?}"))?;
+
+    let (cert_pem, _key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_pem_str = String::from_utf8(cert_pem).unwrap();
+
+    // Verify without signing — should fail with SignatureVerificationFailed.
+    let err = svc
+        .proxy_verify("no-artifacts-test", Some(&cert_pem_str))
+        .context("Verify transport error")?
+        .expect_err("Verify without signing must fail");
+    assert!(
+        matches!(err, OciError::SignatureVerificationFailed { .. }),
+        "expected SignatureVerificationFailed, got: {err:?}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_verify_no_artifacts);
+
+/// Pull, seal, sign, then verify with `cert_pem = None` (digest-only check).
+fn test_varlink_oci_verify_digest_only() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "digest-only-test",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    svc.proxy_seal("digest-only-test", None)
+        .context("Seal transport error")?
+        .map_err(|e| anyhow::anyhow!("Seal error: {e:?}"))?;
+
+    let (cert_pem, key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_pem_str = String::from_utf8(cert_pem).unwrap();
+    let key_pem_str = String::from_utf8(key_pem).unwrap();
+
+    svc.proxy_sign("digest-only-test", &cert_pem_str, &key_pem_str, None)
+        .context("Sign transport error")?
+        .map_err(|e| anyhow::anyhow!("Sign error: {e:?}"))?;
+
+    // Verify without a cert — digest-only.
+    let verify_reply = svc
+        .proxy_verify("digest-only-test", None)
+        .context("Verify transport error")?
+        .map_err(|e| anyhow::anyhow!("Verify digest-only error: {e:?}"))?;
+    assert!(verify_reply.ok, "digest-only verify should be ok");
+    assert_eq!(
+        verify_reply.verified_count, 0,
+        "digest-only verify should report 0 crypto verifications"
+    );
+    assert!(
+        !verify_reply.cert_supplied,
+        "cert_supplied should be false for digest-only"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_verify_digest_only);
+
+/// Pull, seal, then sign with garbage cert/key — must produce `InvalidCertificate`.
+fn test_varlink_oci_sign_bad_key() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "bad-key-test",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    svc.proxy_seal("bad-key-test", None)
+        .context("Seal transport error")?
+        .map_err(|e| anyhow::anyhow!("Seal error: {e:?}"))?;
+
+    let err = svc
+        .proxy_sign("bad-key-test", "garbage", "garbage", None)
+        .context("Sign transport error")?
+        .expect_err("Sign with garbage cert/key must fail");
+    assert!(
+        matches!(err, OciError::InvalidCertificate { .. }),
+        "expected InvalidCertificate, got: {err:?}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_sign_bad_key);
+
+/// Seal a non-existent image — must produce `NoSuchImage`.
+fn test_varlink_oci_seal_missing_image() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::oci(repo)?;
+
+    let err = svc
+        .proxy_seal("nope", None)
+        .context("Seal transport error")?
+        .expect_err("Seal of missing image must fail");
+    assert!(
+        matches!(err, OciError::NoSuchImage { .. }),
+        "expected NoSuchImage, got: {err:?}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_seal_missing_image);
+
+/// Pull, seal inline, sign inline, then verify.
+fn test_varlink_oci_sign_then_verify_inline() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "sign-verify-test-inline",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    svc.proxy_seal("sign-verify-test-inline", Some(true))
+        .context("Seal transport error")?
+        .map_err(|e| anyhow::anyhow!("Seal error: {e:?}"))?;
+
+    let (cert_pem, key_pem) = composefs_oci::signing::generate_test_keypair();
+    let cert_pem_str = String::from_utf8(cert_pem).unwrap();
+    let key_pem_str = String::from_utf8(key_pem).unwrap();
+
+    let sign_reply = svc
+        .proxy_sign(
+            "sign-verify-test-inline",
+            &cert_pem_str,
+            &key_pem_str,
+            Some(true),
+        )
+        .context("Sign transport error")?
+        .map_err(|e| anyhow::anyhow!("Sign error: {e:?}"))?;
+    assert!(
+        !sign_reply.artifact_digest.is_empty(),
+        "artifact_digest should be non-empty"
+    );
+
+    let verify_reply = svc
+        .proxy_verify("sign-verify-test-inline", Some(&cert_pem_str))
+        .context("Verify transport error")?
+        .map_err(|e| anyhow::anyhow!("Verify error: {e:?}"))?;
+    assert!(verify_reply.ok, "verify should be ok");
+    assert!(
+        verify_reply.verified_count >= 1,
+        "at least one signature should verify"
+    );
+    assert!(verify_reply.cert_supplied, "cert_supplied should be true");
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_sign_then_verify_inline);

--- a/crates/composefs-ioctls/Cargo.toml
+++ b/crates/composefs-ioctls/Cargo.toml
@@ -13,8 +13,11 @@ version.workspace = true
 [features]
 default = []
 loop-device = []
+keyring = ["dep:openssl", "dep:keyutils"]
 
 [dependencies]
+keyutils = { version = "0.4", optional = true }
+openssl = { version = "0.10", optional = true }
 rustix = { version = "1.0.0", features = ["fs"] }
 thiserror = "2"
 

--- a/crates/composefs-ioctls/src/fsverity.rs
+++ b/crates/composefs-ioctls/src/fsverity.rs
@@ -28,9 +28,25 @@ pub enum EnableVerityError {
     /// The file has an open writable file descriptor.
     #[error("File is opened for writing")]
     FileOpenedForWrite,
-    /// Signature verification failed (when using kernel signatures).
-    #[error("Signature verification failed")]
+    /// The kernel rejected the signature as invalid (`EKEYREJECTED`) or
+    /// malformed (`EBADMSG`). Unlike [`Self::SigningKeyNotFound`], this
+    /// means a certificate *is* present in the `.fs-verity` keyring, but
+    /// the given signature does not verify against it -- this is a real
+    /// tamper-evidence signal and should not be silently ignored.
+    #[error(
+        "fs-verity signature rejected by kernel: no certificate in the \
+         .fs-verity keyring could verify it (see `cfsctl keyring add-cert`), \
+         or the file has been tampered with"
+    )]
     SignatureVerificationFailed,
+    /// The `.fs-verity` keyring has no certificate able to verify this
+    /// signature (`ENOKEY`). This commonly just means no certificate has
+    /// been loaded yet (see `cfsctl keyring add-cert`), so unlike
+    /// [`Self::SignatureVerificationFailed`] this is not evidence of
+    /// tampering and callers may reasonably fall back to enabling
+    /// verity without a signature.
+    #[error("No certificate in the .fs-verity keyring can verify this signature")]
+    SigningKeyNotFound,
 }
 
 /// Measuring fsverity failed.
@@ -118,8 +134,8 @@ pub fn fs_ioc_enable_verity_with_sig(
         None => (0, 0),
     };
 
-    unsafe {
-        match ioctl(
+    let r = unsafe {
+        ioctl(
             fd,
             Setter::<{ FS_IOC_ENABLE_VERITY }, FsVerityEnableArg>::new(FsVerityEnableArg {
                 version: 1,
@@ -132,16 +148,24 @@ pub fn fs_ioc_enable_verity_with_sig(
                 sig_ptr,
                 __reserved2: [0; 11],
             }),
-        ) {
-            Err(Errno::NOTTY) | Err(Errno::OPNOTSUPP) => {
-                Err(EnableVerityError::FilesystemNotSupported)
-            }
-            Err(Errno::EXIST) => Err(EnableVerityError::AlreadyEnabled),
-            Err(Errno::TXTBSY) => Err(EnableVerityError::FileOpenedForWrite),
-            Err(Errno::KEYREJECTED) => Err(EnableVerityError::SignatureVerificationFailed),
-            Err(e) => Err(Error::from(e).into()),
-            Ok(_) => Ok(()),
-        }
+        )
+    };
+    r.map_err(enable_verity_errno_to_error)
+}
+
+/// Maps the `errno` values documented for `FS_IOC_ENABLE_VERITY` (see
+/// `Documentation/filesystems/fsverity.rst`) onto [`EnableVerityError`].
+///
+/// Split out as a free function so the mapping can be unit tested without
+/// needing an fs-verity- or signature-capable kernel/filesystem.
+fn enable_verity_errno_to_error(e: Errno) -> EnableVerityError {
+    match e {
+        Errno::NOTTY | Errno::OPNOTSUPP => EnableVerityError::FilesystemNotSupported,
+        Errno::EXIST => EnableVerityError::AlreadyEnabled,
+        Errno::TXTBSY => EnableVerityError::FileOpenedForWrite,
+        Errno::KEYREJECTED | Errno::BADMSG => EnableVerityError::SignatureVerificationFailed,
+        Errno::NOKEY => EnableVerityError::SigningKeyNotFound,
+        e => Error::from(e).into(),
     }
 }
 
@@ -212,6 +236,71 @@ pub fn fs_ioc_measure_verity<const N: usize>(
     }
 }
 
+/// Metadata type identifier for the builtin PKCS#7 signature, as passed to
+/// `FS_IOC_READ_VERITY_METADATA` in `fsverity_read_metadata_arg::metadata_type`.
+///
+/// See `FS_VERITY_METADATA_TYPE_SIGNATURE` in `/usr/include/linux/fsverity.h`.
+const FS_VERITY_METADATA_TYPE_SIGNATURE: u64 = 3;
+
+// See /usr/include/linux/fsverity.h
+#[repr(C)]
+#[derive(Debug)]
+struct FsVerityReadMetadataArg {
+    metadata_type: u64,
+    offset: u64,
+    length: u64,
+    buf_ptr: u64,
+    __reserved: u64,
+}
+
+// #define FS_IOC_READ_VERITY_METADATA _IOWR('f', 135, struct fsverity_read_metadata_arg)
+const FS_IOC_READ_VERITY_METADATA: Opcode =
+    opcode::read_write::<FsVerityReadMetadataArg>(b'f', 135);
+
+/// Check whether a file has a kernel-enrolled fs-verity builtin signature.
+///
+/// This is a thin safe wrapper around `FS_IOC_READ_VERITY_METADATA` with
+/// `FS_VERITY_METADATA_TYPE_SIGNATURE`, used only to answer a yes/no
+/// question about signature *presence* -- it does not return the signature
+/// bytes themselves. See `fs_ioc_enable_verity_with_sig` for enrolling one.
+///
+/// # Arguments
+/// * `fd` - File descriptor to query (fs-verity must already be enabled on it,
+///   though the descriptor doesn't need to be opened `O_RDONLY`).
+///
+/// # Returns
+/// * `Ok(true)` if a signature was enrolled with `FS_IOC_ENABLE_VERITY`.
+/// * `Ok(false)` if fs-verity is enabled but no signature was enrolled
+///   (kernel reports `ENODATA`).
+/// * `Err` for any other ioctl failure, e.g. fs-verity not enabled on the
+///   file or not supported by the filesystem.
+pub fn fs_ioc_has_verity_signature(fd: impl AsFd) -> std::io::Result<bool> {
+    // We only care whether a signature is present, not its contents, so a
+    // one-byte buffer is enough: any successful read means a signature is
+    // enrolled (a real PKCS#7 signature is never zero-length).
+    let mut buf = [0u8; 1];
+    let mut arg = FsVerityReadMetadataArg {
+        metadata_type: FS_VERITY_METADATA_TYPE_SIGNATURE,
+        offset: 0,
+        length: buf.len() as u64,
+        buf_ptr: buf.as_mut_ptr() as u64,
+        __reserved: 0,
+    };
+
+    let r = unsafe {
+        ioctl(
+            fd,
+            Updater::<{ FS_IOC_READ_VERITY_METADATA }, FsVerityReadMetadataArg>::new(&mut arg),
+        )
+    };
+
+    match r {
+        Ok(()) => Ok(true),
+        Err(Errno::NODATA) => Ok(false),
+        Err(e) => Err(Error::from(e)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Write;
@@ -268,5 +357,71 @@ mod tests {
         let file = tempfile_in("/dev/shm").unwrap();
         let err = fs_ioc_enable_verity(&file, 1, 4096).unwrap_err();
         assert!(matches!(err, EnableVerityError::FilesystemNotSupported));
+    }
+
+    // `FS_IOC_ENABLE_VERITY` signature-related errnos (`ENOKEY`,
+    // `EKEYREJECTED`, `EBADMSG`) can't reliably be triggered in a test
+    // sandbox: they require a kernel built with
+    // `CONFIG_FS_VERITY_BUILTIN_SIGNATURES` and a real PKCS#7 signature.
+    // Test the errno mapping directly instead of going through the ioctl.
+    #[test]
+    fn test_enable_verity_errno_mapping() {
+        let cases = [
+            (Errno::NOTTY, "FilesystemNotSupported"),
+            (Errno::OPNOTSUPP, "FilesystemNotSupported"),
+            (Errno::EXIST, "AlreadyEnabled"),
+            (Errno::TXTBSY, "FileOpenedForWrite"),
+            (Errno::KEYREJECTED, "SignatureVerificationFailed"),
+            (Errno::BADMSG, "SignatureVerificationFailed"),
+            (Errno::NOKEY, "SigningKeyNotFound"),
+        ];
+        for (errno, expected) in cases {
+            let err = enable_verity_errno_to_error(errno);
+            let actual = match err {
+                EnableVerityError::FilesystemNotSupported => "FilesystemNotSupported",
+                EnableVerityError::AlreadyEnabled => "AlreadyEnabled",
+                EnableVerityError::FileOpenedForWrite => "FileOpenedForWrite",
+                EnableVerityError::SignatureVerificationFailed => "SignatureVerificationFailed",
+                EnableVerityError::SigningKeyNotFound => "SigningKeyNotFound",
+                EnableVerityError::Io(_) => "Io",
+            };
+            assert_eq!(actual, expected, "mapping for {errno:?}");
+        }
+    }
+
+    // Actually enrolling a kernel signature can't be exercised in this
+    // sandbox (see `test_enable_verity_errno_mapping` above), but plain
+    // fs-verity enablement can, so we can at least confirm the "no
+    // signature enrolled" (`ENODATA`) side of `fs_ioc_has_verity_signature`
+    // against a real kernel ioctl.
+    #[test]
+    fn test_has_verity_signature_no_signature() {
+        let mut tf = test_tempfile();
+        tf.write_all(b"hello world").unwrap();
+        tf.sync_all().unwrap();
+
+        // Re-open read-only: verity can only be enabled on an fd with no
+        // other writable descriptors outstanding.
+        let path = format!("/proc/self/fd/{}", std::os::fd::AsRawFd::as_raw_fd(&tf));
+        let ro_fd =
+            rustix::fs::open(&path, rustix::fs::OFlags::RDONLY, rustix::fs::Mode::empty()).unwrap();
+        drop(tf);
+
+        fs_ioc_enable_verity(&ro_fd, 1, 4096).unwrap();
+
+        assert!(!fs_ioc_has_verity_signature(&ro_fd).unwrap());
+    }
+
+    #[test_with::path(/dev/shm)]
+    #[test]
+    fn test_has_verity_signature_wrong_fs() {
+        let file = tempfile_in("/dev/shm").unwrap();
+        let err = fs_ioc_has_verity_signature(&file).unwrap_err();
+        let raw = err.raw_os_error();
+        assert!(
+            raw == Some(Errno::NOTTY.raw_os_error())
+                || raw == Some(Errno::OPNOTSUPP.raw_os_error()),
+            "unexpected error for fs-verity-unsupported filesystem: {err}"
+        );
     }
 }

--- a/crates/composefs-ioctls/src/keyring.rs
+++ b/crates/composefs-ioctls/src/keyring.rs
@@ -1,0 +1,193 @@
+//! Kernel keyring integration for fs-verity certificates.
+//!
+//! This module provides functions for injecting CA certificates into the
+//! kernel's `.fs-verity` keyring, enabling kernel-level signature verification
+//! for fsverity-protected files.
+
+use std::num::NonZeroI32;
+use thiserror::Error;
+
+/// The description string the kernel uses for the `.fs-verity` keyring, as
+/// reported in `/proc/keys`. See `fs/verity/signature.c` in the kernel
+/// source.
+const FSVERITY_KEYRING_DESC: &str = ".fs-verity";
+
+/// Errors that can occur when injecting a certificate into the kernel keyring.
+#[derive(Error, Debug)]
+pub enum KeyringError {
+    /// Failed to parse the PEM certificate (wraps openssl error).
+    #[error("failed to parse PEM certificate: {0}")]
+    PemParseFailed(#[from] openssl::error::ErrorStack),
+    /// Failed to add key to the keyring.
+    #[error("failed to add key to keyring: {0}")]
+    KeyAddFailed(#[from] keyutils::Error),
+    /// Permission denied (requires CAP_SYS_ADMIN).
+    #[error("permission denied: adding keys to .fs-verity keyring requires root/CAP_SYS_ADMIN")]
+    PermissionDenied,
+    /// The keyring does not exist (kernel may not have fs-verity signature support).
+    #[error("the .fs-verity keyring does not exist; kernel may not support fs-verity signatures")]
+    KeyringNotFound,
+    /// Failed to read or parse `/proc/keys` while locating the `.fs-verity` keyring.
+    #[error("failed to read /proc/keys: {0}")]
+    ProcKeysReadFailed(#[from] std::io::Error),
+}
+
+/// Locate the real serial number of the kernel's `.fs-verity` keyring.
+///
+/// The `.fs-verity` keyring (see `fs/verity/signature.c`) is allocated by the
+/// kernel at boot and is a distinct keyring, not one of the eight
+/// `KEY_SPEC_*` special negative IDs defined in
+/// `include/uapi/linux/keyctl.h` (thread/process/session/user/user-session/
+/// group/reqkey-auth/requestor) — there is no fixed special ID that refers to
+/// it. This mirrors how `keyctl(1)`'s `%:<name>` keyring-by-name syntax
+/// resolves it: by scanning `/proc/keys` for a `keyring`-type entry whose
+/// description matches and using the serial number found there.
+fn find_fsverity_keyring_id() -> Result<NonZeroI32, KeyringError> {
+    let keys = std::fs::read_to_string("/proc/keys")?;
+    for line in keys.lines() {
+        // Format (see Documentation/security/keys/core.rst):
+        // ID flags usage timeout perm uid gid type desc: extra...
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        let (Some(id_hex), Some(&"keyring"), Some(desc)) =
+            (fields.first(), fields.get(7), fields.get(8))
+        else {
+            continue;
+        };
+        if desc.strip_suffix(':').unwrap_or(desc) != FSVERITY_KEYRING_DESC {
+            continue;
+        }
+        let id = u32::from_str_radix(id_hex, 16).map_err(|_| KeyringError::KeyringNotFound)? as i32;
+        return NonZeroI32::new(id).ok_or(KeyringError::KeyringNotFound);
+    }
+    Err(KeyringError::KeyringNotFound)
+}
+
+/// Inject a CA certificate into the kernel's `.fs-verity` keyring.
+///
+/// This allows the kernel to require valid PKCS#7 signatures when `FS_IOC_ENABLE_VERITY`
+/// is called. The certificate must be PEM-encoded and will be converted to DER format
+/// before being added to the keyring.
+///
+/// # Trust Model
+///
+/// When a certificate is loaded into the `.fs-verity` keyring, the kernel will verify
+/// PKCS#7 signatures passed to `FS_IOC_ENABLE_VERITY` against this keyring. If the
+/// signature is invalid or the signing certificate is not trusted by a key in the
+/// keyring, the ioctl will fail.
+///
+/// This provides kernel-level enforcement of file integrity signatures, complementing
+/// the application-level verification provided by OCI signature artifacts.
+///
+/// # Requirements
+///
+/// - Requires `CAP_SYS_ADMIN` capability (typically root).
+/// - The kernel must be built with `CONFIG_FS_VERITY_BUILTIN_SIGNATURES=y`.
+/// - The `.fs-verity` keyring must exist.
+///
+/// # Arguments
+///
+/// * `cert_pem` - The PEM-encoded X.509 certificate to add to the keyring.
+///
+/// # Example
+///
+/// ```ignore
+/// use composefs_ioctls::keyring::inject_fsverity_cert;
+///
+/// let cert_pem = std::fs::read("my-ca-cert.pem")?;
+/// inject_fsverity_cert(&cert_pem)?;
+/// println!("Certificate added to .fs-verity keyring");
+/// ```
+#[allow(unsafe_code)]
+pub fn inject_fsverity_cert(cert_pem: &[u8]) -> Result<(), KeyringError> {
+    // Parse PEM and extract DER using openssl
+    let cert = openssl::x509::X509::from_pem(cert_pem)?;
+    let cert_der = cert.to_der()?;
+
+    // Get the .fs-verity keyring
+    let keyring_serial = find_fsverity_keyring_id()?;
+    // SAFETY: `keyring_serial` was read out of `/proc/keys` as the serial of an
+    // existing `keyring`-type key, so it identifies a valid keyring.
+    let mut keyring = unsafe { keyutils::Keyring::new(keyring_serial) };
+
+    // Add the certificate as an asymmetric key.
+    // The description can be anything — the kernel derives the actual description
+    // from the certificate's subject and issuer.
+    let result = keyring.add_key::<keyutils::keytypes::Asymmetric, _, _>("", &cert_der[..]);
+
+    match result {
+        Ok(_key) => Ok(()),
+        Err(e) => {
+            // Check for specific error conditions using errno values.
+            // keyutils::Error is an alias for errno::Errno.
+            let errno_val = e.0;
+            if errno_val == rustix::io::Errno::ACCESS.raw_os_error()
+                || errno_val == rustix::io::Errno::PERM.raw_os_error()
+            {
+                Err(KeyringError::PermissionDenied)
+            } else if errno_val == 126 || errno_val == 128 {
+                // ENOKEY = 126, EKEYREVOKED = 128 on Linux
+                Err(KeyringError::KeyringNotFound)
+            } else {
+                Err(KeyringError::KeyAddFailed(e))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Generate a self-signed PEM certificate for testing via openssl.
+    fn generate_test_cert_pem() -> Vec<u8> {
+        use openssl::asn1::Asn1Time;
+        use openssl::hash::MessageDigest;
+        use openssl::pkey::PKey;
+        use openssl::rsa::Rsa;
+        use openssl::x509::{X509Builder, X509NameBuilder};
+
+        let rsa = Rsa::generate(2048).unwrap();
+        let pkey = PKey::from_rsa(rsa).unwrap();
+
+        let mut name = X509NameBuilder::new().unwrap();
+        name.append_entry_by_text("CN", "test-ca").unwrap();
+        let name = name.build();
+
+        let mut builder = X509Builder::new().unwrap();
+        builder.set_version(2).unwrap();
+        builder.set_subject_name(&name).unwrap();
+        builder.set_issuer_name(&name).unwrap();
+        builder.set_pubkey(&pkey).unwrap();
+        builder
+            .set_not_before(&Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        builder
+            .set_not_after(&Asn1Time::days_from_now(365).unwrap())
+            .unwrap();
+        builder.sign(&pkey, MessageDigest::sha256()).unwrap();
+
+        let cert = builder.build();
+        cert.to_pem().unwrap()
+    }
+
+    #[test]
+    fn test_pem_parse_valid_cert() {
+        let pem = generate_test_cert_pem();
+        let cert = openssl::x509::X509::from_pem(&pem).unwrap();
+        let der = cert.to_der().unwrap();
+        assert!(!der.is_empty());
+    }
+
+    #[test]
+    fn test_pem_parse_invalid() {
+        let bad_pem = b"this is not a PEM certificate";
+        let result = openssl::x509::X509::from_pem(bad_pem);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_inject_invalid_pem() {
+        let result = inject_fsverity_cert(b"not a cert");
+        assert!(matches!(result, Err(KeyringError::PemParseFailed(_))));
+    }
+}

--- a/crates/composefs-ioctls/src/lib.rs
+++ b/crates/composefs-ioctls/src/lib.rs
@@ -27,6 +27,9 @@
 pub mod fsverity;
 pub mod mount;
 
+#[cfg(feature = "keyring")]
+pub mod keyring;
+
 #[cfg(feature = "loop-device")]
 pub mod loop_device;
 

--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -14,14 +14,16 @@ version.workspace = true
 default = ["containers-storage"]
 test = ["tar", "rand", "composefs/test"]
 boot = ["composefs-boot"]
-containers-storage = ["dep:cstorage", "dep:base64", "varlink", "cstorage/layer-transfer"]
+containers-storage = ["dep:cstorage", "varlink", "cstorage/layer-transfer"]
 varlink = ['dep:zlink', 'dep:zlink-core', 'composefs/varlink']
+# Enable OCI client for fetching referrer artifacts from remote registries
+oci-client = ["dep:oci-client"]
 
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
 async-compression = { version = "0.4.0", default-features = false, features = ["tokio", "zstd", "gzip"] }
-base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
+base64 = { version = "0.22", default-features = false, features = ["std"] }
 composefs-splitdirfdstream = { path = "../composefs-splitdirfdstream", version = "0.7.0", features = ["tokio"] }
 bytes = { version = "1", default-features = false }
 composefs = { workspace = true }
@@ -33,6 +35,8 @@ containers-image-proxy = { version = "0.11", default-features = false }
 cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.7.0", optional = true }
 hex = { version = "0.4.0", default-features = false }
 indicatif = { version = "0.18.0", default-features = false }
+oci-client = { version = "0.15", default-features = false, features = ["rustls-tls"], optional = true }
+openssl = { version = "0.10" }
 rustix = { version = "1.0.0", features = ["fs"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }

--- a/crates/composefs-oci/src/boot.rs
+++ b/crates/composefs-oci/src/boot.rs
@@ -12,17 +12,25 @@ use composefs::repository::Repository;
 
 use crate::OciDigest;
 
+/// The name used for the bootable image reference in the config.
+pub const BOOT_IMAGE_REF_NAME: &str = "cfs-oci-for-bootable";
+
 /// Generate a bootable EROFS image from a pulled OCI manifest (idempotent).
+///
+/// If `tag` is provided, the tag is updated to point to the new manifest that
+/// includes the boot EROFS reference (since `ensure_oci_composefs_erofs_boot`
+/// rewrites the config+manifest and the tag must follow the new manifest digest).
 #[cfg(feature = "boot")]
 pub fn generate_boot_image<ObjectID: FsVerityHashValue>(
     repo: &Arc<Repository<ObjectID>>,
     manifest_digest: &OciDigest,
+    tag: Option<&str>,
 ) -> Result<ObjectID> {
     if let Some(existing) = boot_image(repo, manifest_digest)? {
         return Ok(existing);
     }
 
-    let erofs_id = crate::ensure_oci_composefs_erofs_boot(repo, manifest_digest, None, None)?
+    let erofs_id = crate::ensure_oci_composefs_erofs_boot(repo, manifest_digest, None, tag)?
         .expect("container image should produce boot EROFS");
 
     Ok(erofs_id)
@@ -113,12 +121,13 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let image_verity = generate_boot_image(repo, &img.manifest_digest).unwrap();
+        let image_verity =
+            generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
 
         let found = boot_image(repo, &img.manifest_digest).unwrap();
         assert_eq!(found, Some(image_verity.clone()));
 
-        // Open by tag since manifest was rewritten
+        // Open by tag since manifest was rewritten (tag updated via generate_boot_image)
         let oci = OciImage::open_ref(repo, "myapp:v1").unwrap();
         assert_eq!(
             oci.boot_image_ref(repo.erofs_version()),
@@ -140,8 +149,8 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let v1 = generate_boot_image(repo, &img.manifest_digest).unwrap();
-        let v2 = generate_boot_image(repo, &img.manifest_digest).unwrap();
+        let v1 = generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
+        let v2 = generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
         assert_eq!(v1, v2);
     }
 
@@ -152,7 +161,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        generate_boot_image(repo, &img.manifest_digest).unwrap();
+        generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
         assert!(boot_image(repo, &img.manifest_digest).unwrap().is_some());
 
         remove_boot_image(repo, &img.manifest_digest).unwrap();
@@ -180,7 +189,7 @@ mod test {
 
         remove_boot_image(repo, &img.manifest_digest).unwrap();
 
-        generate_boot_image(repo, &img.manifest_digest).unwrap();
+        generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
         remove_boot_image(repo, &img.manifest_digest).unwrap();
         remove_boot_image(repo, &img.manifest_digest).unwrap();
 
@@ -194,7 +203,8 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        let image_verity = generate_boot_image(repo, &img.manifest_digest).unwrap();
+        let image_verity =
+            generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
 
         let gc = repo.gc(&[]).unwrap();
         assert_eq!(gc.images_pruned, 0);
@@ -214,7 +224,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        generate_boot_image(repo, &img.manifest_digest).unwrap();
+        generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
 
         crate::oci_image::untag_image(repo, "myapp:v1").unwrap();
 
@@ -236,7 +246,7 @@ mod test {
 
         let img = test_util::create_bootable_image(repo, Some("myapp:v1"), 1).await;
 
-        generate_boot_image(repo, &img.manifest_digest).unwrap();
+        generate_boot_image(repo, &img.manifest_digest, Some("myapp:v1")).unwrap();
 
         remove_boot_image(repo, &img.manifest_digest).unwrap();
         let gc = repo.gc(&[]).unwrap();
@@ -256,7 +266,7 @@ mod test {
 
             let img = test_util::create_bootable_image(repo, Some(tag), 1).await;
 
-            let boot_verity = generate_boot_image(repo, &img.manifest_digest).unwrap();
+            let boot_verity = generate_boot_image(repo, &img.manifest_digest, Some(tag)).unwrap();
 
             let fs = crate::image::create_filesystem(repo, &img.config_digest, None).unwrap();
             let boot_entries = get_boot_resources(&fs, repo).unwrap();

--- a/crates/composefs-oci/src/image.rs
+++ b/crates/composefs-oci/src/image.rs
@@ -16,7 +16,11 @@ use fn_error_context::context;
 use sha2::{Digest, Sha256};
 
 use composefs::{
-    fsverity::FsVerityHashValue,
+    erofs::{
+        format::FormatVersion,
+        writer::{ValidatedFileSystem, mkfs_erofs_versioned},
+    },
+    fsverity::{FsVerityHashValue, compute_verity},
     repository::Repository,
     tree::{Directory, FileSystem, Inode, Stat},
 };
@@ -88,6 +92,130 @@ pub fn process_entry<ObjectID: FsVerityHashValue>(
     Ok(())
 }
 
+/// Compute per-layer composefs digests for an OCI image.
+///
+/// For each layer, builds a single-layer filesystem and computes its EROFS fsverity digest.
+/// These digests can be stored in a composefs signature artifact.
+///
+/// Per-layer digests are computed without `transform_for_oci()` since individual layers
+/// typically don't have the `/usr` directory needed for the OCI root metadata transform.
+///
+/// The final merged digest (the digest of the complete flattened filesystem with
+/// `transform_for_oci()` applied) can be obtained from `seal()` or `create_filesystem()`.
+///
+/// **Security note**: When `config_verity` is `None`, layer content is not verified against
+/// the config's diff_ids. Callers MUST provide a trusted `config_verity` when computing
+/// digests that will be used in signature artifacts. Without verity, a compromised repository
+/// could cause digests to be computed over substituted layer content.
+#[context("Computing per-layer digests")]
+pub fn compute_per_layer_digests<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    config_name: &OciDigest,
+    config_verity: Option<&ObjectID>,
+) -> Result<Vec<ObjectID>> {
+    let oc = crate::open_config(repo, config_name, config_verity)?;
+
+    let mut layer_digests = Vec::with_capacity(oc.config.rootfs().diff_ids().len());
+
+    for diff_id in oc.config.rootfs().diff_ids() {
+        let layer_verity = oc
+            .layer_refs
+            .get(diff_id.as_str())
+            .context("OCI config splitstream missing named ref to layer")?;
+
+        let mut single_fs = FileSystem::new(Stat::uninitialized());
+        let mut layer_stream =
+            repo.open_stream("", Some(layer_verity), Some(TAR_LAYER_CONTENT_TYPE))?;
+        while let Some(entry) = crate::tar::get_entry(&mut layer_stream)? {
+            process_entry(&mut single_fs, entry)?;
+        }
+        layer_digests.push(single_fs.compute_image_id(FormatVersion::V1));
+    }
+
+    Ok(layer_digests)
+}
+
+/// Computes the composefs merged digest (image ID) for an OCI container.
+///
+/// This is the fs-verity digest of the merged filesystem created from all layers.
+/// This digest is deterministic for a given OCI image and is used in signature
+/// artifacts as the "merged" entry.
+///
+/// Always uses EROFS format version 1 (v1), which is the mandatory format for
+/// composefs sealing artifacts. This ensures the digest is stable and deterministic
+/// across implementations regardless of the repository's default format setting.
+///
+/// If `config_verity` is given, it is used for fast lookup. Otherwise, the config
+/// and layers will be hashed to verify their content.
+#[context("Computing merged digest")]
+pub fn compute_merged_digest<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    config_name: &OciDigest,
+    config_verity: Option<&ObjectID>,
+) -> Result<ObjectID> {
+    let fs = create_filesystem(repo, config_name, config_verity)?;
+    Ok(fs.compute_image_id(FormatVersion::V1))
+}
+
+/// Compute per-layer EROFS images and their fs-verity digests.
+///
+/// Returns one `(erofs_bytes, digest)` pair per OCI layer, in manifest order.
+/// This is the same as `compute_per_layer_digests` but preserves the raw EROFS
+/// bytes for inclusion in composefs artifacts.
+///
+/// **Security note**: When `config_verity` is `None`, layer content is not verified against
+/// the config's diff_ids. Callers MUST provide a trusted `config_verity` when generating
+/// images that will be used in signature artifacts.
+#[context("Generating per-layer EROFS images")]
+pub fn generate_per_layer_images<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    config_name: &OciDigest,
+    config_verity: Option<&ObjectID>,
+) -> Result<Vec<(Box<[u8]>, ObjectID)>> {
+    let oc = crate::open_config(repo, config_name, config_verity)?;
+
+    let mut results = Vec::with_capacity(oc.config.rootfs().diff_ids().len());
+
+    for diff_id in oc.config.rootfs().diff_ids() {
+        let layer_verity = oc
+            .layer_refs
+            .get(diff_id.as_str())
+            .context("OCI config splitstream missing named ref to layer")?;
+
+        let mut single_fs = FileSystem::new(Stat::uninitialized());
+        let mut layer_stream =
+            repo.open_stream("", Some(layer_verity), Some(TAR_LAYER_CONTENT_TYPE))?;
+        while let Some(entry) = crate::tar::get_entry(&mut layer_stream)? {
+            process_entry(&mut single_fs, entry)?;
+        }
+        let erofs_bytes =
+            mkfs_erofs_versioned(&ValidatedFileSystem::new(single_fs)?, FormatVersion::V1);
+        let digest = compute_verity(&erofs_bytes);
+        results.push((erofs_bytes, digest));
+    }
+
+    Ok(results)
+}
+
+/// Generate the merged EROFS image and its fs-verity digest.
+///
+/// This is the same as `compute_merged_digest` but preserves the raw EROFS
+/// bytes for inclusion in composefs artifacts.
+///
+/// Always uses EROFS format version 1 (v1), the mandatory format for composefs
+/// sealing artifacts, ensuring a stable, deterministic digest across implementations.
+#[context("Generating merged EROFS image")]
+pub fn generate_merged_image<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    config_name: &OciDigest,
+    config_verity: Option<&ObjectID>,
+) -> Result<(Box<[u8]>, ObjectID)> {
+    let fs = create_filesystem(repo, config_name, config_verity)?;
+    let erofs_bytes = mkfs_erofs_versioned(&ValidatedFileSystem::new(fs)?, FormatVersion::V1);
+    let digest = compute_verity(&erofs_bytes);
+    Ok((erofs_bytes, digest))
+}
+
 /// Creates a filesystem from the given OCI container.  No special transformations are performed to
 /// make the filesystem bootable.
 ///
@@ -156,10 +284,13 @@ mod test {
     use composefs::{
         dumpfile::write_dumpfile,
         fsverity::Sha256HashValue,
-        repository::RepositoryConfig,
         tree::{LeafContent, RegularFile, Stat},
     };
-    use std::{collections::BTreeMap, io::BufRead, path::PathBuf};
+    use std::{
+        collections::BTreeMap,
+        io::BufRead,
+        path::{Path, PathBuf},
+    };
 
     use super::*;
 
@@ -366,7 +497,7 @@ mod test {
         let by_path = |p: &str| -> &TarEntry<Sha256HashValue> {
             entries
                 .iter()
-                .find(|e| e.path == PathBuf::from(p))
+                .find(|e| e.path == Path::new(p))
                 .unwrap_or_else(|| panic!("missing entry for {p}"))
         };
 
@@ -499,7 +630,7 @@ mod test {
         // Find the *last* /bin entry, which should be the symlink.
         let bin_entries: Vec<_> = entries
             .iter()
-            .filter(|e| e.path == PathBuf::from("/bin"))
+            .filter(|e| e.path == Path::new("/bin"))
             .collect();
         assert!(
             bin_entries.len() >= 2,
@@ -528,6 +659,115 @@ mod test {
         );
 
         Ok(())
+    }
+
+    /// Helper to import a baseimage layer and create an OCI config for it.
+    /// Returns (config_digest, config_verity, diff_id).
+    fn import_baseimage_with_config(
+        repo: &std::sync::Arc<Repository<Sha256HashValue>>,
+    ) -> (OciDigest, Sha256HashValue, String) {
+        use containers_image_proxy::oci_spec::image::{ImageConfigurationBuilder, RootFsBuilder};
+
+        let (layer_data, diff_id) = build_baseimage();
+        let diff_id_digest: OciDigest = diff_id.parse().unwrap();
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let (layer_verity, _stats) = rt
+            .block_on(crate::import_layer(
+                repo,
+                &diff_id_digest,
+                None,
+                &mut layer_data.as_slice(),
+            ))
+            .unwrap();
+
+        let rootfs = RootFsBuilder::default()
+            .typ("layers")
+            .diff_ids(vec![diff_id.clone()])
+            .build()
+            .unwrap();
+        let config = ImageConfigurationBuilder::default()
+            .architecture("amd64")
+            .os("linux")
+            .rootfs(rootfs)
+            .build()
+            .unwrap();
+
+        let mut refs = std::collections::HashMap::new();
+        refs.insert(Box::from(diff_id.as_str()), layer_verity);
+
+        let (config_digest, config_verity) =
+            crate::write_config(repo, &config, refs, None, None, None, None).unwrap();
+        (config_digest, config_verity, diff_id)
+    }
+
+    #[test]
+    fn test_compute_per_layer_digests() {
+        use composefs::{repository::Repository, test::tempdir};
+        use rustix::fs::CWD;
+        use std::sync::Arc;
+
+        let repo_dir = tempdir();
+        let (repo, _) = Repository::<Sha256HashValue>::init_path(
+            CWD,
+            &repo_dir,
+            composefs::repository::RepositoryConfig::default().set_insecure(),
+        )
+        .unwrap();
+        let repo = Arc::new(repo);
+
+        let (config_digest, config_verity, _diff_id) = import_baseimage_with_config(&repo);
+
+        // Compute per-layer digests (with verity)
+        let digests =
+            compute_per_layer_digests(&repo, &config_digest, Some(&config_verity)).unwrap();
+        assert_eq!(digests.len(), 1, "expected exactly 1 per-layer digest");
+
+        // Determinism: calling again should produce the same result
+        let digests2 =
+            compute_per_layer_digests(&repo, &config_digest, Some(&config_verity)).unwrap();
+        assert_eq!(
+            digests, digests2,
+            "per-layer digests should be deterministic"
+        );
+
+        // Also works without verity (slower path that verifies content hashes)
+        let digests3 = compute_per_layer_digests(&repo, &config_digest, None).unwrap();
+        assert_eq!(
+            digests, digests3,
+            "verity and non-verity paths should agree"
+        );
+    }
+
+    #[test]
+    fn test_per_layer_digest_differs_from_merged() {
+        use composefs::{repository::Repository, test::tempdir};
+        use rustix::fs::CWD;
+        use std::sync::Arc;
+
+        let repo_dir = tempdir();
+        let (repo, _) = Repository::<Sha256HashValue>::init_path(
+            CWD,
+            &repo_dir,
+            composefs::repository::RepositoryConfig::default().set_insecure(),
+        )
+        .unwrap();
+        let repo = Arc::new(repo);
+
+        let (config_digest, config_verity, _diff_id) = import_baseimage_with_config(&repo);
+
+        let per_layer =
+            compute_per_layer_digests(&repo, &config_digest, Some(&config_verity)).unwrap();
+        assert_eq!(per_layer.len(), 1);
+
+        let merged_fs = create_filesystem(&repo, &config_digest, Some(&config_verity)).unwrap();
+        let merged_digest = merged_fs.compute_image_id(FormatVersion::V1);
+
+        // The merged filesystem applies transform_for_oci() which copies /usr metadata
+        // to the root, so the digests should differ.
+        assert_ne!(
+            per_layer[0], merged_digest,
+            "per-layer and merged digests should differ because of transform_for_oci"
+        );
     }
 
     #[test]
@@ -828,7 +1068,10 @@ mod test {
 
     #[tokio::test]
     async fn test_create_filesystem_filters_xattrs() -> Result<()> {
-        use composefs::{repository::Repository, test::tempdir};
+        use composefs::{
+            repository::{Repository, RepositoryConfig},
+            test::tempdir,
+        };
         use rustix::fs::CWD;
         use std::{ffi::OsStr, sync::Arc};
 

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -28,6 +28,10 @@ pub mod oci_image;
 pub mod oci_layout;
 /// Re-exported from [`composefs::progress`]; use that path directly in new code.
 pub mod progress;
+#[cfg(feature = "oci-client")]
+pub mod referrers;
+pub mod signature;
+pub mod signing;
 pub mod skopeo;
 pub mod tar;
 /// Shared wire types and client proxy for the `org.composefs.Oci` interface.
@@ -53,11 +57,17 @@ pub use composefs;
 use std::io::Read;
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::{Context, Result, ensure};
+use anyhow::{Context, Result, bail, ensure};
 /// OCI content-addressable digest type (e.g. `sha256:abcd...`).
 ///
 /// Re-exported from `oci-spec` for convenience.
 pub use containers_image_proxy::oci_spec::image::Digest as OciDigest;
+
+/// Re-export OCI image spec types for downstream consumers.
+pub use containers_image_proxy::oci_spec::image::{
+    Descriptor as OciDescriptor, DescriptorBuilder as OciDescriptorBuilder,
+    ImageConfiguration as OciImageConfiguration, MediaType as OciMediaType,
+};
 
 use containers_image_proxy::ImageProxyConfig;
 use containers_image_proxy::oci_spec::image::ImageConfiguration;
@@ -72,6 +82,7 @@ use composefs::{
 };
 
 use crate::skopeo::{OCI_BLOB_CONTENT_TYPE, OCI_CONFIG_CONTENT_TYPE, TAR_LAYER_CONTENT_TYPE};
+use crate::tar::get_entry;
 
 /// The content-type tag used to identify OCI layer (tar) splitstreams in the
 /// repository.
@@ -103,14 +114,25 @@ pub const BOOT_IMAGE_REF_KEY_V1: &str = "composefs.image.boot.v1";
 // Re-export key types for convenience
 #[cfg(feature = "boot")]
 pub use boot::generate_boot_image;
-pub use boot::{boot_image, remove_boot_image};
+pub use boot::{BOOT_IMAGE_REF_NAME, boot_image, remove_boot_image};
+pub use image::{
+    compute_merged_digest, compute_per_layer_digests, generate_merged_image,
+    generate_per_layer_images,
+};
 pub use oci_image::{
     ImageInfo, LayerInfo, OCI_REF_PREFIX, OciFsckError, OciFsckResult, OciImage, OciImageNotFound,
-    OciRefNotFound, SplitstreamInfo, add_referrer, layer_dumpfile, layer_info, layer_tar,
-    list_images, list_referrers, list_refs, oci_fsck, oci_fsck_image, remove_referrer,
-    remove_referrers_for_subject, resolve_ref, tag_image, untag_image,
+    OciRefNotFound, SplitstreamInfo, add_referrer, export_image_to_oci_layout,
+    export_referrers_to_oci_layout, layer_dumpfile, layer_info, layer_tar, list_images,
+    list_referrers, list_refs, oci_fsck, oci_fsck_image, remove_referrer,
+    remove_referrers_for_subject, resolve_ref, seal_image, seal_image_inline, tag_image,
+    untag_image,
 };
 pub use progress::{ComponentId, NullReporter, ProgressEvent, ProgressReporter, SharedReporter};
+pub use signature::{
+    NoSignatureArtifacts, SignatureVerificationFailed, VerificationEntry, VerificationReport,
+    sign_image, sign_image_inline, verify_image_report, verify_image_signatures,
+    verify_image_signatures_inline,
+};
 pub use skopeo::pull_image;
 
 /// Statistics from an image import operation.
@@ -543,6 +565,31 @@ pub fn extract_diff_ids(
     }
 }
 
+/// Lists the contents of a container layer stored in the repository.
+///
+/// Reads the split stream for the named layer and writes each tar entry to
+/// `out` in composefs dumpfile format.
+///
+/// This is a library function, so it takes an explicit writer rather than
+/// printing to stdout; callers (e.g. the CLI) pass `std::io::stdout()`.
+pub fn ls_layer<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    diff_id: &OciDigest,
+    mut out: impl std::io::Write,
+) -> Result<()> {
+    let mut split_stream = repo.open_stream(
+        &layer_identifier(diff_id),
+        None,
+        Some(TAR_LAYER_CONTENT_TYPE),
+    )?;
+
+    while let Some(entry) = get_entry(&mut split_stream)? {
+        writeln!(out, "{entry}")?;
+    }
+
+    Ok(())
+}
+
 /// Opens and parses a container configuration.
 ///
 /// Reads the OCI image configuration from the repository and returns an [`OpenConfig`]
@@ -794,6 +841,42 @@ pub fn write_config_raw<ObjectID: FsVerityHashValue>(
     Ok((config_digest, id))
 }
 
+/// Adds a composefs sealing annotation (the fs-verity digest of the merged
+/// composefs filesystem) to the given OCI image config.
+///
+/// This is the core of the "seal" operation: it computes the composefs
+/// image ID for the merged filesystem and stores it as the
+/// `containers.composefs.fsverity` label on the config.
+fn seal<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    config_name: &OciDigest,
+    config_verity: Option<&ObjectID>,
+) -> Result<ContentAndVerity<ObjectID>> {
+    let OpenConfig {
+        mut config,
+        layer_refs,
+        image_ref,
+        image_ref_v1,
+        boot_image_ref,
+        boot_image_ref_v1,
+    } = open_config(repo, config_name, config_verity)?;
+    let mut myconfig = config.config().clone().unwrap_or_default();
+    let labels = myconfig.labels_mut().get_or_insert_with(HashMap::new);
+    let fs = crate::image::create_filesystem(repo, config_name, config_verity)?;
+    let id = fs.compute_image_id(FormatVersion::V1);
+    labels.insert("containers.composefs.fsverity".to_string(), id.to_hex());
+    config.set_config(Some(myconfig));
+    write_config(
+        repo,
+        &config,
+        layer_refs,
+        image_ref.as_ref(),
+        image_ref_v1.as_ref(),
+        boot_image_ref.as_ref(),
+        boot_image_ref_v1.as_ref(),
+    )
+}
+
 /// Ensures a composefs EROFS image exists for the given OCI container image,
 /// linking it to the config splitstream so GC keeps it alive through the tag chain.
 ///
@@ -818,6 +901,26 @@ pub(crate) fn ensure_oci_composefs_erofs<ObjectID: FsVerityHashValue>(
     manifest_verity: Option<&ObjectID>,
     tag: Option<&str>,
 ) -> Result<Option<ObjectID>> {
+    ensure_oci_composefs_erofs_with_sig(repo, manifest_digest, manifest_verity, tag, &[])
+}
+
+/// Like [`ensure_oci_composefs_erofs`], but also enrolls kernel fs-verity
+/// signatures (`FS_IOC_ENABLE_VERITY`) on the generated EROFS image(s) when
+/// available.
+///
+/// Inline-annotation signatures are always picked up automatically, since
+/// they live directly on the manifest/config/layers that are opened here.
+/// `referrer_artifact_digests` additionally supplies any OCI referrer
+/// signature artifacts that the caller has already fetched and imported
+/// into `repo` (referrer-mode signatures require a registry round-trip that
+/// only the network-aware pull path can perform; other callers pass `&[]`).
+fn ensure_oci_composefs_erofs_with_sig<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    manifest_digest: &OciDigest,
+    manifest_verity: Option<&ObjectID>,
+    tag: Option<&str>,
+    referrer_artifact_digests: &[OciDigest],
+) -> Result<Option<ObjectID>> {
     let img = oci_image::OciImage::open(repo, manifest_digest, manifest_verity)?;
     if !img.is_container_image() {
         return Ok(None);
@@ -826,9 +929,11 @@ pub(crate) fn ensure_oci_composefs_erofs<ObjectID: FsVerityHashValue>(
     // Build the composefs filesystem from all layers
     let fs = image::create_filesystem(repo, img.config_digest(), Some(img.config_verity()))?;
 
+    let signatures = signature::collect_kernel_signatures(repo, &img, referrer_artifact_digests)?;
+
     // Commit as EROFS image(s) for all formats in the repository's default set.
     // No named ref — the GC link comes from the config splitstream ref.
-    let mut erofs_map = fs.commit_images(repo, None)?;
+    let mut erofs_map = fs.commit_images_with_sig(repo, None, Some(&signatures))?;
     let erofs_id_v2 = erofs_map.remove(&FormatVersion::V2);
     let erofs_id_v1 = erofs_map.remove(&FormatVersion::V1);
 
@@ -890,6 +995,21 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
     manifest_verity: Option<&ObjectID>,
     tag: Option<&str>,
 ) -> Result<Option<ObjectID>> {
+    ensure_oci_composefs_erofs_boot_with_sig(repo, manifest_digest, manifest_verity, tag, &[])
+}
+
+/// Like [`ensure_oci_composefs_erofs_boot`], but also enrolls kernel
+/// fs-verity signatures on the generated boot EROFS image(s); see
+/// [`ensure_oci_composefs_erofs_with_sig`] for details on
+/// `referrer_artifact_digests`.
+#[cfg(feature = "boot")]
+fn ensure_oci_composefs_erofs_boot_with_sig<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    manifest_digest: &OciDigest,
+    manifest_verity: Option<&ObjectID>,
+    tag: Option<&str>,
+    referrer_artifact_digests: &[OciDigest],
+) -> Result<Option<ObjectID>> {
     use composefs_boot::BootOps;
 
     let img = oci_image::OciImage::open(repo, manifest_digest, manifest_verity)?;
@@ -901,8 +1021,10 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
     let mut fs = image::create_filesystem(repo, img.config_digest(), Some(img.config_verity()))?;
     fs.transform_for_boot(repo)?;
 
+    let signatures = signature::collect_kernel_signatures(repo, &img, referrer_artifact_digests)?;
+
     // Commit as EROFS image(s) for all formats in the repository's default set.
-    let mut boot_erofs_map = fs.commit_images(repo, None)?;
+    let mut boot_erofs_map = fs.commit_images_with_sig(repo, None, Some(&signatures))?;
     let boot_erofs_id_v2 = boot_erofs_map.remove(&FormatVersion::V2);
     let boot_erofs_id_v1 = boot_erofs_map.remove(&FormatVersion::V1);
 
@@ -948,6 +1070,36 @@ fn ensure_oci_composefs_erofs_boot<ObjectID: FsVerityHashValue>(
     )?;
 
     Ok(Some(boot_erofs_id))
+}
+
+/// Mounts a sealed container filesystem at the specified mountpoint.
+///
+/// Looks up the composefs fs-verity digest stored in the image config's
+/// `containers.composefs.fsverity` label (set by `seal_image`), and
+/// uses it to mount the composefs overlay.
+pub fn mount<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: &str,
+    mountpoint: &str,
+    verity: Option<&ObjectID>,
+) -> Result<()> {
+    // Try to resolve tag names first. If name is a tag, open via the OCI
+    // image referencing path; otherwise fall back to direct config lookup
+    // for backward compatibility with raw config digests.
+    let config = if let Ok(img) = oci_image::OciImage::open_ref(repo, name) {
+        open_config(repo, img.config_digest(), None)?
+    } else {
+        let name_digest: OciDigest = name.parse().context("parsing config name as OCI digest")?;
+        open_config(repo, &name_digest, verity)?
+    };
+
+    let Some(id) = config
+        .config
+        .get_config_annotation("containers.composefs.fsverity")
+    else {
+        bail!("Can only mount sealed containers");
+    };
+    repo.mount_at(id, mountpoint, &composefs::mount::MountOptions::default())
 }
 
 #[cfg(test)]

--- a/crates/composefs-oci/src/oci_image.rs
+++ b/crates/composefs-oci/src/oci_image.rs
@@ -38,12 +38,15 @@
 //! This module handles both transparently. Use `is_container_image()` to check.
 
 use std::collections::{HashMap, HashSet};
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, ensure};
 use containers_image_proxy::oci_spec::image::{
-    Descriptor, Digest as OciDigest, ImageConfiguration, ImageManifest, MediaType,
+    Descriptor, DescriptorBuilder, Digest as OciDigest, ImageConfiguration, ImageManifest,
+    ImageManifestBuilder, MediaType,
 };
+use ocidir::OciRead;
 use rustix::fs::{AtFlags, Dir, Mode, OFlags, openat, readlinkat, unlinkat};
 use rustix::io::Errno;
 use serde::Serialize;
@@ -212,14 +215,8 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
         let manifest_verity = if let Some(v) = verity {
             v.clone()
         } else {
-            match repo.has_stream(&manifest_id)? {
-                Some(v) => v,
-                None => {
-                    return Err(anyhow::Error::new(OciImageNotFound {
-                        digest: manifest_digest.to_string(),
-                    }));
-                }
-            }
+            repo.has_stream(&manifest_id)?
+                .context("Manifest not found")?
         };
 
         Ok(Self {
@@ -347,6 +344,18 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
         self.config.as_ref().and_then(|c| c.created().as_deref())
     }
 
+    /// Returns the composefs seal digest, if sealed.
+    pub fn seal_digest(&self) -> Option<&str> {
+        self.config
+            .as_ref()
+            .and_then(|c| c.get_config_annotation("containers.composefs.fsverity"))
+    }
+
+    /// Returns whether this image has been sealed.
+    pub fn is_sealed(&self) -> bool {
+        self.seal_digest().is_some()
+    }
+
     /// Opens an artifact layer's backing object by index, returning a
     /// read-only file descriptor to the raw blob data.
     ///
@@ -471,7 +480,15 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
 
         let referrers_value: Vec<serde_json::Value> = referrers
             .iter()
-            .map(|(digest, _verity)| serde_json::json!({ "digest": digest }))
+            .map(|(digest, verity)| {
+                let mut entry = serde_json::json!({ "digest": digest });
+                if let Ok(referrer_img) = OciImage::open(repo, digest, Some(verity))
+                    && let Some(artifact_type) = referrer_img.manifest().artifact_type()
+                {
+                    entry["artifactType"] = serde_json::json!(artifact_type.to_string());
+                }
+                entry
+            })
             .collect();
 
         let mut result = serde_json::json!({
@@ -510,6 +527,10 @@ fn validate_ref_name(name: &str) -> Result<()> {
 ///
 /// The name should be in the format `image:tag` or just `image` (implies `:latest`).
 /// Names must not contain `@`, which is reserved for digest references.
+// TODO: Validate that manifest_digest actually exists in the repository
+// before creating the symlink. If the user passes a tag name instead
+// of a digest, this silently creates a broken symlink. Consider also
+// accepting tag names and resolving them via OciImage::open_ref().
 pub fn tag_image<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
     manifest_digest: &OciDigest,
@@ -545,7 +566,7 @@ pub fn resolve_ref<ObjectID: FsVerityHashValue>(
     // Read the symlink to get the manifest path
     let target = match readlinkat(repo.repo_fd(), &ref_path, vec![]) {
         Ok(t) => t,
-        Err(Errno::NOENT) => {
+        Err(rustix::io::Errno::NOENT) => {
             return Err(anyhow::Error::new(OciRefNotFound {
                 name: name.to_string(),
             }));
@@ -617,6 +638,8 @@ pub struct ImageInfo {
     pub manifest_digest: OciDigest,
     /// Whether this is a container image (vs artifact)
     pub is_container: bool,
+    /// Whether this image has been sealed (has composefs fsverity label)
+    pub sealed: bool,
     /// Architecture (empty for artifacts)
     pub architecture: String,
     /// OS (empty for artifacts)
@@ -643,6 +666,7 @@ pub fn list_images<ObjectID: FsVerityHashValue>(
                     name,
                     manifest_digest: digest,
                     is_container: img.is_container_image(),
+                    sealed: img.is_sealed(),
                     architecture: img.architecture(),
                     os: img.os(),
                     created: img.created().map(String::from),
@@ -759,6 +783,200 @@ pub(crate) fn rewrite_manifest<ObjectID: FsVerityHashValue, S: AsRef<str>>(
     let id = repo.write_stream(stream, &content_id, oci_ref.as_deref())?;
 
     Ok((manifest_digest.clone(), id))
+}
+
+/// Seals an image by tag: creates a sealed config, a new manifest referencing it,
+/// and updates the tag to point to the new manifest.
+///
+/// This is the complete seal workflow. It:
+/// 1. Opens the image by tag to get the original manifest and layer refs
+/// 2. Calls `seal()` to create a config with the fsverity label
+/// 3. Builds a new manifest referencing the sealed config (same layers)
+/// 4. Stores the new manifest and updates the tag
+///
+/// Returns the new manifest digest.
+// TODO: When re-sealing, the tag will point to a new manifest digest,
+// orphaning any existing referrer artifacts (signatures) that referenced the
+// old manifest. Consider warning the user, requiring --force, or cleaning up
+// old referrers via remove_referrers_for_subject(). If the sealed digest is
+// unchanged, this should ideally be a no-op.
+pub fn seal_image<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    name: &str,
+) -> Result<OciDigest> {
+    let img = OciImage::open_ref(repo, name)?;
+    ensure!(
+        img.is_container_image(),
+        "Can only seal container images, not artifacts"
+    );
+
+    let (sealed_config_digest, sealed_config_verity) =
+        crate::seal(repo, img.config_digest(), None)?;
+
+    // Build a new config descriptor for the sealed config
+    let sealed_config_json = {
+        let config_id = crate::config_identifier(&sealed_config_digest);
+        let (data, _) = read_external_splitstream(
+            repo,
+            &config_id,
+            Some(&sealed_config_verity),
+            Some(OCI_CONFIG_CONTENT_TYPE),
+        )?;
+        data
+    };
+
+    let new_config_descriptor = DescriptorBuilder::default()
+        .media_type(MediaType::ImageConfig)
+        .digest(sealed_config_digest.clone())
+        .size(sealed_config_json.len() as u64)
+        .build()
+        .context("building config descriptor")?;
+
+    // Build new manifest with same layers but sealed config
+    let new_manifest = ImageManifestBuilder::default()
+        .schema_version(2u32)
+        .media_type(MediaType::ImageManifest)
+        .config(new_config_descriptor)
+        .layers(img.manifest().layers().to_vec())
+        .build()
+        .context("building sealed manifest")?;
+
+    let new_manifest_json = new_manifest.to_string()?;
+    let new_manifest_digest = crate::sha256_content_digest(new_manifest_json.as_bytes());
+
+    let layer_refs_vec: Vec<(Box<str>, ObjectID)> = img
+        .layer_refs()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    write_manifest(
+        repo,
+        &new_manifest,
+        &new_manifest_digest,
+        &sealed_config_verity,
+        &layer_refs_vec,
+        Some(name),
+    )?;
+
+    Ok(new_manifest_digest)
+}
+
+/// Seals an image by tag in inline mode: embeds digest annotations directly in
+/// the OCI image manifest config descriptor, layer descriptors, and top-level annotations.
+pub fn seal_image_inline<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    name: &str,
+) -> Result<OciDigest> {
+    let img = OciImage::open_ref(repo, name)?;
+    ensure!(
+        img.is_container_image(),
+        "Can only seal container images, not artifacts"
+    );
+
+    let (sealed_config_digest, sealed_config_verity) =
+        crate::seal(repo, img.config_digest(), None)?;
+
+    // Build a new config descriptor for the sealed config
+    let sealed_config_json = {
+        let config_id = crate::config_identifier(&sealed_config_digest);
+        let (data, _) = read_external_splitstream(
+            repo,
+            &config_id,
+            Some(&sealed_config_verity),
+            Some(OCI_CONFIG_CONTENT_TYPE),
+        )?;
+        data
+    };
+
+    let per_layer_digests = crate::image::compute_per_layer_digests(
+        repo,
+        img.config_digest(),
+        Some(img.config_verity()),
+    )?;
+    let merged_digest =
+        crate::image::compute_merged_digest(repo, img.config_digest(), Some(img.config_verity()))?;
+
+    let algorithm = ObjectID::ALGORITHM;
+
+    let mut config_annotations = img
+        .manifest()
+        .config()
+        .annotations()
+        .as_ref()
+        .cloned()
+        .unwrap_or_default();
+    config_annotations.insert(
+        crate::signature::SignatureType::Config.annotation_key(algorithm),
+        sealed_config_verity.to_hex(),
+    );
+
+    let new_config_descriptor = DescriptorBuilder::default()
+        .media_type(MediaType::ImageConfig)
+        .digest(sealed_config_digest.clone())
+        .size(sealed_config_json.len() as u64)
+        .annotations(config_annotations)
+        .build()
+        .context("building config descriptor")?;
+
+    let mut new_layers = Vec::new();
+    for (i, layer) in img.manifest().layers().iter().enumerate() {
+        let mut annotations = layer.annotations().as_ref().cloned().unwrap_or_default();
+        annotations.insert(
+            crate::signature::SignatureType::Layer.annotation_key(algorithm),
+            per_layer_digests
+                .get(i)
+                .ok_or_else(|| anyhow::anyhow!("manifest has more layers than config diff_ids"))?
+                .to_hex(),
+        );
+        let new_layer = DescriptorBuilder::default()
+            .media_type(layer.media_type().clone())
+            .digest(layer.digest().clone())
+            .size(layer.size())
+            .annotations(annotations)
+            .build()
+            .context("building layer descriptor")?;
+        new_layers.push(new_layer);
+    }
+
+    let mut manifest_annotations = img
+        .manifest()
+        .annotations()
+        .as_ref()
+        .cloned()
+        .unwrap_or_default();
+    manifest_annotations.insert(
+        crate::signature::SignatureType::Merged.annotation_key(algorithm),
+        merged_digest.to_hex(),
+    );
+
+    // Build new manifest with same layers but sealed config
+    let new_manifest = ImageManifestBuilder::default()
+        .schema_version(img.manifest().schema_version())
+        .media_type(MediaType::ImageManifest)
+        .config(new_config_descriptor)
+        .layers(new_layers)
+        .annotations(manifest_annotations)
+        .build()
+        .context("building sealed manifest")?;
+
+    let new_manifest_json = new_manifest.to_string()?;
+    let new_manifest_digest = crate::sha256_content_digest(new_manifest_json.as_bytes());
+
+    let layer_refs_vec: Vec<(Box<str>, ObjectID)> = img
+        .layer_refs()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    write_manifest(
+        repo,
+        &new_manifest,
+        &new_manifest_digest,
+        &sealed_config_verity,
+        &layer_refs_vec,
+        Some(name),
+    )?;
+
+    Ok(new_manifest_digest)
 }
 
 /// Checks if a manifest exists.
@@ -1660,6 +1878,443 @@ pub fn layer_tar<ObjectID: FsVerityHashValue>(
     )
 }
 
+// =============================================================================
+// OCI Layout Export
+// =============================================================================
+
+/// Export an OCI image to an OCI layout directory.
+///
+/// Writes the manifest, config, and all layers (as uncompressed tar) to the
+/// OCI layout using the `ocidir` crate for atomic, content-addressed writes.
+/// Since composefs stores layers as uncompressed splitstreams, the exported
+/// manifest is rewritten with uncompressed layer descriptors.
+///
+/// If `tag` is provided, the manifest is tagged in the index.
+/// If `include_referrers` is true, also exports any referrer artifacts
+/// (composefs signature artifacts).
+pub fn export_image_to_oci_layout<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    image: &OciImage<ObjectID>,
+    oci_layout_path: &std::path::Path,
+    tag: Option<&str>,
+    include_referrers: bool,
+) -> Result<()> {
+    use containers_image_proxy::oci_spec::image::{
+        ImageManifestBuilder, Platform, PlatformBuilder,
+    };
+    use std::io::Write;
+
+    std::fs::create_dir_all(oci_layout_path).context("creating OCI layout directory")?;
+    let cap_dir = ocidir::cap_std::fs::Dir::open_ambient_dir(
+        oci_layout_path,
+        ocidir::cap_std::ambient_authority(),
+    )
+    .context("opening OCI layout directory")?;
+    let ocidir = ocidir::OciDir::ensure(cap_dir).context("ensuring OCI layout")?;
+
+    // 1. Write the config blob
+    let config_json = image.read_config_json(repo)?;
+    let mut config_blob = ocidir.create_blob().context("creating config blob")?;
+    config_blob
+        .write_all(&config_json)
+        .context("writing config blob")?;
+    let config_blob = config_blob.complete().context("completing config blob")?;
+    let config_descriptor = config_blob
+        .descriptor()
+        .media_type(image.manifest().config().media_type().clone())
+        .build()
+        .context("building config descriptor")?;
+
+    // 2. Write each tar layer and build new descriptors
+    let diff_ids = image.layer_diff_ids();
+    let mut new_layer_descriptors = Vec::with_capacity(diff_ids.len());
+
+    for diff_id in &diff_ids {
+        let diff_id_digest: OciDigest = diff_id.parse().context("parsing diff_id")?;
+        let mut layer_blob = ocidir.create_blob().context("creating layer blob")?;
+        layer_tar(repo, &diff_id_digest, &mut layer_blob)
+            .with_context(|| format!("reconstituting layer tar for {diff_id}"))?;
+        let layer_blob = layer_blob.complete().context("completing layer blob")?;
+        let descriptor = layer_blob
+            .descriptor()
+            .media_type(MediaType::ImageLayer)
+            .build()
+            .context("building layer descriptor")?;
+        new_layer_descriptors.push(descriptor);
+    }
+
+    // 3. Build a new manifest with the uncompressed layer descriptors
+    let original_manifest = image.manifest();
+    let mut manifest_builder = ImageManifestBuilder::default()
+        .schema_version(original_manifest.schema_version())
+        .media_type(MediaType::ImageManifest)
+        .config(config_descriptor)
+        .layers(new_layer_descriptors);
+
+    if let Some(annotations) = original_manifest.annotations() {
+        manifest_builder = manifest_builder.annotations(annotations.clone());
+    }
+
+    let new_manifest = manifest_builder.build().context("building manifest")?;
+
+    // 4. Write manifest and update index.json atomically via ocidir
+    let platform: Platform = PlatformBuilder::default()
+        .architecture(image.architecture().as_str())
+        .os(image.os().as_str())
+        .build()
+        .context("building platform")?;
+
+    let new_manifest_desc = ocidir
+        .insert_manifest(new_manifest, tag, platform)
+        .context("inserting manifest into OCI layout")?;
+
+    // 5. Optionally export referrers, rewriting subject.digest to match
+    //    the new manifest digest (which differs from the original because
+    //    layers are reconstituted as uncompressed tars).
+    if include_referrers {
+        let new_digest = new_manifest_desc.digest().to_string();
+        export_referrers_to_oci_layout(
+            repo,
+            image.manifest_digest(),
+            oci_layout_path,
+            Some(&new_digest),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Exports referrer artifacts (e.g., signature artifacts) for a subject image
+/// to an OCI layout directory.
+///
+/// This function:
+/// 1. Lists all referrers for the given subject manifest digest
+/// 2. For each referrer artifact:
+///    - Writes config, layer, and manifest blobs via `ocidir::OciDir`
+///    - Optionally rewrites the `subject.digest` field in the artifact manifest
+///    - Updates the index.json with artifact_type and annotations for
+///      OCI Referrers API discoverability
+///
+/// The OCI layout directory must already exist (e.g., from `export_image_to_oci_layout`
+/// or `skopeo copy`). This enables tools like skopeo to see signature artifacts
+/// when pulling.
+///
+/// # Arguments
+///
+/// * `repo` - The composefs repository
+/// * `subject_digest` - The manifest digest of the subject image in the repo (sha256:...)
+/// * `oci_layout_path` - Path to the OCI layout directory
+/// * `rewrite_subject_digest` - If `Some`, rewrite the artifact's `subject.digest` to this
+///   value. This is needed when the exported image manifest has a different digest than the
+///   original (e.g., because layers were reconstituted as uncompressed tars).
+///
+/// # Returns
+///
+/// The number of referrer artifacts exported.
+pub fn export_referrers_to_oci_layout<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    subject_digest: &OciDigest,
+    oci_layout_path: &std::path::Path,
+    rewrite_subject_digest: Option<&str>,
+) -> Result<usize> {
+    use containers_image_proxy::oci_spec::image::ImageIndexBuilder;
+    use std::io::Write;
+
+    std::fs::create_dir_all(oci_layout_path).context("creating OCI layout directory")?;
+    let cap_dir = ocidir::cap_std::fs::Dir::open_ambient_dir(
+        oci_layout_path,
+        ocidir::cap_std::ambient_authority(),
+    )
+    .context("opening OCI layout directory")?;
+    let ocidir = ocidir::OciDir::ensure(cap_dir).context("ensuring OCI layout")?;
+
+    let referrers = list_referrers(repo, subject_digest)?;
+    let mut exported_count = 0;
+
+    // Read existing index to check for duplicates and to append to
+    let mut index = ocidir.read_index().unwrap_or_else(|_| {
+        ImageIndexBuilder::default()
+            .schema_version(2u32)
+            .manifests(Vec::new())
+            .build()
+            .unwrap()
+    });
+
+    for (artifact_digest, artifact_verity) in &referrers {
+        // Skip if already in the index
+        let already_in_index = index
+            .manifests()
+            .iter()
+            .any(|d: &Descriptor| d.digest() == artifact_digest);
+        if already_in_index {
+            exported_count += 1;
+            continue;
+        }
+
+        let artifact = OciImage::open(repo, artifact_digest, Some(artifact_verity))
+            .with_context(|| format!("opening referrer artifact {artifact_digest}"))?;
+
+        let manifest = artifact.manifest();
+
+        // Write config blob
+        let config_data = match read_config_blob(repo, manifest.config().digest()) {
+            Ok(data) => data,
+            Err(_) => b"{}".to_vec(),
+        };
+        let mut config_blob = ocidir.create_blob().context("creating config blob")?;
+        config_blob
+            .write_all(&config_data)
+            .context("writing config blob")?;
+        config_blob.complete().context("completing config blob")?;
+
+        // Write each layer blob
+        for layer_desc in manifest.layers() {
+            let layer_digest = layer_desc.digest();
+            let layer_data = open_blob(repo, layer_digest, None)
+                .with_context(|| format!("reading layer blob {layer_digest}"))?;
+            let mut layer_blob = ocidir.create_blob().context("creating layer blob")?;
+            layer_blob
+                .write_all(&layer_data)
+                .context("writing layer blob")?;
+            layer_blob.complete().context("completing layer blob")?;
+        }
+
+        // Optionally rewrite subject.digest to match the exported image manifest
+        let manifest_json = if let Some(new_digest) = rewrite_subject_digest {
+            let mut rewritten = manifest.clone();
+            if let Some(ref old_subject) = rewritten.subject().clone() {
+                use containers_image_proxy::oci_spec::image::DescriptorBuilder;
+                let mut new_subject_builder = DescriptorBuilder::default()
+                    .media_type(old_subject.media_type().clone())
+                    .digest(
+                        containers_image_proxy::oci_spec::image::Digest::from_str(new_digest)
+                            .context("parsing new subject digest")?,
+                    )
+                    .size(old_subject.size());
+                if let Some(annotations) = old_subject.annotations() {
+                    new_subject_builder = new_subject_builder.annotations(annotations.clone());
+                }
+                let new_subject = new_subject_builder
+                    .build()
+                    .context("building rewritten subject descriptor")?;
+                rewritten.set_subject(Some(new_subject));
+            }
+            rewritten.to_string()?
+        } else {
+            manifest.to_string()?
+        };
+
+        // Write the manifest blob
+        let mut manifest_blob = ocidir.create_blob().context("creating manifest blob")?;
+        manifest_blob
+            .write_all(manifest_json.as_bytes())
+            .context("writing manifest blob")?;
+        let manifest_blob = manifest_blob
+            .complete()
+            .context("completing manifest blob")?;
+
+        // Build the index descriptor with artifact_type and annotations
+        // for OCI Referrers API discoverability. We can't use insert_manifest()
+        // here because it doesn't propagate artifact_type to the index descriptor.
+        let mut desc_builder = manifest_blob
+            .descriptor()
+            .media_type(containers_image_proxy::oci_spec::image::MediaType::ImageManifest);
+
+        if let Some(artifact_type) = manifest.artifact_type() {
+            desc_builder = desc_builder.artifact_type(artifact_type.clone());
+        }
+        if let Some(annotations) = manifest.annotations() {
+            desc_builder = desc_builder.annotations(annotations.clone());
+        }
+
+        let manifest_desc = desc_builder
+            .build()
+            .context("building manifest descriptor")?;
+
+        let mut manifests = index.manifests().clone();
+        manifests.push(manifest_desc);
+        index = ImageIndexBuilder::default()
+            .schema_version(index.schema_version())
+            .manifests(manifests)
+            .build()
+            .context("rebuilding index")?;
+
+        exported_count += 1;
+    }
+
+    // Write updated index.json atomically
+    use cap_std_ext::dirext::CapStdExtDirExt;
+    ocidir
+        .dir()
+        .atomic_replace_with("index.json", |w| -> Result<()> {
+            serde_json::to_writer(w, &index)?;
+            Ok(())
+        })
+        .context("writing index.json")?;
+
+    Ok(exported_count)
+}
+
+/// Helper to read a config blob from the repo.
+fn read_config_blob<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    config_digest: &OciDigest,
+) -> Result<Vec<u8>> {
+    let config_id = crate::config_identifier(config_digest);
+    let (data, _named_refs) = read_external_splitstream(
+        repo,
+        &config_id,
+        None,
+        Some(crate::skopeo::OCI_CONFIG_CONTENT_TYPE),
+    )?;
+    Ok(data)
+}
+
+/// Imports referrer artifacts (e.g., signature artifacts) from an OCI layout directory
+/// for a given subject manifest digest.
+///
+/// This function:
+/// 1. Reads the index.json from the OCI layout via `ocidir::OciDir`
+/// 2. Finds entries with the specified artifactType
+/// 3. For each matching artifact, reads blobs via `ocidir` and imports
+///    them into the composefs repository
+///
+/// This is the inverse of `export_referrers_to_oci_layout`.
+///
+/// # Arguments
+///
+/// * `repo` - The composefs repository to import into
+/// * `oci_layout_path` - Path to the OCI layout directory
+/// * `subject_digest` - The manifest digest of the subject image (sha256:...)
+/// * `artifact_type` - The artifactType to filter on (e.g., "application/vnd.composefs.erofs-alongside.v1")
+///
+/// # Returns
+///
+/// The number of referrer artifacts imported.
+pub fn import_referrers_from_oci_layout<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    oci_layout_path: &std::path::Path,
+    subject_digest: &OciDigest,
+    artifact_type: &str,
+) -> Result<usize> {
+    use containers_image_proxy::oci_spec::image::ImageManifest;
+    use std::io::Read;
+
+    let cap_dir = ocidir::cap_std::fs::Dir::open_ambient_dir(
+        oci_layout_path,
+        ocidir::cap_std::ambient_authority(),
+    )
+    .context("opening OCI layout directory")?;
+    let ocidir = ocidir::OciDir::open(cap_dir).context("opening OCI layout")?;
+
+    let index = ocidir
+        .read_index()
+        .context("reading index.json from OCI layout")?;
+
+    let mut imported_count = 0;
+
+    for manifest_desc in index.manifests() {
+        // Check if this entry has the right artifactType
+        let is_matching_artifact = matches!(
+            manifest_desc.artifact_type(),
+            Some(containers_image_proxy::oci_spec::image::MediaType::Other(t)) if t == artifact_type
+        );
+
+        if !is_matching_artifact {
+            continue;
+        }
+
+        let artifact_digest = manifest_desc.digest().clone();
+
+        // Read the artifact manifest via ocidir
+        let manifest: ImageManifest = ocidir
+            .read_json_blob(manifest_desc)
+            .with_context(|| format!("reading artifact manifest {artifact_digest}"))?;
+
+        // Check if this artifact's subject matches our target
+        let matches_subject = match manifest.subject() {
+            Some(subject) => subject.digest() == subject_digest,
+            None => false,
+        };
+
+        if !matches_subject {
+            continue;
+        }
+
+        // Import the artifact manifest to repo
+        let manifest_content_id = manifest_identifier(&artifact_digest);
+        if repo.has_stream(&manifest_content_id)?.is_some() {
+            imported_count += 1;
+            continue;
+        }
+
+        // Read config blob via ocidir
+        let config_digest = manifest.config().digest().clone();
+        let config_data = match ocidir.read_blob(manifest.config()) {
+            Ok(mut f) => {
+                let mut data = Vec::new();
+                f.read_to_end(&mut data)
+                    .context("reading config blob data")?;
+                data
+            }
+            Err(_) => b"{}".to_vec(),
+        };
+
+        // Store config in composefs repo
+        let config_content_id = crate::config_identifier(&config_digest);
+        let config_verity = if let Some(v) = repo.has_stream(&config_content_id)? {
+            v
+        } else {
+            let mut config_stream = repo.create_stream(crate::skopeo::OCI_CONFIG_CONTENT_TYPE)?;
+            config_stream.write_external(&config_data)?;
+            repo.write_stream(config_stream, &config_content_id, None)?
+        };
+
+        // Read and store each layer blob
+        let mut layer_verities = Vec::new();
+        for layer_desc in manifest.layers() {
+            let layer_digest = layer_desc.digest().clone();
+
+            let layer_content_id = blob_identifier(&layer_digest);
+            let layer_verity = if let Some(v) = repo.has_stream(&layer_content_id)? {
+                v
+            } else {
+                let mut f = ocidir
+                    .read_blob(layer_desc)
+                    .with_context(|| format!("reading layer blob {layer_digest}"))?;
+                let mut layer_data = Vec::new();
+                f.read_to_end(&mut layer_data)
+                    .with_context(|| format!("reading layer blob data {layer_digest}"))?;
+                let mut layer_stream = repo.create_stream(crate::skopeo::OCI_BLOB_CONTENT_TYPE)?;
+                layer_stream.write_external(&layer_data)?;
+                repo.write_stream(layer_stream, &layer_content_id, None)?
+            };
+            layer_verities.push((layer_digest, layer_verity));
+        }
+
+        // Store the manifest
+        let manifest_json = manifest.to_string()?;
+        let mut manifest_stream = repo.create_stream(crate::skopeo::OCI_MANIFEST_CONTENT_TYPE)?;
+
+        let config_key = format!("config:{config_digest}");
+        manifest_stream.add_named_stream_ref(&config_key, &config_verity);
+
+        for (layer_digest, layer_verity) in &layer_verities {
+            manifest_stream.add_named_stream_ref(layer_digest.as_ref(), layer_verity);
+        }
+
+        manifest_stream.write_external(manifest_json.as_bytes())?;
+        repo.write_stream(manifest_stream, &manifest_content_id, None)?;
+
+        // Add to referrer index
+        add_referrer(repo, subject_digest, &artifact_digest)?;
+
+        imported_count += 1;
+    }
+
+    Ok(imported_count)
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1864,11 +2519,11 @@ mod test {
         assert!(digest.as_ref().starts_with("sha256:"));
 
         // Read back with verity (fast path)
-        let read_data = open_blob(&repo, &digest, Some(&verity)).unwrap();
+        let read_data = open_blob(repo, &digest, Some(&verity)).unwrap();
         assert_eq!(read_data, data);
 
         // Read back without verity (verifies content hash)
-        let read_data2 = open_blob(&repo, &digest, None).unwrap();
+        let read_data2 = open_blob(repo, &digest, None).unwrap();
         assert_eq!(read_data2, data);
     }
 
@@ -1932,7 +2587,7 @@ mod test {
             "Manifest splitstream should contain external object references"
         );
 
-        let img = OciImage::open(&repo, &manifest_digest, Some(&manifest_verity)).unwrap();
+        let img = OciImage::open(repo, &manifest_digest, Some(&manifest_verity)).unwrap();
         let manifest_json = img.manifest().to_string().unwrap();
         let expected_verity: Sha256HashValue =
             composefs::fsverity::compute_verity(manifest_json.as_bytes());
@@ -2033,7 +2688,7 @@ mod test {
         let manifest_digest = hash_sha256(manifest_json.as_bytes());
 
         let (stored_digest, manifest_verity) = write_manifest(
-            &repo,
+            repo,
             &manifest,
             &manifest_digest,
             &config_verity,
@@ -2044,7 +2699,7 @@ mod test {
 
         assert_eq!(stored_digest, manifest_digest);
 
-        let opened = OciImage::open(&repo, &manifest_digest, Some(&manifest_verity)).unwrap();
+        let opened = OciImage::open(repo, &manifest_digest, Some(&manifest_verity)).unwrap();
 
         assert!(!opened.is_container_image()); // Not a container image
         assert_eq!(opened.manifest_digest(), &manifest_digest);
@@ -2058,12 +2713,12 @@ mod test {
         let by_tag = OciImage::open_ref(&repo, "my-wasm-artifact:v1").unwrap();
         assert_eq!(by_tag.manifest_digest(), &manifest_digest);
 
-        let images = list_images(&repo).unwrap();
+        let images = list_images(repo).unwrap();
         assert_eq!(images.len(), 1);
         assert_eq!(images[0].name, "my-wasm-artifact:v1");
         assert!(!images[0].is_container);
 
-        let read_wasm = open_blob(&repo, &blob_digest, Some(&blob_verity)).unwrap();
+        let read_wasm = open_blob(repo, &blob_digest, Some(&blob_verity)).unwrap();
         assert_eq!(read_wasm, wasm_bytes);
     }
 
@@ -2146,7 +2801,7 @@ mod test {
         let manifest_digest = hash_sha256(manifest_json.as_bytes());
 
         let (_stored_digest, manifest_verity) = write_manifest(
-            &repo,
+            repo,
             &manifest,
             &manifest_digest,
             &config_verity,
@@ -2155,7 +2810,7 @@ mod test {
         )
         .unwrap();
 
-        let opened = OciImage::open(&repo, &manifest_digest, Some(&manifest_verity)).unwrap();
+        let opened = OciImage::open(repo, &manifest_digest, Some(&manifest_verity)).unwrap();
         assert!(!opened.is_container_image());
         assert_eq!(opened.layer_descriptors().len(), 1);
         assert_eq!(
@@ -2163,17 +2818,17 @@ mod test {
             &MediaType::Other("text/spdx+json".to_string())
         );
 
-        let fd = opened.open_layer_fd(&repo, 0).unwrap();
+        let fd = opened.open_layer_fd(repo, 0).unwrap();
         let mut recovered = vec![];
         File::from(fd).read_to_end(&mut recovered).unwrap();
         assert_eq!(recovered, sbom_data);
 
-        assert!(opened.open_layer_fd(&repo, 1).is_err());
+        assert!(opened.open_layer_fd(repo, 1).is_err());
 
         let gc = repo.gc(&[]).unwrap();
         assert_eq!(gc.objects_removed, 0);
 
-        untag_image(&repo, "my-sbom:v1").unwrap();
+        untag_image(repo, "my-sbom:v1").unwrap();
         let gc = repo.gc(&[]).unwrap();
         assert!(gc.objects_removed > 0);
     }
@@ -2185,11 +2840,11 @@ mod test {
         let repo = &test_repo.repo;
 
         let (digest, verity, _) = create_test_image(repo, Some("myimage:v1"), "amd64");
-        let img = OciImage::open(&repo, &digest, Some(&verity)).unwrap();
+        let img = OciImage::open(repo, &digest, Some(&verity)).unwrap();
         assert!(img.is_container_image());
 
         // Tar layer should be rejected
-        let err = img.open_layer_fd(&repo, 0).unwrap_err();
+        let err = img.open_layer_fd(repo, 0).unwrap_err();
         let msg = format!("{err}");
         assert!(msg.contains("does not support tar layers"), "got: {msg}");
     }
@@ -2302,7 +2957,7 @@ mod test {
         let manifest_digest = hash_sha256(manifest_json.as_bytes());
 
         let (_stored_digest, _manifest_verity) = write_manifest(
-            &repo,
+            repo,
             &manifest,
             &manifest_digest,
             &config_verity,

--- a/crates/composefs-oci/src/referrers.rs
+++ b/crates/composefs-oci/src/referrers.rs
@@ -1,0 +1,377 @@
+//! Fetch OCI referrer artifacts from a remote registry.
+//!
+//! This module supplements the skopeo-based pull (which doesn't support the
+//! OCI Referrers API) by querying the registry directly via `oci-client` for
+//! artifacts that reference the pulled image's manifest digest.
+//!
+//! The primary use case is fetching composefs signature artifacts so that
+//! `--require-signature` works after pulling a sealed+signed image.
+
+use std::str::FromStr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+
+use composefs::fsverity::FsVerityHashValue;
+use composefs::repository::Repository;
+use oci_client::Client;
+use oci_client::Reference;
+use oci_client::client::ClientConfig;
+use oci_client::secrets::RegistryAuth;
+
+use crate::OciDigest;
+use crate::oci_image;
+use crate::signature::METADATA_ARTIFACT_TYPE;
+
+/// Fetch OCI referrer artifacts from a remote registry and import them
+/// into the local composefs repository.
+///
+/// This supplements the skopeo-based pull (which doesn't support the
+/// OCI Referrers API) by querying the registry directly for artifacts
+/// that reference the pulled image's manifest digest.
+///
+/// `registry_ref` is the image reference as used for pulling, e.g.
+/// `"docker://docker.io/myorg/myimage:latest"`. Transport prefixes are
+/// stripped automatically.
+///
+/// `registry_manifest_digest` is the manifest digest as known by the
+/// registry — used to query the Referrers API and tag scheme fallback.
+///
+/// `local_subject_digest` is the manifest digest as stored in the local
+/// composefs repo (which may differ from the registry digest due to
+/// config rewriting for EROFS refs). Used to register the referrer
+/// relationship locally via `add_referrer`.
+///
+/// Returns the number of referrer artifacts imported.
+///
+/// This is a convenience wrapper around [`fetch_referrer_artifacts`] and
+/// [`register_referrers`] for callers that don't need kernel signature
+/// enrollment and so don't care about the digest being available before
+/// EROFS generation. Callers that do (i.e. the registry pull path) should
+/// call the two halves separately, fetching referrers *before* generating
+/// EROFS images and registering them (with the now-known local digest)
+/// afterwards.
+pub async fn fetch_and_import_referrers<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    registry_ref: &str,
+    registry_manifest_digest: &str,
+    local_subject_digest: &str,
+) -> Result<usize> {
+    let artifacts = fetch_referrer_artifacts(repo, registry_ref, registry_manifest_digest).await?;
+    register_referrers(repo, local_subject_digest, &artifacts)
+}
+
+/// Fetch OCI referrer artifacts from a remote registry and import their
+/// manifest, config, and layer (signature blob) content into the local
+/// composefs repository, without registering the referrer relationship.
+///
+/// This is split out from [`fetch_and_import_referrers`] so that the
+/// network fetch (and the resulting locally-available signature content)
+/// can happen *before* EROFS images are generated, which is required for
+/// kernel fs-verity signature enrollment to see referrer-mode signatures.
+/// Call [`register_referrers`] afterwards, once the local (possibly
+/// EROFS-rewritten) subject digest is known, to make the artifacts
+/// discoverable via `list_referrers`/`cfsctl oci verify`.
+///
+/// `registry_ref` is the image reference as used for pulling, e.g.
+/// `"docker://docker.io/myorg/myimage:latest"`. Transport prefixes are
+/// stripped automatically.
+///
+/// `registry_manifest_digest` is the manifest digest as known by the
+/// registry — used to query the Referrers API and tag scheme fallback.
+///
+/// Returns the digests of all referrer artifacts now available locally
+/// (whether freshly imported or already present).
+pub async fn fetch_referrer_artifacts<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    registry_ref: &str,
+    registry_manifest_digest: &str,
+) -> Result<Vec<OciDigest>> {
+    // Strip transport prefixes that skopeo uses but oci-client doesn't understand
+    let clean_ref = strip_transport_prefix(registry_ref);
+
+    // Parse into an oci-client Reference
+    let reference = Reference::from_str(clean_ref)
+        .with_context(|| format!("parsing image reference '{clean_ref}' for referrer lookup"))?;
+
+    // Create a reference with the registry manifest digest for the referrers API.
+    // The referrers API needs the registry-side digest, not the local one.
+    let digest_ref = reference.clone_with_digest(registry_manifest_digest.to_string());
+
+    let client = Client::new(ClientConfig::default());
+
+    // Fetch the referrers index, filtering by our artifact type.
+    // Try the OCI Referrers API first, then fall back to the tag scheme.
+    // Some registries (e.g. GHCR) don't properly support the referrers API
+    // but store referrers under a tag named "sha256-<hex>" per the OCI 1.1
+    // referrers tag scheme fallback.
+    let index = match client
+        .pull_referrers(&digest_ref, Some(METADATA_ARTIFACT_TYPE))
+        .await
+    {
+        Ok(idx) => idx,
+        Err(api_err) => {
+            tracing::debug!("Referrers API failed ({api_err:#}), trying tag scheme fallback");
+            fetch_referrers_by_tag(&client, &reference, registry_manifest_digest).await?
+        }
+    };
+
+    if index.manifests.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut artifact_digests = Vec::new();
+
+    for entry in &index.manifests {
+        let artifact_digest_str = &entry.digest;
+        let artifact_digest: OciDigest = artifact_digest_str
+            .parse()
+            .with_context(|| format!("parsing artifact digest {artifact_digest_str}"))?;
+
+        // Check if we already have this artifact
+        let manifest_content_id = oci_image::manifest_identifier(&artifact_digest);
+        if repo.has_stream(&manifest_content_id)?.is_some() {
+            tracing::debug!("Already have referrer artifact {artifact_digest_str}");
+            artifact_digests.push(artifact_digest);
+            continue;
+        }
+
+        // Fetch the artifact manifest
+        let artifact_ref = reference.clone_with_digest(artifact_digest_str.clone());
+        let (raw_manifest_bytes, _manifest_content_digest) = client
+            .pull_manifest_raw(
+                &artifact_ref,
+                &RegistryAuth::Anonymous,
+                &["application/vnd.oci.image.manifest.v1+json"],
+            )
+            .await
+            .with_context(|| format!("fetching artifact manifest {artifact_digest_str}"))?;
+
+        let manifest: containers_image_proxy::oci_spec::image::ImageManifest =
+            serde_json::from_slice(&raw_manifest_bytes)
+                .with_context(|| format!("parsing artifact manifest {artifact_digest_str}"))?;
+
+        // Import the config blob
+        let config_digest = manifest.config().digest().clone();
+        let config_content_id = crate::config_identifier(&config_digest);
+        let config_verity = if let Some(v) = repo.has_stream(&config_content_id)? {
+            v
+        } else {
+            // Fetch config blob from registry
+            let config_data = fetch_blob(&client, &reference, config_digest.as_ref())
+                .await
+                .with_context(|| format!("fetching config blob {config_digest}"))?;
+            let mut config_stream = repo.create_stream(crate::skopeo::OCI_CONFIG_CONTENT_TYPE)?;
+            config_stream.write_external(&config_data)?;
+            repo.write_stream(config_stream, &config_content_id, None)?
+        };
+
+        // Import each layer blob
+        let mut layer_verities: Vec<(OciDigest, ObjectID)> = Vec::new();
+        for layer_desc in manifest.layers() {
+            let layer_digest = layer_desc.digest().clone();
+            let layer_content_id = oci_image::blob_identifier(&layer_digest);
+            let layer_verity = if let Some(v) = repo.has_stream(&layer_content_id)? {
+                v
+            } else {
+                let layer_data = fetch_blob(&client, &reference, layer_digest.as_ref())
+                    .await
+                    .with_context(|| format!("fetching layer blob {layer_digest}"))?;
+                let mut layer_stream = repo.create_stream(crate::skopeo::OCI_BLOB_CONTENT_TYPE)?;
+                layer_stream.write_external(&layer_data)?;
+                repo.write_stream(layer_stream, &layer_content_id, None)?
+            };
+            layer_verities.push((layer_digest, layer_verity));
+        }
+
+        // Store the manifest splitstream
+        let mut manifest_stream = repo.create_stream(crate::skopeo::OCI_MANIFEST_CONTENT_TYPE)?;
+
+        let config_key = format!("config:{config_digest}");
+        manifest_stream.add_named_stream_ref(&config_key, &config_verity);
+
+        for (layer_digest, layer_verity) in &layer_verities {
+            manifest_stream.add_named_stream_ref(layer_digest.as_ref(), layer_verity);
+        }
+
+        // Store the raw manifest bytes (from the registry) as-is to preserve
+        // the exact digest
+        manifest_stream.write_external(&raw_manifest_bytes)?;
+        repo.write_stream(manifest_stream, &manifest_content_id, None)?;
+
+        tracing::info!("Imported referrer artifact {artifact_digest}");
+        artifact_digests.push(artifact_digest);
+    }
+
+    Ok(artifact_digests)
+}
+
+/// Register the referrer relationship for each of `artifact_digests`
+/// against `local_subject_digest`, so they become discoverable via
+/// [`crate::oci_image::list_referrers`] (and thus `cfsctl oci verify`).
+///
+/// The artifacts themselves must already be present locally, e.g. via
+/// [`fetch_referrer_artifacts`].
+///
+/// Returns the number of relationships registered.
+pub fn register_referrers<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    local_subject_digest: &str,
+    artifact_digests: &[OciDigest],
+) -> Result<usize> {
+    let local_digest: OciDigest = local_subject_digest
+        .parse()
+        .with_context(|| format!("parsing local subject digest {local_subject_digest}"))?;
+
+    for artifact_digest in artifact_digests {
+        oci_image::add_referrer(repo, &local_digest, artifact_digest)?;
+    }
+
+    Ok(artifact_digests.len())
+}
+
+/// Fetch referrers using the OCI 1.1 tag scheme fallback.
+///
+/// When a registry doesn't support the Referrers API (e.g. GHCR returns 303/404),
+/// referrer artifacts are stored under a tag named `sha256-<hex>` in the same
+/// repository. The tagged manifest is an OCI Image Index listing all referrers.
+async fn fetch_referrers_by_tag(
+    client: &Client,
+    reference: &Reference,
+    manifest_digest: &str,
+) -> Result<oci_client::manifest::OciImageIndex> {
+    // Convert "sha256:abcdef..." to tag "sha256-abcdef..."
+    let tag = manifest_digest.replace(':', "-");
+    let tag_ref = Reference::with_tag(
+        reference.registry().to_string(),
+        reference.repository().to_string(),
+        tag.clone(),
+    );
+
+    let (raw_bytes, _digest) = client
+        .pull_manifest_raw(
+            &tag_ref,
+            &RegistryAuth::Anonymous,
+            &["application/vnd.oci.image.index.v1+json"],
+        )
+        .await
+        .with_context(|| format!("fetching referrers via tag scheme (tag '{tag}')"))?;
+
+    let index: oci_client::manifest::OciImageIndex =
+        serde_json::from_slice(&raw_bytes).context("parsing referrers tag index")?;
+
+    tracing::info!(
+        "Found {} referrer(s) via tag scheme fallback",
+        index.manifests.len()
+    );
+    Ok(index)
+}
+
+/// Fetch a blob by digest from the registry.
+///
+/// Uses the oci-client `pull_blob` method which writes to an async writer.
+async fn fetch_blob(client: &Client, reference: &Reference, digest: &str) -> Result<Vec<u8>> {
+    // Create a descriptor for pull_blob — it just needs the digest field
+    let desc = oci_client::manifest::OciDescriptor {
+        digest: digest.to_string(),
+        ..Default::default()
+    };
+
+    let mut buf = Vec::new();
+    client
+        .pull_blob(reference, &desc, &mut buf)
+        .await
+        .with_context(|| format!("pulling blob {digest}"))?;
+    Ok(buf)
+}
+
+/// Strip common transport prefixes from image references.
+///
+/// Skopeo-style references include transport prefixes like `docker://`,
+/// `containers-storage:`, etc. The `oci-client` `Reference` parser expects
+/// bare registry references like `docker.io/library/nginx:latest`.
+fn strip_transport_prefix(imgref: &str) -> &str {
+    // Common transport prefixes used by skopeo/containers-image
+    for prefix in &[
+        "docker://",
+        "docker:",
+        "containers-storage:",
+        "oci:",
+        "dir:",
+    ] {
+        if let Some(rest) = imgref.strip_prefix(prefix) {
+            return rest;
+        }
+    }
+    imgref
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_transport_prefix() {
+        assert_eq!(
+            strip_transport_prefix("docker://docker.io/library/nginx:latest"),
+            "docker.io/library/nginx:latest"
+        );
+        assert_eq!(
+            strip_transport_prefix("docker:docker.io/myorg/myimage:v1"),
+            "docker.io/myorg/myimage:v1"
+        );
+        assert_eq!(
+            strip_transport_prefix("containers-storage:sha256:abc123"),
+            "sha256:abc123"
+        );
+        assert_eq!(
+            strip_transport_prefix("oci:/path/to/layout"),
+            "/path/to/layout"
+        );
+        assert_eq!(
+            strip_transport_prefix("quay.io/fedora/fedora:latest"),
+            "quay.io/fedora/fedora:latest"
+        );
+    }
+
+    #[test]
+    fn test_reference_parsing() {
+        // Verify that common image references parse correctly after stripping
+        let cases = [
+            "docker.io/library/nginx:latest",
+            "quay.io/fedora/fedora:40",
+            "ghcr.io/myorg/myimage:v1.0",
+            "registry.example.com/repo:tag",
+        ];
+
+        for case in cases {
+            let reference = Reference::from_str(case);
+            assert!(
+                reference.is_ok(),
+                "Failed to parse reference '{case}': {:?}",
+                reference.err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_reference_clone_with_digest() {
+        let reference = Reference::from_str("docker.io/library/nginx:latest").unwrap();
+        let digest = "sha256:abc123def456";
+        let digest_ref = reference.clone_with_digest(digest.to_string());
+
+        assert_eq!(digest_ref.registry(), "docker.io");
+        assert_eq!(digest_ref.repository(), "library/nginx");
+        assert_eq!(digest_ref.digest(), Some(digest));
+    }
+
+    #[test]
+    fn test_strip_and_parse_docker_prefix() {
+        let imgref = "docker://quay.io/fedora/fedora:40";
+        let clean = strip_transport_prefix(imgref);
+        let reference = Reference::from_str(clean).unwrap();
+        assert_eq!(reference.registry(), "quay.io");
+        assert_eq!(reference.repository(), "fedora/fedora");
+        assert_eq!(reference.tag(), Some("40"));
+    }
+}

--- a/crates/composefs-oci/src/sealing_spec.rs
+++ b/crates/composefs-oci/src/sealing_spec.rs
@@ -349,7 +349,7 @@
 //!
 //! - The `.sig` values are base64-encoded PKCS#7 DER, identical in content to the raw blobs stored in artifact mode signature layers. To apply them locally, base64-decode the value and pass the result to `FS_IOC_ENABLE_VERITY`.
 //! - There is no manifest signature in inline mode. Adding a `composefs.manifest.fsverity-sha512-12` annotation would alter the manifest bytes, invalidating any digest computed before the annotation was added.
-//! - For large certificate chains, the base64-encoded signature annotation may be several kilobytes. If annotation size is a concern — for example, registries or tooling that imposes limits — use artifact mode instead, where signatures travel as separate layer blobs.
+//! - Signature annotations stay small: this crate's signer (see `signing.rs`), like standard fsverity signing tooling (e.g. `fsverity-utils`), builds the PKCS#7 message with `PKCS7_NOCERTS`, omitting the signer's certificate entirely — verification matches directly against a certificate already loaded into the `.fs-verity` keyring (kernel side) or supplied out-of-band via `--trust-cert`/`--cert` (userspace verifier). A base64-encoded signature is typically a few hundred bytes, not a source of manifest bloat.
 //!
 //! #### Whiteout Handling in Merged Filesystem
 //!
@@ -360,6 +360,24 @@
 //! #### Linux kernel fsverity signatures
 //!
 //! The primary signature mechanism is Linux kernel [fsverity built-in signature verification](https://docs.kernel.org/filesystems/fsverity.html#built-in-signature-verification). The kernel's `FS_IOC_ENABLE_VERITY` ioctl accepts a PKCS#7 signature that is verified against the `.fs-verity` keyring. This provides a clear chain of trust: the same component that controls data access (the Linux kernel) also validates the signature. The Linux kernel has subsystems that can build on top of fsverity signatures, such as [IPE](https://docs.kernel.org/admin-guide/LSM/ipe.html) (Integrity Policy Enforcement).
+//!
+//! #### Local kernel enrollment during pull
+//!
+//! `composefs-oci` opportunistically enrolls fsverity signatures with the kernel while pulling an image, so that the objects it writes locally benefit from kernel-enforced tamper evidence without any extra step. This applies only to the EROFS image objects it generates itself — the per-layer, merged, and merged-bootable EROFS files. It does not apply to plain content-addressed blob objects (e.g. individual extracted layer files), which have no associated composefs signature to enroll.
+//!
+//! Both integrity metadata modes feed the same enrollment step: a signature found either as an inline `.sig` annotation or fetched from a composefs metadata artifact via the OCI referrers API is looked up by the expected EROFS digest before the corresponding EROFS is generated, so it can be passed to `FS_IOC_ENABLE_VERITY` at the point the file is written.
+//!
+//! Repository object storage never downgrades an object from signed to unsigned: an image previously stored without a signature can later be upgraded in place (via an atomic rename) once a signature becomes available on a subsequent pull, but a previously-enrolled signed object is left untouched when written again without one.
+//!
+//! Because enrollment only happens as a side effect of the repository write path, it is inherently a *pull-time* operation. `cfsctl oci sign` — which signs an OCI artifact or updates inline annotations against a registry image — does not itself touch any locally-stored copy of that image. If an image was already pulled locally before it was signed, kernel enrollment for that existing local copy only happens on a subsequent pull; there is no mechanism to retroactively enroll a signature into an object already sitting in the repository.
+//!
+//! Kernel enrollment is a coarse, machine-wide, best-effort layer, not the primary trust decision. The `.fs-verity` keyring has no notion of which certificate should apply to which file — any signature that verifies against *any* certificate loaded via `cfsctl keyring add-cert` is accepted for enrollment. If the keyring has no certificate able to verify the signature at all (`ENOKEY`), that's treated as "kernel enrollment unavailable" rather than a failure: the object is still stored with plain (unsigned) fsverity enabled, and the pull proceeds normally. If the keyring does have a certificate but the signature fails to verify against it (`EKEYREJECTED`/`EBADMSG`), that's a real tamper-evidence signal and the object write fails outright. Userspace PKCS#7 verification (`cfsctl oci verify`, or `--require-signature` on pull) remains the authoritative trust decision regardless of whether kernel enrollment happened to succeed.
+//!
+//! ##### Single active signature per content digest
+//!
+//! A given fsverity signature can only be attached to a file at the moment `FS_IOC_ENABLE_VERITY` is called on it; it cannot be changed or read back out afterward, and it is a property of the inode rather than the content. Because repository object storage is content-addressed by digest, there is only one namable slot per digest for an enrolled object. If byte-identical EROFS content is pulled and enrolled with signature A, and later the same content is pulled again enrolled with a different signature B, B's enrollment replaces A's in that slot (still subject to the never-downgrade rule above: a signed slot is never replaced by an unsigned write, but two *signed* writes for the same digest are last-one-wins).
+//!
+//! This is intentional for now, not an oversight: kernel enrollment already can't distinguish which certificate produced the signature it accepted, so from the kernel's point of view A's and B's enrollments are equally valid tamper-evidence — the meaningful trust decision (which specific signer to require) is made in userspace beforehand, not by whichever enrollment happens to be currently on disk. A future extension could support multiple simultaneously-enrolled variants of the same content, keyed by a composite of `(digest, signature)`, letting several signers' copies coexist rather than overwrite each other. This is more tractable than it sounds because composefs EROFS images are metadata-only — actual file contents live in separate content-addressed objects referenced out-of-line via EROFS's chunk-based inode data layout, not embedded — so each additional enrolled variant is small regardless of how large the filesystem tree it describes is, and on filesystems supporting reflink (`ioctl_ficlone`, already used elsewhere in the object-import path) it need not even duplicate that small amount of data.
 //!
 //! #### Digest-only verification
 //!

--- a/crates/composefs-oci/src/signature.rs
+++ b/crates/composefs-oci/src/signature.rs
@@ -1,0 +1,1482 @@
+//! Composefs artifact construction and verification.
+//!
+//! Builds OCI artifact manifests containing composefs fsverity digests
+//! and PKCS#7 signatures per the OCI sealing specification.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, bail};
+use base64::Engine;
+use composefs::fsverity::Algorithm;
+
+/// Error when an image has no signature artifacts.
+#[derive(Debug, thiserror::Error)]
+#[error("No signature artifacts found for {name}")]
+pub struct NoSignatureArtifacts {
+    /// Name of the image missing artifacts.
+    pub name: String,
+}
+
+/// Error when an image's signature artifact fails verification.
+#[derive(Debug, thiserror::Error)]
+#[error("Signature verification failed: {reason}")]
+pub struct SignatureVerificationFailed {
+    /// Reason for the verification failure.
+    pub reason: String,
+}
+use composefs::fsverity::FsVerityHashValue;
+use composefs::repository::Repository;
+use containers_image_proxy::oci_spec::image::{
+    Descriptor, DescriptorBuilder, Digest as OciDigest, ImageManifest, ImageManifestBuilder,
+    MediaType,
+};
+
+/// Artifact type for composefs metadata manifests.
+pub const METADATA_ARTIFACT_TYPE: &str = "application/vnd.composefs.metadata.v1";
+
+/// Backward-compatible alias for the artifact type constant.
+pub const ARTIFACT_TYPE: &str = METADATA_ARTIFACT_TYPE;
+
+/// Media type for PKCS#7 DER signature layers.
+pub const SIGNATURE_MEDIA_TYPE: &str = "application/vnd.composefs.signature.v1+pkcs7";
+
+/// The type of object a signature layer refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignatureType {
+    /// Signature for the OCI manifest JSON.
+    Manifest,
+    /// Signature for the OCI config JSON.
+    Config,
+    /// Signature for an individual composefs layer EROFS (inline mode only).
+    Layer,
+    /// Signature for a merged (rolling) composefs filesystem.
+    Merged,
+    /// Signature for a bootable merged composefs filesystem.
+    MergedBootable,
+}
+
+impl SignatureType {
+    /// The annotation value string for this type.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SignatureType::Manifest => "manifest",
+            SignatureType::Config => "config",
+            SignatureType::Layer => "layer",
+            SignatureType::Merged => "merged",
+            SignatureType::MergedBootable => "merged.bootable",
+        }
+    }
+
+    /// Return the annotation key for this role.
+    pub fn annotation_key(&self, algorithm: Algorithm) -> String {
+        let suffix = match algorithm {
+            Algorithm::Sha256 { lg_blocksize } => format!("sha256-{lg_blocksize}"),
+            Algorithm::Sha512 { lg_blocksize } => format!("sha512-{lg_blocksize}"),
+        };
+        match self {
+            SignatureType::Manifest | SignatureType::Config => {
+                format!("composefs.{}.fsverity-{}", self.as_str(), suffix)
+            }
+            _ => {
+                format!("composefs.{}.erofs.v1.fsverity-{}", self.as_str(), suffix)
+            }
+        }
+    }
+}
+
+/// A single signature entry in a composefs artifact.
+#[derive(Debug, Clone)]
+pub struct SignatureEntry {
+    /// What this entry signs.
+    pub sig_type: SignatureType,
+    /// The composefs fsverity digest as a hex string.
+    pub digest: String,
+    /// Raw PKCS#7 DER signature blob, if available (always available if parsed from artifact).
+    pub signature: Option<Vec<u8>>,
+}
+
+/// The result of parsing a composefs artifact manifest.
+#[derive(Debug)]
+pub struct ParsedComposeFsArtifact {
+    /// The composefs algorithm used for fsverity digests.
+    pub algorithm: Algorithm,
+    /// The subject descriptor (the image this artifact refers to).
+    pub subject: Descriptor,
+    /// Signature entries.
+    pub signature_entries: Vec<SignatureEntry>,
+}
+
+/// Backward-compatible alias for ParsedComposeFsArtifact.
+pub type ParsedSignatureArtifact = ParsedComposeFsArtifact;
+
+/// Extracts (Algorithm, SignatureType, digest_hex) from annotation key/value pair
+#[allow(clippy::manual_map)]
+pub fn parse_annotation_key_value(
+    key: &str,
+    value: &str,
+) -> Option<(Algorithm, SignatureType, String)> {
+    let suffix = if let Some(s) = key.strip_prefix("composefs.manifest.fsverity-") {
+        Some((SignatureType::Manifest, s))
+    } else if let Some(s) = key.strip_prefix("composefs.config.fsverity-") {
+        Some((SignatureType::Config, s))
+    } else if let Some(s) = key.strip_prefix("composefs.merged.erofs.v1.fsverity-") {
+        Some((SignatureType::Merged, s))
+    } else if let Some(s) = key.strip_prefix("composefs.merged.bootable.erofs.v1.fsverity-") {
+        Some((SignatureType::MergedBootable, s))
+    } else if let Some(s) = key.strip_prefix("composefs.layer.erofs.v1.fsverity-") {
+        Some((SignatureType::Layer, s))
+    } else {
+        None
+    };
+
+    let (sig_type, alg_str) = suffix?;
+
+    // Check for .sig suffix (used in inline mode) and strip it
+    let alg_str = alg_str.strip_suffix(".sig").unwrap_or(alg_str);
+
+    let algorithm = match alg_str {
+        "sha256-12" => Algorithm::Sha256 { lg_blocksize: 12 },
+        "sha512-12" => Algorithm::Sha512 { lg_blocksize: 12 },
+        "sha256-16" => Algorithm::Sha256 { lg_blocksize: 16 },
+        "sha512-16" => Algorithm::Sha512 { lg_blocksize: 16 },
+        _ => return None,
+    };
+
+    Some((algorithm, sig_type, value.to_string()))
+}
+
+/// Parses an OCI image manifest into a ParsedComposeFsArtifact.
+pub fn parse_signature_artifact(manifest: &ImageManifest) -> Result<ParsedComposeFsArtifact> {
+    match manifest.artifact_type() {
+        Some(MediaType::Other(s)) if s == METADATA_ARTIFACT_TYPE => {}
+        other => bail!("wrong artifact type: {:?}", other),
+    }
+
+    let subject = manifest
+        .subject()
+        .as_ref()
+        .context("composefs artifact missing subject descriptor")?
+        .clone();
+
+    let mut signature_entries = Vec::new();
+    let mut detected_algorithm = None;
+
+    for layer in manifest.layers() {
+        let annotations = layer
+            .annotations()
+            .as_ref()
+            .context("layer missing annotations")?;
+
+        let mut found = None;
+        for (k, v) in annotations {
+            if let Some((alg, sig_type, digest)) = parse_annotation_key_value(k, v) {
+                found = Some((alg, sig_type, digest));
+                break;
+            }
+        }
+
+        let (algorithm, sig_type, digest) =
+            found.context("layer missing valid composefs digest annotation")?;
+
+        if let Some(existing) = detected_algorithm {
+            if existing != algorithm {
+                bail!("mixed algorithms in artifact");
+            }
+        } else {
+            detected_algorithm = Some(algorithm);
+        }
+
+        signature_entries.push(SignatureEntry {
+            sig_type,
+            digest,
+            signature: None, // Will be populated by caller if downloading the blob
+        });
+    }
+
+    let algorithm = detected_algorithm.context("no composefs layers found")?;
+
+    Ok(ParsedComposeFsArtifact {
+        algorithm,
+        subject,
+        signature_entries,
+    })
+}
+
+fn sha256_digest(data: &[u8]) -> OciDigest {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    let hex = hex::encode(result);
+    format!("sha256:{hex}").parse().unwrap()
+}
+
+/// Signs a container image and stores the resulting composefs signature artifact in the repository.
+pub fn sign_image<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    name: &str,
+    signing_key: &crate::signing::FsVeritySigningKey,
+) -> Result<(OciDigest, ObjectID)> {
+    let img = crate::oci_image::OciImage::open_ref(repo, name)?;
+
+    anyhow::ensure!(
+        img.is_container_image(),
+        "can only sign container images, not artifacts"
+    );
+
+    let config_digest = img.config_digest();
+    let algorithm = ObjectID::ALGORITHM;
+
+    let (_merged_erofs, merged_digest) = crate::generate_merged_image(repo, config_digest, None)?;
+
+    let subject = crate::OciDescriptorBuilder::default()
+        .media_type(crate::OciMediaType::ImageManifest)
+        .digest(img.manifest_digest().clone())
+        .size(img.manifest().to_string()?.len() as u64)
+        .build()
+        .context("building subject descriptor")?;
+
+    let merged_sig = signing_key.sign(&merged_digest)?;
+
+    // Construct layers
+    let mut layers = Vec::new();
+    let mut blobs = Vec::new();
+
+    // 1. Manifest signature (optional, we'll skip for now since we don't have manifest bytes readily available in standard fsverity format)
+    // 2. Config signature (optional, we'll skip for now)
+
+    // 3. Merged EROFS signature
+    let mut merged_annotations = std::collections::HashMap::new();
+    merged_annotations.insert(
+        SignatureType::Merged.annotation_key(algorithm),
+        merged_digest.to_hex(),
+    );
+
+    let merged_desc = DescriptorBuilder::default()
+        .media_type(MediaType::Other(SIGNATURE_MEDIA_TYPE.to_string()))
+        .digest(sha256_digest(&merged_sig))
+        .size(merged_sig.len() as u64)
+        .annotations(merged_annotations)
+        .build()
+        .context("building merged signature descriptor")?;
+
+    layers.push(merged_desc);
+    blobs.push(merged_sig);
+
+    let empty_config = b"{}";
+    let config_digest = sha256_digest(empty_config);
+    let config_id = crate::config_identifier(&config_digest);
+
+    let config_verity = if let Some(v) = repo.has_stream(&config_id)? {
+        v
+    } else {
+        let mut config_stream = repo.create_stream(crate::skopeo::OCI_CONFIG_CONTENT_TYPE)?;
+        config_stream.write_external(empty_config)?;
+        repo.write_stream(config_stream, &config_id, None)?
+    };
+
+    let mut artifact_builder = ImageManifestBuilder::default()
+        .schema_version(2u32)
+        .media_type(crate::OciMediaType::ImageManifest)
+        .artifact_type(MediaType::Other(METADATA_ARTIFACT_TYPE.to_string()))
+        .subject(subject)
+        .config(
+            DescriptorBuilder::default()
+                .media_type(MediaType::Other(
+                    "application/vnd.oci.empty.v1+json".to_string(),
+                ))
+                .digest(config_digest)
+                .size(empty_config.len() as u64)
+                .build()?,
+        );
+
+    artifact_builder = artifact_builder.layers(layers);
+    let artifact_manifest = artifact_builder.build()?;
+
+    // Write signature blobs and collect their verities
+    let mut layer_verities = Vec::new();
+    for blob in blobs {
+        let (digest, verity) = crate::oci_image::write_blob(repo, &blob)?;
+        layer_verities.push((digest.to_string(), verity));
+    }
+
+    let manifest_bytes = artifact_manifest.to_string()?.into_bytes();
+    let manifest_digest = sha256_digest(&manifest_bytes);
+
+    let (manifest_digest, artifact_id) = crate::oci_image::write_manifest(
+        repo,
+        &artifact_manifest,
+        &manifest_digest,
+        &config_verity,
+        &layer_verities,
+        None,
+    )?;
+
+    crate::oci_image::add_referrer(repo, img.manifest_digest(), &manifest_digest)?;
+
+    Ok((manifest_digest, artifact_id))
+}
+
+/// Verifies the composefs signatures associated with a container image.
+pub fn verify_image_signatures<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: &str,
+    verifier: Option<&crate::signing::FsVeritySignatureVerifier>,
+) -> Result<usize> {
+    Ok(verify_image_report(repo, name, verifier)?.verified_count)
+}
+
+/// Signs an inline-sealed container image by adding signature annotations directly in the image manifest.
+pub fn sign_image_inline<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    name: &str,
+    signing_key: &crate::signing::FsVeritySigningKey,
+) -> Result<OciDigest> {
+    let img = crate::oci_image::OciImage::open_ref(repo, name)?;
+    anyhow::ensure!(
+        img.is_container_image(),
+        "can only sign container images, not artifacts"
+    );
+
+    // Sign config annotations
+    let mut config_annotations = img
+        .manifest()
+        .config()
+        .annotations()
+        .as_ref()
+        .cloned()
+        .unwrap_or_default();
+    let mut config_sigs_to_add = Vec::new();
+    for (key, value) in &config_annotations {
+        if key.ends_with(".sig") {
+            continue;
+        }
+        if let Some((_, sig_type, digest_hex)) = parse_annotation_key_value(key, value) {
+            if sig_type == SignatureType::Manifest {
+                continue;
+            }
+            let objid = ObjectID::from_hex(&digest_hex)
+                .map_err(|e| anyhow::anyhow!("invalid digest hex in config annotation: {e}"))?;
+            let sig_bytes = signing_key.sign(&objid)?;
+            let base64_sig = base64::engine::general_purpose::STANDARD.encode(&sig_bytes);
+            config_sigs_to_add.push((format!("{key}.sig"), base64_sig));
+        }
+    }
+    for (k, v) in config_sigs_to_add {
+        config_annotations.insert(k, v);
+    }
+
+    // Sign layer annotations
+    let mut new_layers = Vec::new();
+    for layer in img.manifest().layers() {
+        let mut layer_annotations = layer.annotations().as_ref().cloned().unwrap_or_default();
+        let mut layer_sigs_to_add = Vec::new();
+        for (key, value) in &layer_annotations {
+            if key.ends_with(".sig") {
+                continue;
+            }
+            if let Some((_, sig_type, digest_hex)) = parse_annotation_key_value(key, value) {
+                if sig_type == SignatureType::Manifest {
+                    continue;
+                }
+                let objid = ObjectID::from_hex(&digest_hex)
+                    .map_err(|e| anyhow::anyhow!("invalid digest hex in layer annotation: {e}"))?;
+                let sig_bytes = signing_key.sign(&objid)?;
+                let base64_sig = base64::engine::general_purpose::STANDARD.encode(&sig_bytes);
+                layer_sigs_to_add.push((format!("{key}.sig"), base64_sig));
+            }
+        }
+        for (k, v) in layer_sigs_to_add {
+            layer_annotations.insert(k, v);
+        }
+        let new_layer = DescriptorBuilder::default()
+            .media_type(layer.media_type().clone())
+            .digest(layer.digest().clone())
+            .size(layer.size())
+            .annotations(layer_annotations)
+            .build()
+            .context("building layer descriptor")?;
+        new_layers.push(new_layer);
+    }
+
+    // Sign top-level manifest annotations
+    let mut manifest_annotations = img
+        .manifest()
+        .annotations()
+        .as_ref()
+        .cloned()
+        .unwrap_or_default();
+    let mut manifest_sigs_to_add = Vec::new();
+    for (key, value) in &manifest_annotations {
+        if key.ends_with(".sig") {
+            continue;
+        }
+        if let Some((_, sig_type, digest_hex)) = parse_annotation_key_value(key, value) {
+            if sig_type == SignatureType::Manifest {
+                continue;
+            }
+            let objid = ObjectID::from_hex(&digest_hex)
+                .map_err(|e| anyhow::anyhow!("invalid digest hex in manifest annotation: {e}"))?;
+            let sig_bytes = signing_key.sign(&objid)?;
+            let base64_sig = base64::engine::general_purpose::STANDARD.encode(&sig_bytes);
+            manifest_sigs_to_add.push((format!("{key}.sig"), base64_sig));
+        }
+    }
+    for (k, v) in manifest_sigs_to_add {
+        manifest_annotations.insert(k, v);
+    }
+
+    let new_config_descriptor = DescriptorBuilder::default()
+        .media_type(MediaType::ImageConfig)
+        .digest(img.config_digest().clone())
+        .size(img.manifest().config().size())
+        .annotations(config_annotations)
+        .build()
+        .context("building config descriptor")?;
+
+    let new_manifest = ImageManifestBuilder::default()
+        .schema_version(img.manifest().schema_version())
+        .media_type(MediaType::ImageManifest)
+        .config(new_config_descriptor)
+        .layers(new_layers)
+        .annotations(manifest_annotations)
+        .build()
+        .context("building signed manifest")?;
+
+    let new_manifest_json = new_manifest.to_string()?;
+    let new_manifest_digest = crate::sha256_content_digest(new_manifest_json.as_bytes());
+
+    let layer_refs_vec: Vec<(Box<str>, ObjectID)> = img
+        .layer_refs()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    crate::oci_image::write_manifest(
+        repo,
+        &new_manifest,
+        &new_manifest_digest,
+        img.config_verity(),
+        &layer_refs_vec,
+        Some(name),
+    )?;
+
+    Ok(new_manifest_digest)
+}
+
+/// Verifies the inline composefs signatures and digests embedded in a container image manifest.
+pub fn verify_image_signatures_inline<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: &str,
+    verifier: Option<&crate::signing::FsVeritySignatureVerifier>,
+) -> Result<usize> {
+    Ok(verify_image_report(repo, name, verifier)?.verified_count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use composefs::fsverity::Sha256HashValue;
+    use composefs::test::TestRepo;
+
+    #[test]
+    fn test_inline_annotation_keys_roundtrip() {
+        let algs = vec![
+            Algorithm::Sha256 { lg_blocksize: 12 },
+            Algorithm::Sha512 { lg_blocksize: 12 },
+            Algorithm::Sha256 { lg_blocksize: 16 },
+            Algorithm::Sha512 { lg_blocksize: 16 },
+        ];
+        let types = vec![
+            SignatureType::Config,
+            SignatureType::Layer,
+            SignatureType::Merged,
+        ];
+        for alg in algs {
+            for t in &types {
+                let key = t.annotation_key(alg);
+                let value = "abcd1234abcd1234";
+                let res = parse_annotation_key_value(&key, value);
+                assert!(res.is_some());
+                let (parsed_alg, parsed_t, parsed_val) = res.unwrap();
+                assert_eq!(parsed_alg, alg);
+                assert_eq!(parsed_t, *t);
+                assert_eq!(parsed_val, value);
+
+                // With .sig suffix
+                let sig_key = format!("{key}.sig");
+                let res_sig = parse_annotation_key_value(&sig_key, value);
+                assert!(res_sig.is_some());
+                let (parsed_alg_sig, parsed_t_sig, parsed_val_sig) = res_sig.unwrap();
+                assert_eq!(parsed_alg_sig, alg);
+                assert_eq!(parsed_t_sig, *t);
+                assert_eq!(parsed_val_sig, value);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_inline_sign_verify_end_to_end() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = Arc::new(test_repo.repo);
+
+        // 1. Create a base image
+        let _img = crate::test_util::create_base_image(&repo, Some("base:v1")).await;
+
+        // 2. Seal inline
+        let sealed_digest = crate::oci_image::seal_image_inline(&repo, "base:v1").unwrap();
+
+        // Check that annotations are present on the new image
+        let sealed_img = crate::oci_image::OciImage::open_ref(&repo, "base:v1").unwrap();
+        assert_eq!(sealed_img.manifest_digest(), &sealed_digest);
+
+        let alg = Sha256HashValue::ALGORITHM;
+        let config_anno_key = SignatureType::Config.annotation_key(alg);
+        let merged_anno_key = SignatureType::Merged.annotation_key(alg);
+        let layer_anno_key = SignatureType::Layer.annotation_key(alg);
+
+        assert!(
+            sealed_img
+                .manifest()
+                .config()
+                .annotations()
+                .as_ref()
+                .unwrap()
+                .contains_key(&config_anno_key)
+        );
+        assert!(
+            sealed_img
+                .manifest()
+                .annotations()
+                .as_ref()
+                .unwrap()
+                .contains_key(&merged_anno_key)
+        );
+        for layer in sealed_img.manifest().layers() {
+            assert!(
+                layer
+                    .annotations()
+                    .as_ref()
+                    .unwrap()
+                    .contains_key(&layer_anno_key)
+            );
+        }
+
+        // Verify digest-only (verifier is None)
+        let verified_digests = verify_image_signatures_inline(&repo, "base:v1", None).unwrap();
+        assert!(verified_digests >= 2); // merged + config + layers
+
+        // 3. Sign inline
+        let (cert_pem, key_pem) = crate::signing::generate_test_keypair();
+        let signer = crate::signing::FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = crate::signing::FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let _signed_digest = sign_image_inline(&repo, "base:v1", &signer).unwrap();
+
+        // Verify with verifier
+        let verified_sigs =
+            verify_image_signatures_inline(&repo, "base:v1", Some(&verifier)).unwrap();
+        assert!(verified_sigs >= 2); // config + merged + layers should have signatures
+
+        // Verify that trying to verify with a different cert fails
+        let (wrong_cert_pem, _wrong_key_pem) = crate::signing::generate_test_keypair();
+        let wrong_verifier =
+            crate::signing::FsVeritySignatureVerifier::from_pem(&wrong_cert_pem).unwrap();
+        let wrong_verify_res =
+            verify_image_signatures_inline(&repo, "base:v1", Some(&wrong_verifier));
+        assert!(wrong_verify_res.is_err());
+    }
+
+    fn mutate_and_restore_manifest<ObjectID: FsVerityHashValue>(
+        repo: &Arc<Repository<ObjectID>>,
+        name: &str,
+        mutator: impl FnOnce(&mut std::collections::HashMap<String, String>),
+    ) -> Result<()> {
+        let img = crate::oci_image::OciImage::open_ref(repo, name)?;
+        let mut manifest_annotations = img
+            .manifest()
+            .annotations()
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+
+        mutator(&mut manifest_annotations);
+
+        let config_annotations = img
+            .manifest()
+            .config()
+            .annotations()
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+
+        let new_config_descriptor = DescriptorBuilder::default()
+            .media_type(MediaType::ImageConfig)
+            .digest(img.config_digest().clone())
+            .size(img.manifest().config().size())
+            .annotations(config_annotations)
+            .build()
+            .context("building config descriptor")?;
+
+        let new_manifest = ImageManifestBuilder::default()
+            .schema_version(img.manifest().schema_version())
+            .media_type(MediaType::ImageManifest)
+            .config(new_config_descriptor)
+            .layers(img.manifest().layers().to_vec())
+            .annotations(manifest_annotations)
+            .build()
+            .context("building signed manifest")?;
+
+        let new_manifest_json = new_manifest.to_string()?;
+        let new_manifest_digest = crate::sha256_content_digest(new_manifest_json.as_bytes());
+
+        let layer_refs_vec: Vec<(Box<str>, ObjectID)> = img
+            .layer_refs()
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        crate::oci_image::write_manifest(
+            repo,
+            &new_manifest,
+            &new_manifest_digest,
+            img.config_verity(),
+            &layer_refs_vec,
+            Some(name),
+        )?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_inline_verify_rejects_stripped_merged_signature() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = Arc::new(test_repo.repo);
+
+        let _img = crate::test_util::create_base_image(&repo, Some("base:v1")).await;
+        let _sealed_digest = crate::oci_image::seal_image_inline(&repo, "base:v1").unwrap();
+
+        let (cert_pem, key_pem) = crate::signing::generate_test_keypair();
+        let signer = crate::signing::FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = crate::signing::FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let _signed_digest = sign_image_inline(&repo, "base:v1", &signer).unwrap();
+
+        let verified_sigs =
+            verify_image_signatures_inline(&repo, "base:v1", Some(&verifier)).unwrap();
+        assert!(verified_sigs >= 1);
+
+        let alg = Sha256HashValue::ALGORITHM;
+        let merged_sig_key = format!("{}.sig", SignatureType::Merged.annotation_key(alg));
+
+        mutate_and_restore_manifest(&repo, "base:v1", |annotations| {
+            assert!(annotations.remove(&merged_sig_key).is_some());
+        })
+        .unwrap();
+
+        let verify_res = verify_image_signatures_inline(&repo, "base:v1", Some(&verifier));
+        assert!(verify_res.is_err());
+        let err = verify_res.err().unwrap();
+        let err_msg = format!("{:#}", err);
+        assert!(
+            err_msg.contains("merged filesystem digest is not signed"),
+            "Expected 'merged filesystem digest is not signed' error, got: {}",
+            err_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_inline_verify_rejects_tampered_merged_digest() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = Arc::new(test_repo.repo);
+
+        let _img = crate::test_util::create_base_image(&repo, Some("base:v1")).await;
+        let _sealed_digest = crate::oci_image::seal_image_inline(&repo, "base:v1").unwrap();
+
+        let (cert_pem, key_pem) = crate::signing::generate_test_keypair();
+        let signer = crate::signing::FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = crate::signing::FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let _signed_digest = sign_image_inline(&repo, "base:v1", &signer).unwrap();
+
+        let alg = Sha256HashValue::ALGORITHM;
+        let merged_digest_key = SignatureType::Merged.annotation_key(alg);
+
+        mutate_and_restore_manifest(&repo, "base:v1", |annotations| {
+            let old_value = annotations.get(&merged_digest_key).unwrap().clone();
+            let tampered_value = "0".repeat(old_value.len());
+            annotations.insert(merged_digest_key, tampered_value);
+        })
+        .unwrap();
+
+        let verify_res = verify_image_signatures_inline(&repo, "base:v1", Some(&verifier));
+        assert!(verify_res.is_err());
+        let err_msg = format!("{:#}", verify_res.err().unwrap());
+        assert!(
+            err_msg.contains("Merged digest mismatch")
+                || err_msg.to_lowercase().contains("merged")
+                || err_msg.to_lowercase().contains("signature"),
+            "Expected digest or signature error, got: {}",
+            err_msg
+        );
+
+        let verify_none_res = verify_image_signatures_inline(&repo, "base:v1", None);
+        assert!(verify_none_res.is_err());
+        let err_none_msg = format!("{:#}", verify_none_res.err().unwrap());
+        assert!(
+            err_none_msg.contains("Merged digest mismatch")
+                || err_none_msg.to_lowercase().contains("merged"),
+            "Expected merged digest mismatch error for None verifier, got: {}",
+            err_none_msg
+        );
+    }
+
+    #[tokio::test]
+    async fn test_inline_verify_digest_only_no_error_when_unsigned() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = Arc::new(test_repo.repo);
+
+        let _img = crate::test_util::create_base_image(&repo, Some("base:v1")).await;
+        let _sealed_digest = crate::oci_image::seal_image_inline(&repo, "base:v1").unwrap();
+
+        let verified_digests = verify_image_signatures_inline(&repo, "base:v1", None);
+        assert!(verified_digests.is_ok());
+        let count = verified_digests.unwrap();
+        assert!(count >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_collect_kernel_signatures_from_inline_annotations() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = Arc::new(test_repo.repo);
+
+        let _img = crate::test_util::create_base_image(&repo, Some("base:v1")).await;
+        crate::oci_image::seal_image_inline(&repo, "base:v1").unwrap();
+
+        // Digest annotations exist right after sealing, but there are no
+        // `.sig` siblings yet, so nothing should be collected.
+        let sealed_img = crate::oci_image::OciImage::open_ref(&repo, "base:v1").unwrap();
+        let map = collect_kernel_signatures(&repo, &sealed_img, &[]).unwrap();
+        assert!(map.is_empty());
+
+        let (cert_pem, key_pem) = crate::signing::generate_test_keypair();
+        let signer = crate::signing::FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        sign_image_inline(&repo, "base:v1", &signer).unwrap();
+
+        let signed_img = crate::oci_image::OciImage::open_ref(&repo, "base:v1").unwrap();
+        let map = collect_kernel_signatures(&repo, &signed_img, &[]).unwrap();
+
+        let per_layer_digests = crate::image::compute_per_layer_digests(
+            &repo,
+            signed_img.config_digest(),
+            Some(signed_img.config_verity()),
+        )
+        .unwrap();
+        let merged_digest = crate::image::compute_merged_digest(
+            &repo,
+            signed_img.config_digest(),
+            Some(signed_img.config_verity()),
+        )
+        .unwrap();
+
+        assert!(!per_layer_digests.is_empty());
+        for layer_digest in &per_layer_digests {
+            assert!(
+                map.contains_key(layer_digest),
+                "expected map to contain per-layer digest {layer_digest:?}"
+            );
+        }
+        assert!(map.contains_key(&merged_digest));
+
+        // The collected signature bytes must match the base64-decoded
+        // `.sig` annotation exactly.
+        let alg = Sha256HashValue::ALGORITHM;
+        let merged_sig_key = format!("{}.sig", SignatureType::Merged.annotation_key(alg));
+        let merged_sig_b64 = signed_img
+            .manifest()
+            .annotations()
+            .as_ref()
+            .unwrap()
+            .get(&merged_sig_key)
+            .unwrap();
+        let expected_sig = base64::engine::general_purpose::STANDARD
+            .decode(merged_sig_b64)
+            .unwrap();
+        assert_eq!(map.get(&merged_digest).unwrap(), &expected_sig);
+
+        // The config signature is `SignatureType::Config`, which signs the
+        // raw OCI config JSON rather than an EROFS object, so its digest
+        // must never appear in the kernel-enrollment map.
+        assert!(!map.contains_key(signed_img.config_verity()));
+    }
+
+    #[tokio::test]
+    async fn test_collect_kernel_signatures_empty_for_unsealed_image() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = Arc::new(test_repo.repo);
+
+        let _img = crate::test_util::create_base_image(&repo, Some("base:v1")).await;
+        let img = crate::oci_image::OciImage::open_ref(&repo, "base:v1").unwrap();
+
+        let map = collect_kernel_signatures(&repo, &img, &[]).unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_collect_kernel_signatures_from_referrer_artifact() {
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = Arc::new(test_repo.repo);
+
+        let _img = crate::test_util::create_base_image(&repo, Some("base:v1")).await;
+
+        let (cert_pem, key_pem) = crate::signing::generate_test_keypair();
+        let signer = crate::signing::FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let (artifact_digest, _artifact_id) = sign_image(&repo, "base:v1", &signer).unwrap();
+
+        let img = crate::oci_image::OciImage::open_ref(&repo, "base:v1").unwrap();
+        let merged_digest = crate::image::compute_merged_digest(
+            &repo,
+            img.config_digest(),
+            Some(img.config_verity()),
+        )
+        .unwrap();
+
+        // Without listing the artifact digest, nothing is collected.
+        let map = collect_kernel_signatures(&repo, &img, &[]).unwrap();
+        assert!(map.is_empty());
+
+        let map = collect_kernel_signatures(&repo, &img, &[artifact_digest]).unwrap();
+        assert!(map.contains_key(&merged_digest));
+
+        // The bytes collected must be a valid signature for the merged
+        // digest under the signing certificate.
+        let verifier = crate::signing::FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+        verifier
+            .verify(map.get(&merged_digest).unwrap(), &merged_digest)
+            .unwrap();
+    }
+}
+
+/// Individual verification entry of an OCI image's component.
+#[derive(Debug, Clone)]
+pub struct VerificationEntry {
+    /// The role of this entry (e.g. `layer[0]`, merged, config, manifest).
+    pub role: String,
+    /// The expected digest for this role.
+    pub expected_digest: Option<String>,
+    /// Whether the expected digest matches the actual digest.
+    pub digest_ok: bool,
+    /// Whether the cryptographic signature verified successfully.
+    pub signature_verified: bool,
+    /// Detailed error message if verification failed.
+    pub detail: Option<String>,
+}
+
+/// Verification report summarizing the full signature/digest checks.
+#[derive(Debug, Clone)]
+pub struct VerificationReport {
+    /// The number of signatures cryptographically verified.
+    pub verified_count: usize,
+    /// Whether a certificate was supplied for verification.
+    pub cert_supplied: bool,
+    /// The mode of verification: inline or artifact.
+    pub mode: &'static str,
+    /// The algorithm used (e.g. sha256-12).
+    pub algorithm: Option<String>,
+    /// Component-by-component verification results.
+    pub entries: Vec<VerificationEntry>,
+}
+
+/// Verification report for OCI image, single source of truth.
+pub fn verify_image_report<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: &str,
+    verifier: Option<&crate::signing::FsVeritySignatureVerifier>,
+) -> Result<VerificationReport> {
+    let img = crate::oci_image::OciImage::open_ref(repo, name)?;
+
+    // Check inline vs artifact
+    let mut is_inline = false;
+    if let Some(annotations) = img.manifest().annotations() {
+        for key in annotations.keys() {
+            if key.starts_with("composefs.") && key.contains(".fsverity-") {
+                is_inline = true;
+            }
+        }
+    }
+    if let Some(annotations) = img.manifest().config().annotations() {
+        for key in annotations.keys() {
+            if key.starts_with("composefs.") && key.contains(".fsverity-") {
+                is_inline = true;
+            }
+        }
+    }
+    for layer in img.manifest().layers() {
+        if let Some(annotations) = layer.annotations() {
+            for key in annotations.keys() {
+                if key.starts_with("composefs.") && key.contains(".fsverity-") {
+                    is_inline = true;
+                }
+            }
+        }
+    }
+
+    if is_inline {
+        verify_image_report_inline(repo, &img, name, verifier)
+    } else {
+        verify_image_report_artifact(repo, &img, name, verifier)
+    }
+}
+
+fn verify_image_report_inline<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    img: &crate::oci_image::OciImage<ObjectID>,
+    name: &str,
+    verifier: Option<&crate::signing::FsVeritySignatureVerifier>,
+) -> Result<VerificationReport> {
+    // 1. Collect annotations
+    let mut config_digests = Vec::new();
+    let mut config_sigs = std::collections::HashMap::new();
+    if let Some(annotations) = img.manifest().config().annotations() {
+        for (key, value) in annotations {
+            if key.ends_with(".sig") {
+                config_sigs.insert(key.clone(), value.clone());
+            } else if let Some((alg, sig_type, digest)) = parse_annotation_key_value(key, value) {
+                config_digests.push((key.clone(), alg, sig_type, digest));
+            }
+        }
+    }
+
+    let mut layer_digests = Vec::new();
+    for layer in img.manifest().layers() {
+        let mut layer_info = Vec::new();
+        if let Some(annotations) = layer.annotations() {
+            for (key, value) in annotations {
+                if key.ends_with(".sig") {
+                    continue;
+                }
+                if let Some((alg, sig_type, digest)) = parse_annotation_key_value(key, value) {
+                    let sig_key = format!("{key}.sig");
+                    let sig_base64 = annotations.get(&sig_key).cloned();
+                    layer_info.push((key.clone(), alg, sig_type, digest, sig_base64));
+                }
+            }
+        }
+        layer_digests.push(layer_info);
+    }
+
+    let mut manifest_digests = Vec::new();
+    let mut manifest_sigs = std::collections::HashMap::new();
+    if let Some(annotations) = img.manifest().annotations() {
+        for (key, value) in annotations {
+            if key.ends_with(".sig") {
+                manifest_sigs.insert(key.clone(), value.clone());
+            } else if let Some((alg, sig_type, digest)) = parse_annotation_key_value(key, value) {
+                manifest_digests.push((key.clone(), alg, sig_type, digest));
+            }
+        }
+    }
+
+    // 2. DIGEST-CHECK & verify
+    let local_merged_digest =
+        crate::image::compute_merged_digest(repo, img.config_digest(), Some(img.config_verity()))?;
+    let local_merged_hex = local_merged_digest.to_hex();
+
+    let local_layer_digests = crate::image::compute_per_layer_digests(
+        repo,
+        img.config_digest(),
+        Some(img.config_verity()),
+    )?;
+
+    let mut entries = Vec::new();
+    let mut verified_count = 0;
+    let mut detected_algorithm = None;
+
+    // Config entries
+    for (key, alg, _sig_type, digest) in &config_digests {
+        if detected_algorithm.is_none() {
+            detected_algorithm = Some(alg.to_string());
+        }
+        let role = "config".to_string();
+        let expected_digest = Some(img.config_verity().to_hex());
+        let digest_ok = Some(digest) == expected_digest.as_ref();
+
+        if !digest_ok {
+            return Err(anyhow::Error::new(SignatureVerificationFailed {
+                reason: format!(
+                    "Config verity mismatch for key {key}: expected {}, got {digest}",
+                    expected_digest.as_ref().unwrap()
+                ),
+            }));
+        }
+
+        let mut signature_verified = false;
+        if let Some(verifier) = verifier {
+            let sig_key = format!("{key}.sig");
+            if let Some(sig_base64) = config_sigs.get(&sig_key) {
+                let sig_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(sig_base64)
+                    .map_err(|e| {
+                        anyhow::Error::new(SignatureVerificationFailed {
+                            reason: format!("failed to base64-decode config signature: {e}"),
+                        })
+                    })?;
+                let digest_bytes = hex::decode(digest).map_err(|e| {
+                    anyhow::Error::new(SignatureVerificationFailed {
+                        reason: format!("invalid digest hex: {e}"),
+                    })
+                })?;
+                verifier
+                    .verify_raw(&sig_bytes, alg.kernel_id(), &digest_bytes)
+                    .map_err(|e| {
+                        anyhow::Error::new(SignatureVerificationFailed {
+                            reason: format!("signature verification failed for {key}: {e}"),
+                        })
+                    })?;
+                signature_verified = true;
+                verified_count += 1;
+            }
+        }
+
+        entries.push(VerificationEntry {
+            role,
+            expected_digest,
+            digest_ok,
+            signature_verified,
+            detail: None,
+        });
+    }
+
+    // Merged/manifest entries
+    let mut merged_sig_verified = false;
+    let mut has_merged_digest = false;
+
+    for (key, alg, sig_type, digest) in &manifest_digests {
+        if detected_algorithm.is_none() {
+            detected_algorithm = Some(alg.to_string());
+        }
+        if *sig_type == SignatureType::Merged {
+            has_merged_digest = true;
+            let role = "merged".to_string();
+            let expected_digest = Some(local_merged_hex.clone());
+            let digest_ok = Some(digest) == expected_digest.as_ref();
+
+            if !digest_ok {
+                return Err(anyhow::Error::new(SignatureVerificationFailed {
+                    reason: format!(
+                        "Merged digest mismatch for key {key}: expected {}, got {digest}",
+                        expected_digest.as_ref().unwrap()
+                    ),
+                }));
+            }
+
+            let mut signature_verified = false;
+            if let Some(verifier) = verifier {
+                let sig_key = format!("{key}.sig");
+                if let Some(sig_base64) = manifest_sigs.get(&sig_key) {
+                    let sig_bytes = base64::engine::general_purpose::STANDARD
+                        .decode(sig_base64)
+                        .map_err(|e| {
+                            anyhow::Error::new(SignatureVerificationFailed {
+                                reason: format!("failed to base64-decode manifest signature: {e}"),
+                            })
+                        })?;
+                    let digest_bytes = hex::decode(digest).map_err(|e| {
+                        anyhow::Error::new(SignatureVerificationFailed {
+                            reason: format!("invalid digest hex: {e}"),
+                        })
+                    })?;
+                    verifier
+                        .verify_raw(&sig_bytes, alg.kernel_id(), &digest_bytes)
+                        .map_err(|e| {
+                            anyhow::Error::new(SignatureVerificationFailed {
+                                reason: format!("signature verification failed for {key}: {e}"),
+                            })
+                        })?;
+                    signature_verified = true;
+                    merged_sig_verified = true;
+                    verified_count += 1;
+                }
+            }
+
+            entries.push(VerificationEntry {
+                role,
+                expected_digest,
+                digest_ok,
+                signature_verified,
+                detail: None,
+            });
+        }
+    }
+
+    // Layer entries
+    let has_layer_digests = layer_digests.iter().any(|infos| !infos.is_empty());
+    if has_layer_digests {
+        for (i, infos) in layer_digests.iter().enumerate() {
+            let expected_hex = local_layer_digests
+                .get(i)
+                .ok_or_else(|| {
+                    anyhow::Error::new(SignatureVerificationFailed {
+                        reason: "manifest layer count exceeds config diff_ids".into(),
+                    })
+                })?
+                .to_hex();
+
+            for (key, alg, _sig_type, digest, sig_base64_opt) in infos {
+                if detected_algorithm.is_none() {
+                    detected_algorithm = Some(alg.to_string());
+                }
+                let role = format!("layer[{i}]");
+                let expected_digest = Some(expected_hex.clone());
+                let digest_ok = Some(digest) == expected_digest.as_ref();
+
+                if !digest_ok {
+                    return Err(anyhow::Error::new(SignatureVerificationFailed {
+                        reason: format!(
+                            "Layer {i} digest mismatch for key {key}: expected {expected_hex}, got {digest}"
+                        ),
+                    }));
+                }
+
+                let mut signature_verified = false;
+                if let (Some(verifier), Some(sig_base64)) = (verifier, sig_base64_opt) {
+                    let sig_bytes = base64::engine::general_purpose::STANDARD
+                        .decode(sig_base64)
+                        .map_err(|e| {
+                            anyhow::Error::new(SignatureVerificationFailed {
+                                reason: format!("failed to base64-decode layer signature: {e}"),
+                            })
+                        })?;
+                    let digest_bytes = hex::decode(digest).map_err(|e| {
+                        anyhow::Error::new(SignatureVerificationFailed {
+                            reason: format!("invalid digest hex: {e}"),
+                        })
+                    })?;
+                    verifier
+                        .verify_raw(&sig_bytes, alg.kernel_id(), &digest_bytes)
+                        .map_err(|e| {
+                            anyhow::Error::new(SignatureVerificationFailed {
+                                reason: format!("signature verification failed for {key}: {e}"),
+                            })
+                        })?;
+                    signature_verified = true;
+                    verified_count += 1;
+                }
+
+                entries.push(VerificationEntry {
+                    role,
+                    expected_digest,
+                    digest_ok,
+                    signature_verified,
+                    detail: None,
+                });
+            }
+        }
+    }
+
+    if verifier.is_some() {
+        if !has_merged_digest || !merged_sig_verified {
+            return Err(anyhow::Error::new(SignatureVerificationFailed {
+                reason: "merged filesystem digest is not signed".into(),
+            }));
+        }
+
+        let total_sigs_found = config_digests
+            .iter()
+            .filter(|(k, _, _, _)| config_sigs.contains_key(&format!("{k}.sig")))
+            .count()
+            + manifest_digests
+                .iter()
+                .filter(|(k, _, _, _)| manifest_sigs.contains_key(&format!("{k}.sig")))
+                .count()
+            + layer_digests
+                .iter()
+                .flatten()
+                .filter(|(_, _, _, _, sig_opt)| sig_opt.is_some())
+                .count();
+
+        if total_sigs_found == 0 {
+            return Err(anyhow::Error::new(NoSignatureArtifacts {
+                name: name.to_string(),
+            }));
+        }
+    }
+
+    let verified_count = if verifier.is_some() {
+        verified_count
+    } else {
+        entries.len()
+    };
+
+    Ok(VerificationReport {
+        verified_count,
+        cert_supplied: verifier.is_some(),
+        mode: "inline",
+        algorithm: detected_algorithm,
+        entries,
+    })
+}
+
+fn verify_image_report_artifact<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    img: &crate::oci_image::OciImage<ObjectID>,
+    name: &str,
+    verifier: Option<&crate::signing::FsVeritySignatureVerifier>,
+) -> Result<VerificationReport> {
+    let manifest_digest = img.manifest_digest();
+    let referrers = crate::oci_image::list_referrers(repo, manifest_digest)?;
+
+    let mut metadata_artifacts = Vec::new();
+    for (artifact_digest, verity) in &referrers {
+        let artifact_image = crate::oci_image::OciImage::open(repo, artifact_digest, Some(verity))?;
+        if artifact_image.manifest().artifact_type()
+            == &Some(MediaType::Other(METADATA_ARTIFACT_TYPE.to_string()))
+        {
+            metadata_artifacts.push(artifact_image);
+        }
+    }
+
+    if metadata_artifacts.is_empty() {
+        return Err(anyhow::Error::new(NoSignatureArtifacts {
+            name: name.to_string(),
+        }));
+    }
+
+    let config_digest = img.config_digest();
+    let algorithm = ObjectID::ALGORITHM;
+
+    let per_layer_digests = crate::image::compute_per_layer_digests(repo, config_digest, None)?;
+    let merged_digest: ObjectID = crate::image::compute_merged_digest(repo, config_digest, None)?;
+    let merged_hex = merged_digest.to_hex();
+
+    let mut entries = Vec::new();
+    let mut verified_count = 0usize;
+    let mut detected_algorithm = None;
+
+    for artifact in &metadata_artifacts {
+        let parsed = parse_signature_artifact(artifact.manifest())?;
+        detected_algorithm = Some(parsed.algorithm.to_string());
+
+        let layer_descriptors = artifact.layer_descriptors();
+        let mut layer_idx = 0usize;
+        let sig_layer_offset = 0;
+
+        for (entry_idx, entry) in parsed.signature_entries.iter().enumerate() {
+            let (role, expected_digest) = match entry.sig_type {
+                SignatureType::Layer => {
+                    let r = format!("layer[{layer_idx}]");
+                    let expected = per_layer_digests.get(layer_idx).map(|d| d.to_hex());
+                    layer_idx += 1;
+                    (r, expected)
+                }
+                SignatureType::Merged => ("merged".to_string(), Some(merged_hex.clone())),
+                SignatureType::Config => ("config".to_string(), None),
+                SignatureType::Manifest => ("manifest".to_string(), None),
+                SignatureType::MergedBootable => ("merged.bootable".to_string(), None),
+            };
+
+            let digest_ok = match &expected_digest {
+                Some(expected) => *expected == entry.digest,
+                None => false,
+            };
+
+            if expected_digest.is_some() && !digest_ok {
+                let expected = expected_digest.as_deref().unwrap_or("");
+                return Err(anyhow::Error::new(SignatureVerificationFailed {
+                    reason: format!(
+                        "digest mismatch for entry {role}: expected {expected}, got {}",
+                        entry.digest
+                    ),
+                }));
+            }
+
+            let mut signature_verified = false;
+
+            if let Some(verifier) = verifier {
+                let layer_desc = layer_descriptors
+                    .get(sig_layer_offset + entry_idx)
+                    .ok_or_else(|| {
+                        anyhow::Error::new(SignatureVerificationFailed {
+                            reason: "layer descriptor out of bounds".to_string(),
+                        })
+                    })?;
+                let blob_digest = layer_desc.digest();
+
+                if layer_desc.size() == 0u64 {
+                    return Err(anyhow::Error::new(SignatureVerificationFailed {
+                        reason: format!("signature blob size is 0 for {role}"),
+                    }));
+                }
+
+                let blob_verity = artifact.layer_verity(blob_digest.as_ref()).ok_or_else(|| {
+                    anyhow::Error::new(SignatureVerificationFailed {
+                        reason: format!("verity not found for {blob_digest}"),
+                    })
+                })?;
+                let signature_blob =
+                    crate::oci_image::open_blob(repo, blob_digest, Some(blob_verity))?;
+
+                let digest_bytes = hex::decode(&entry.digest).map_err(|e| {
+                    anyhow::Error::new(SignatureVerificationFailed {
+                        reason: format!("invalid hex digest {}: {e}", entry.digest),
+                    })
+                })?;
+
+                verifier
+                    .verify_raw(&signature_blob, algorithm.kernel_id(), &digest_bytes)
+                    .map_err(|e| {
+                        anyhow::Error::new(SignatureVerificationFailed {
+                            reason: format!("signature verification failed for {role}: {e:#}"),
+                        })
+                    })?;
+                signature_verified = true;
+                verified_count += 1;
+            }
+
+            entries.push(VerificationEntry {
+                role,
+                expected_digest,
+                digest_ok,
+                signature_verified,
+                detail: None,
+            });
+        }
+    }
+
+    if verifier.is_some() && verified_count == 0 {
+        return Err(anyhow::Error::new(SignatureVerificationFailed {
+            reason: "no signature artifacts verified with the given certificate".to_string(),
+        }));
+    }
+
+    let verified_count = if verifier.is_some() {
+        verified_count
+    } else {
+        metadata_artifacts.len()
+    };
+
+    Ok(VerificationReport {
+        verified_count,
+        cert_supplied: verifier.is_some(),
+        mode: "artifact",
+        algorithm: detected_algorithm,
+        entries,
+    })
+}
+
+/// Build a fs-verity digest → PKCS#7 signature map suitable for kernel
+/// enrollment (`FS_IOC_ENABLE_VERITY`) of EROFS image objects, from
+/// whichever signature source is present: inline manifest/config/layer
+/// annotations, an already-locally-imported OCI referrer signature
+/// artifact, or both.
+///
+/// Only signature entries whose role corresponds to an EROFS image object
+/// actually stored via `write_image`/`commit_images` are included:
+/// per-layer (`SignatureType::Layer`), merged (`SignatureType::Merged`),
+/// and merged-bootable (`SignatureType::MergedBootable`). Manifest/config
+/// signatures cover the raw OCI JSON content, not EROFS objects, and are
+/// never applicable here.
+///
+/// `referrer_artifact_digests` should list any signature artifacts that
+/// have already been imported into `repo` (e.g. via
+/// [`crate::referrers::fetch_referrer_artifacts`]); this function performs
+/// no network I/O of its own.
+///
+/// This is best-effort: an annotation or artifact entry whose claimed
+/// digest doesn't match any real EROFS image digest is silently ignored.
+/// It's harmless because `write_image_with_sig` only ever consults the map
+/// by the digest it actually computed for the data being stored.
+pub(crate) fn collect_kernel_signatures<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    img: &crate::oci_image::OciImage<ObjectID>,
+    referrer_artifact_digests: &[OciDigest],
+) -> Result<HashMap<ObjectID, Vec<u8>>> {
+    fn is_erofs_signature(sig_type: SignatureType) -> bool {
+        matches!(
+            sig_type,
+            SignatureType::Layer | SignatureType::Merged | SignatureType::MergedBootable
+        )
+    }
+
+    let mut map = HashMap::new();
+
+    // Inline mode: each EROFS-relevant digest annotation has a sibling
+    // `{key}.sig` annotation holding the base64-encoded signature.
+    let scan_inline_annotations =
+        |annotations: &HashMap<String, String>, map: &mut HashMap<ObjectID, Vec<u8>>| {
+            for (key, value) in annotations {
+                if key.ends_with(".sig") {
+                    continue;
+                }
+                let Some((_alg, sig_type, digest_hex)) = parse_annotation_key_value(key, value)
+                else {
+                    continue;
+                };
+                if !is_erofs_signature(sig_type) {
+                    continue;
+                }
+                let Some(sig_base64) = annotations.get(&format!("{key}.sig")) else {
+                    continue;
+                };
+                let Ok(sig_bytes) = base64::engine::general_purpose::STANDARD.decode(sig_base64)
+                else {
+                    continue;
+                };
+                let Ok(id) = ObjectID::from_hex(&digest_hex) else {
+                    continue;
+                };
+                map.insert(id, sig_bytes);
+            }
+        };
+
+    if let Some(annotations) = img.manifest().config().annotations() {
+        scan_inline_annotations(annotations, &mut map);
+    }
+    for layer in img.manifest().layers() {
+        if let Some(annotations) = layer.annotations() {
+            scan_inline_annotations(annotations, &mut map);
+        }
+    }
+    if let Some(annotations) = img.manifest().annotations() {
+        scan_inline_annotations(annotations, &mut map);
+    }
+
+    // Referrer/artifact mode: signature entries are matched to their layer
+    // blob (which holds the raw signature bytes) by position, the same way
+    // `verify_image_report_artifact` does.
+    for artifact_digest in referrer_artifact_digests {
+        let Some(verity) =
+            repo.has_stream(&crate::oci_image::manifest_identifier(artifact_digest))?
+        else {
+            continue;
+        };
+        let artifact = crate::oci_image::OciImage::open(repo, artifact_digest, Some(&verity))?;
+        let Ok(parsed) = parse_signature_artifact(artifact.manifest()) else {
+            continue;
+        };
+        let layer_descriptors = artifact.layer_descriptors();
+        for (entry_idx, entry) in parsed.signature_entries.iter().enumerate() {
+            if !is_erofs_signature(entry.sig_type) {
+                continue;
+            }
+            let Some(layer_desc) = layer_descriptors.get(entry_idx) else {
+                continue;
+            };
+            let blob_digest = layer_desc.digest();
+            let Some(blob_verity) = artifact.layer_verity(blob_digest.as_ref()) else {
+                continue;
+            };
+            let Ok(sig_bytes) = crate::oci_image::open_blob(repo, blob_digest, Some(blob_verity))
+            else {
+                continue;
+            };
+            let Ok(id) = ObjectID::from_hex(&entry.digest) else {
+                continue;
+            };
+            map.insert(id, sig_bytes);
+        }
+    }
+
+    Ok(map)
+}

--- a/crates/composefs-oci/src/signing.rs
+++ b/crates/composefs-oci/src/signing.rs
@@ -1,0 +1,488 @@
+//! PKCS#7 signing and verification for composefs fsverity digests.
+//!
+//! This module produces DER-encoded PKCS#7 detached signatures compatible with
+//! the Linux kernel's fsverity signature verification. Signatures cover the
+//! `fsverity_formatted_digest` structure (see [`composefs::fsverity::formatted_digest`]).
+//!
+//! # External `openssl` CLI alternative
+//!
+//! For environments where linking against libssl is not desired, equivalent
+//! signatures can be produced using the `openssl` command-line tool:
+//!
+//! ```bash
+//! # 1. Compute the fsverity digest
+//! DIGEST=$(fsverity digest --hash-alg=sha256 myfile | awk '{print $1}')
+//!
+//! # 2. Construct the formatted_digest structure and sign it
+//! # (see doc/plans/oci-sealing-spec.md for the byte layout)
+//! printf 'FSVerity' > /tmp/formatted_digest
+//! printf '\x01\x00\x20\x00' >> /tmp/formatted_digest  # SHA256, 32 bytes
+//! echo -n "$DIGEST" | xxd -r -p >> /tmp/formatted_digest
+//!
+//! # 3. Sign with PKCS#7
+//! openssl smime -sign -binary -in /tmp/formatted_digest \
+//!     -signer cert.pem -inkey key.pem -outform DER -noattr -nocerts -out sig.der
+//! ```
+
+use anyhow::{Context, Result};
+use composefs::fsverity::FsVerityHashValue;
+use openssl::pkcs7::{Pkcs7, Pkcs7Flags};
+use openssl::pkey::{PKey, Private};
+use openssl::stack::Stack;
+use openssl::x509::X509;
+use openssl::x509::store::X509StoreBuilder;
+
+/// A signing key pair for fsverity PKCS#7 signatures.
+///
+/// Holds a certificate and private key used to produce DER-encoded PKCS#7
+/// detached signatures over the `fsverity_formatted_digest` structure.
+pub struct FsVeritySigningKey {
+    cert: X509,
+    key: PKey<Private>,
+}
+
+impl std::fmt::Debug for FsVeritySigningKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FsVeritySigningKey")
+            .field("cert_subject", &"<redacted>")
+            .finish()
+    }
+}
+
+impl FsVeritySigningKey {
+    /// Load from PEM-encoded certificate and private key.
+    ///
+    /// The certificate must correspond to the private key. It is used to
+    /// produce the signature but is *not* embedded in the resulting PKCS#7
+    /// blob (see the `NOCERTS` flag in `sign_raw`); verifiers are expected
+    /// to already have it out-of-band.
+    pub fn from_pem(cert_pem: &[u8], key_pem: &[u8]) -> Result<Self> {
+        let cert = X509::from_pem(cert_pem).context("parsing certificate PEM")?;
+        let key = PKey::private_key_from_pem(key_pem).context("parsing private key PEM")?;
+
+        // Verify cert and key correspond to each other
+        let cert_pubkey = cert
+            .public_key()
+            .context("extracting public key from certificate")?;
+        anyhow::ensure!(
+            cert_pubkey.public_eq(&key),
+            "certificate public key does not match the provided private key"
+        );
+
+        Ok(Self { cert, key })
+    }
+
+    /// Sign an fsverity digest, producing a DER-encoded PKCS#7 detached signature.
+    ///
+    /// The signature covers the `fsverity_formatted_digest` structure, making it
+    /// compatible with the kernel's `FS_IOC_ENABLE_VERITY` ioctl.
+    pub fn sign<ObjectID: FsVerityHashValue>(&self, digest: &ObjectID) -> Result<Vec<u8>> {
+        self.sign_raw(ObjectID::ALGORITHM.kernel_id(), digest.as_bytes())
+    }
+
+    /// Sign a raw digest with explicit algorithm, for when you don't have a typed ObjectID.
+    ///
+    /// # Arguments
+    /// * `algorithm` - Kernel hash algorithm identifier (1=SHA-256, 2=SHA-512)
+    /// * `digest` - Raw digest bytes
+    pub fn sign_raw(&self, algorithm: u8, digest: &[u8]) -> Result<Vec<u8>> {
+        // Validate algorithm and digest length
+        let expected_size = match algorithm {
+            1 => 32, // SHA-256
+            2 => 64, // SHA-512
+            _ => anyhow::bail!("unsupported fsverity algorithm: {algorithm}"),
+        };
+        anyhow::ensure!(
+            digest.len() == expected_size,
+            "digest length mismatch: expected {expected_size} bytes for algorithm {algorithm}, got {}",
+            digest.len()
+        );
+
+        let formatted =
+            composefs::fsverity::formatted_digest::format_fsverity_digest_raw(algorithm, digest);
+
+        let certs = Stack::new().context("failed to create certificate stack")?;
+        // NOCERTS omits the signer's certificate chain from the PKCS#7 blob.
+        // Both the kernel's builtin fs-verity verification (which falls back
+        // to matching the SignerInfo's issuer+serial directly against the
+        // `.fs-verity` keyring when no certs are embedded) and our own
+        // `FsVeritySignatureVerifier` (which is always given the trusted
+        // cert out-of-band, not extracted from the signature) verify fine
+        // without it. Omitting it keeps signatures at a few hundred bytes
+        // instead of several kilobytes.
+        let flags =
+            Pkcs7Flags::DETACHED | Pkcs7Flags::BINARY | Pkcs7Flags::NOATTR | Pkcs7Flags::NOCERTS;
+
+        let pkcs7 = Pkcs7::sign(&self.cert, &self.key, &certs, &formatted, flags)
+            .context("PKCS#7 signing failed")?;
+
+        pkcs7.to_der().context("PKCS#7 DER encoding failed")
+    }
+}
+
+/// Verifier for fsverity PKCS#7 signatures.
+///
+/// Holds a trusted certificate used to verify DER-encoded PKCS#7 detached
+/// signatures over the `fsverity_formatted_digest` structure.
+#[derive(Debug)]
+pub struct FsVeritySignatureVerifier {
+    cert: X509,
+}
+
+impl FsVeritySignatureVerifier {
+    /// Create a verifier trusting the given PEM-encoded certificate(s).
+    ///
+    /// The first certificate in the PEM data is used as the trusted root.
+    pub fn from_pem(cert_pem: &[u8]) -> Result<Self> {
+        let cert = X509::from_pem(cert_pem).context("failed to parse trusted certificate PEM")?;
+        Ok(Self { cert })
+    }
+
+    /// Verify a DER-encoded PKCS#7 signature against an fsverity digest.
+    ///
+    /// Returns `Ok(())` if the signature is valid for the given digest under
+    /// the trusted certificate. Returns an error if verification fails for
+    /// any reason (wrong digest, wrong key, malformed signature, etc.).
+    pub fn verify<ObjectID: FsVerityHashValue>(
+        &self,
+        signature: &[u8],
+        digest: &ObjectID,
+    ) -> Result<()> {
+        self.verify_raw(
+            signature,
+            ObjectID::ALGORITHM.kernel_id(),
+            digest.as_bytes(),
+        )
+    }
+
+    /// Verify with raw algorithm + digest bytes.
+    ///
+    /// # Arguments
+    /// * `signature` - DER-encoded PKCS#7 detached signature
+    /// * `algorithm` - Kernel hash algorithm identifier (1=SHA-256, 2=SHA-512)
+    /// * `digest` - Raw digest bytes
+    pub fn verify_raw(&self, signature: &[u8], algorithm: u8, digest: &[u8]) -> Result<()> {
+        // Validate algorithm and digest length
+        let expected_size = match algorithm {
+            1 => 32, // SHA-256
+            2 => 64, // SHA-512
+            _ => anyhow::bail!("unsupported fsverity algorithm: {algorithm}"),
+        };
+        anyhow::ensure!(
+            digest.len() == expected_size,
+            "digest length mismatch: expected {expected_size} bytes for algorithm {algorithm}, got {}",
+            digest.len()
+        );
+
+        let formatted =
+            composefs::fsverity::formatted_digest::format_fsverity_digest_raw(algorithm, digest);
+
+        let pkcs7 = Pkcs7::from_der(signature).context("failed to parse PKCS#7 DER signature")?;
+
+        let mut store_builder = X509StoreBuilder::new().context("failed to create X509 store")?;
+        store_builder
+            .add_cert(self.cert.clone())
+            .context("failed to add trusted cert to store")?;
+        let store = store_builder.build();
+
+        let mut certs = Stack::new().context("failed to create certificate stack")?;
+        certs
+            .push(self.cert.clone())
+            .context("failed to push cert to stack")?;
+
+        // Do NOT use Pkcs7Flags::NOVERIFY — we want full certificate chain validation.
+        let flags = Pkcs7Flags::BINARY;
+        pkcs7
+            .verify(&certs, &store, Some(&formatted), None, flags)
+            .context("PKCS#7 signature verification failed")?;
+
+        Ok(())
+    }
+}
+
+/// Generate a self-signed test certificate and RSA-2048 private key.
+/// Returns `(cert_pem, key_pem)`.
+///
+/// This is intended for use in tests and benchmarks. It is available when the
+/// `test` feature is enabled so that consumers (such as integration tests) can
+/// share the same key-generation logic without duplicating it.
+#[cfg(any(test, feature = "test"))]
+pub fn generate_test_keypair() -> (Vec<u8>, Vec<u8>) {
+    use openssl::asn1::Asn1Time;
+    use openssl::hash::MessageDigest;
+    use openssl::pkey::PKey;
+    use openssl::rsa::Rsa;
+    use openssl::x509::{X509Builder, X509NameBuilder};
+
+    let rsa = Rsa::generate(2048).expect("RSA key generation");
+    let key = PKey::from_rsa(rsa).expect("PKey from RSA");
+
+    let mut name_builder = X509NameBuilder::new().expect("X509NameBuilder");
+    name_builder
+        .append_entry_by_text("CN", "composefs-test")
+        .expect("append CN");
+    let name = name_builder.build();
+
+    let mut builder = X509Builder::new().expect("X509Builder");
+    builder.set_version(2).expect("set version");
+    builder.set_subject_name(&name).expect("set subject");
+    builder.set_issuer_name(&name).expect("set issuer");
+    builder.set_pubkey(&key).expect("set pubkey");
+
+    let not_before = Asn1Time::days_from_now(0).expect("not_before");
+    let not_after = Asn1Time::days_from_now(365).expect("not_after");
+    builder.set_not_before(&not_before).expect("set not_before");
+    builder.set_not_after(&not_after).expect("set not_after");
+
+    builder
+        .sign(&key, MessageDigest::sha256())
+        .expect("self-sign");
+    let cert = builder.build();
+
+    let cert_pem = cert.to_pem().expect("cert to PEM");
+    let key_pem = key.private_key_to_pem_pkcs8().expect("key to PEM");
+
+    (cert_pem, key_pem)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use composefs::fsverity::{Sha256HashValue, Sha512HashValue};
+
+    #[test]
+    fn test_rejects_mismatched_cert_key() {
+        let (cert_pem_a, _key_pem_a) = generate_test_keypair();
+        let (_cert_pem_b, key_pem_b) = generate_test_keypair();
+        let result = FsVeritySigningKey::from_pem(&cert_pem_a, &key_pem_b);
+        assert!(result.is_err());
+        let err = format!("{:#}", result.unwrap_err());
+        assert!(err.contains("does not match"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_sign_and_verify_sha256() {
+        let (cert_pem, key_pem) = generate_test_keypair();
+        let signer = FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let digest = Sha256HashValue::from_hex(
+            "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+        )
+        .unwrap();
+
+        let sig = signer.sign(&digest).unwrap();
+        verifier.verify(&sig, &digest).unwrap();
+    }
+
+    /// Regression test for signature bloat: without `Pkcs7Flags::NOCERTS`,
+    /// the full X.509 cert chain gets embedded in every signature, pushing
+    /// an RSA-2048 signature from a few hundred bytes to over a kilobyte.
+    /// Since verification never relies on a cert extracted from the
+    /// signature itself (see the comment at the `flags` definition in
+    /// `sign_raw`), the cert should never be embedded.
+    #[test]
+    fn test_signature_omits_certificate() {
+        let (cert_pem, key_pem) = generate_test_keypair();
+        let signer = FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+
+        let digest = Sha256HashValue::from_hex(
+            "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+        )
+        .unwrap();
+        let sig = signer.sign(&digest).unwrap();
+
+        // An RSA-2048 detached PKCS#7 signature with no embedded cert is
+        // well under 512 bytes; with the cert embedded it exceeds 1000.
+        assert!(
+            sig.len() < 512,
+            "signature unexpectedly large ({} bytes); is the certificate being embedded?",
+            sig.len()
+        );
+
+        // Cross-check directly against the parsed PKCS#7 structure: it must
+        // carry no certificates at all.
+        let pkcs7 = Pkcs7::from_der(&sig).unwrap();
+        let embedded_certs = pkcs7.signed().and_then(|s| s.certificates());
+        assert!(
+            embedded_certs.is_none_or(|c| c.is_empty()),
+            "PKCS#7 signature should not carry any embedded certificates"
+        );
+    }
+
+    #[test]
+    fn test_sign_and_verify_sha512() {
+        let (cert_pem, key_pem) = generate_test_keypair();
+        let signer = FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let hex_str = "ab".repeat(64); // 64 bytes = valid SHA-512
+        let digest = Sha512HashValue::from_hex(&hex_str).unwrap();
+
+        let sig = signer.sign(&digest).unwrap();
+        verifier.verify(&sig, &digest).unwrap();
+    }
+
+    #[test]
+    fn test_verify_rejects_wrong_digest() {
+        let (cert_pem, key_pem) = generate_test_keypair();
+        let signer = FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let digest_a = Sha256HashValue::from_hex(
+            "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+        )
+        .unwrap();
+        let digest_b = Sha256HashValue::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .unwrap();
+
+        let sig = signer.sign(&digest_a).unwrap();
+        let result = verifier.verify(&sig, &digest_b);
+        assert!(
+            result.is_err(),
+            "verification should fail with wrong digest"
+        );
+    }
+
+    #[test]
+    fn test_verify_rejects_wrong_cert() {
+        let (cert_a, key_a) = generate_test_keypair();
+        let (cert_b, _key_b) = generate_test_keypair();
+
+        let signer = FsVeritySigningKey::from_pem(&cert_a, &key_a).unwrap();
+        let verifier = FsVeritySignatureVerifier::from_pem(&cert_b).unwrap();
+
+        let digest = Sha256HashValue::from_hex(
+            "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+        )
+        .unwrap();
+
+        let sig = signer.sign(&digest).unwrap();
+        let result = verifier.verify(&sig, &digest);
+        assert!(
+            result.is_err(),
+            "verification should fail with untrusted cert"
+        );
+    }
+
+    #[test]
+    fn test_verify_rejects_tampered_signature() {
+        let (cert_pem, key_pem) = generate_test_keypair();
+        let signer = FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let digest = Sha256HashValue::from_hex(
+            "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+        )
+        .unwrap();
+
+        let mut sig = signer.sign(&digest).unwrap();
+
+        // Tamper with a byte near the end of the signature (inside the actual
+        // signature data, not the ASN.1 framing at the beginning).
+        let tamper_idx = sig.len() - 10;
+        sig[tamper_idx] ^= 0xff;
+
+        let result = verifier.verify(&sig, &digest);
+        assert!(
+            result.is_err(),
+            "verification should fail with tampered signature"
+        );
+    }
+
+    #[test]
+    fn test_sign_raw_matches_typed() {
+        let (cert_pem, key_pem) = generate_test_keypair();
+        let signer = FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+        let verifier = FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+
+        let hex = "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64";
+        let digest = Sha256HashValue::from_hex(hex).unwrap();
+        let raw_bytes = hex::decode(hex).unwrap();
+
+        // Both signing paths should produce signatures that verify
+        let sig_typed = signer.sign(&digest).unwrap();
+        let sig_raw = signer
+            .sign_raw(Sha256HashValue::ALGORITHM.kernel_id(), &raw_bytes)
+            .unwrap();
+
+        // The DER content may differ (timestamps, nonces) but both must verify
+        verifier.verify(&sig_typed, &digest).unwrap();
+        verifier
+            .verify_raw(&sig_raw, Sha256HashValue::ALGORITHM.kernel_id(), &raw_bytes)
+            .unwrap();
+
+        // And cross-verify: raw sig verifies with typed API, typed sig with raw API
+        verifier.verify(&sig_raw, &digest).unwrap();
+        verifier
+            .verify_raw(
+                &sig_typed,
+                Sha256HashValue::ALGORITHM.kernel_id(),
+                &raw_bytes,
+            )
+            .unwrap();
+    }
+
+    /// Data-driven tests for sign_raw / verify_raw input validation.
+    #[test]
+    fn test_sign_raw_rejects_bad_inputs() {
+        let (cert_pem, key_pem) = generate_test_keypair();
+        let signer = FsVeritySigningKey::from_pem(&cert_pem, &key_pem).unwrap();
+
+        // (algorithm, digest_bytes, expected_err_substring)
+        let cases: &[(u8, &[u8], &str)] = &[
+            (0, &[0u8; 32], "unsupported"),
+            (3, &[0u8; 32], "unsupported"),
+            (255, &[0u8; 32], "unsupported"),
+            (1, &[0xab; 64], "digest length mismatch"), // SHA-256 expects 32, got 64
+            (2, &[0xab; 32], "digest length mismatch"), // SHA-512 expects 64, got 32
+            (1, &[], "digest length mismatch"),         // empty digest
+        ];
+
+        for (alg, digest, expected) in cases {
+            let err = signer.sign_raw(*alg, digest).unwrap_err();
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains(expected),
+                "sign_raw(alg={alg}, len={}): unexpected error: {msg}",
+                digest.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_verify_raw_rejects_bad_inputs() {
+        let (cert_pem, _) = generate_test_keypair();
+        let verifier = FsVeritySignatureVerifier::from_pem(&cert_pem).unwrap();
+        let dummy_sig = &[0x30, 0x82, 0x01, 0x00];
+
+        // (signature, algorithm, digest, expected_err_substring)
+        let cases: &[(&[u8], u8, &[u8], &str)] = &[
+            (dummy_sig, 3, &[0u8; 64], "unsupported"),
+            (dummy_sig, 0, &[0u8; 32], "unsupported"),
+            (dummy_sig, 2, &[0xab; 32], "digest length mismatch"), // SHA-512 expects 64
+            (dummy_sig, 1, &[0xab; 64], "digest length mismatch"), // SHA-256 expects 32
+            (b"not-valid-der", 1, &[0xab; 32], "PKCS#7 DER"),
+            (&[], 1, &[0xab; 32], "PKCS#7 DER"), // empty signature
+        ];
+
+        for (sig, alg, digest, expected) in cases {
+            let err = verifier.verify_raw(sig, *alg, digest).unwrap_err();
+            let msg = format!("{err:#}");
+            assert!(
+                msg.contains(expected),
+                "verify_raw(alg={alg}, sig_len={}, digest_len={}): unexpected error: {msg}",
+                sig.len(),
+                digest.len()
+            );
+        }
+    }
+
+    #[test]
+    fn test_from_pem_rejects_garbage() {
+        assert!(FsVeritySigningKey::from_pem(b"garbage", b"garbage").is_err());
+        assert!(FsVeritySignatureVerifier::from_pem(b"garbage").is_err());
+    }
+}

--- a/crates/composefs-oci/src/skopeo.rs
+++ b/crates/composefs-oci/src/skopeo.rs
@@ -614,19 +614,80 @@ pub async fn pull_image<ObjectID: FsVerityHashValue>(
             .with_context(|| format!("Unable to pull container image {imgref}"))?
     };
 
+    // Supplement the skopeo-based pull by fetching referrer artifacts
+    // (composefs signature artifacts) directly from the registry via
+    // oci-client. Skopeo doesn't support the OCI Referrers API, so without
+    // this, --require-signature always fails after pulling.
+    //
+    // This must happen *before* EROFS generation below: kernel fs-verity
+    // signature enrollment needs the referrer-mode signature bytes to be
+    // available locally while the EROFS image is being written, not
+    // afterwards. We only have the *registry* manifest digest at this
+    // point (EROFS generation hasn't rewritten anything yet), which is
+    // exactly what the Referrers API query needs.
+    #[cfg(feature = "oci-client")]
+    let referrer_artifacts = if image_ref.transport == Transport::Registry {
+        match crate::referrers::fetch_referrer_artifacts(
+            repo,
+            imgref,
+            result.manifest_digest.as_ref(),
+        )
+        .await
+        {
+            Ok(artifacts) => artifacts,
+            Err(e) => {
+                tracing::warn!("Failed to fetch referrer artifacts: {e:#}");
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
+    #[cfg(not(feature = "oci-client"))]
+    let referrer_artifacts: Vec<crate::OciDigest> = Vec::new();
+
     // Generate the composefs EROFS image and link it to the config splitstream.
     // For container images this rewrites the config+manifest with the EROFS ref
     // and tags the final manifest. Artifacts are skipped and tagged as-is.
-    let erofs = crate::ensure_oci_composefs_erofs(
+    // Any inline or referrer-mode signatures found above are enrolled with
+    // the kernel via FS_IOC_ENABLE_VERITY as the image is stored.
+    let erofs = crate::ensure_oci_composefs_erofs_with_sig(
         repo,
         &result.manifest_digest,
         Some(&result.manifest_verity),
         reference,
+        &referrer_artifacts,
     )?;
     if erofs.is_none() {
         // Not a container image (artifact) — tag the manifest directly
         if let Some(name) = reference {
             tag_image(repo, &result.manifest_digest, name)?;
+        }
+    }
+
+    // Now that EROFS generation (if any) has settled the final local
+    // manifest digest, register the referrer relationship so the imported
+    // artifacts become discoverable via `cfsctl oci verify`.
+    #[cfg(feature = "oci-client")]
+    if !referrer_artifacts.is_empty() {
+        // ensure_oci_composefs_erofs_with_sig may rewrite the manifest, so
+        // the local manifest digest can differ from the registry digest.
+        // Use the local (post-EROFS-rewrite) digest here so referrers
+        // remain discoverable from the tag/digest actually stored locally.
+        let local_digest = if let Some(name) = reference {
+            crate::oci_image::resolve_ref(repo, name)
+                .map(|(d, _)| d)
+                .unwrap_or_else(|_| result.manifest_digest.clone())
+        } else {
+            result.manifest_digest.clone()
+        };
+        match crate::referrers::register_referrers(repo, local_digest.as_ref(), &referrer_artifacts)
+        {
+            Ok(count) if count > 0 => {
+                tracing::info!("Imported {count} referrer artifact(s) from registry");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!("Failed to register referrer artifacts: {e:#}"),
         }
     }
 

--- a/crates/composefs-oci/src/test_util.rs
+++ b/crates/composefs-oci/src/test_util.rs
@@ -959,7 +959,7 @@ pub fn create_test_bootable_oci_image(
     let rt = tokio::runtime::Runtime::new()?;
     let img = rt.block_on(create_bootable_image(&repo, Some(tag), 1));
     ensure_erofs_for_image(&repo, tag)?;
-    crate::boot::generate_boot_image(&repo, &img.manifest_digest)?;
+    crate::boot::generate_boot_image(&repo, &img.manifest_digest, Some(tag))?;
     Ok(())
 }
 

--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [features]
 'pre-6.15' = ['tempfile']
 rhel9 = ['pre-6.15', 'composefs-ioctls/loop-device']
+keyring = ['composefs-ioctls/keyring']
 test = ["tempfile"]
 varlink = ['dep:zlink-core']
 

--- a/crates/composefs/src/filesystem_ops.rs
+++ b/crates/composefs/src/filesystem_ops.rs
@@ -38,6 +38,25 @@ impl<ObjectID: FsVerityHashValue> FileSystem<ObjectID> {
         repository: &Repository<ObjectID>,
         image_name: Option<&str>,
     ) -> Result<HashMap<FormatVersion, ObjectID>> {
+        self.commit_images_with_sig(repository, image_name, None)
+    }
+
+    /// Like [`commit_images`](Self::commit_images), but enrolls a kernel
+    /// fs-verity signature for each generated EROFS image whose digest is
+    /// found in `signatures`.
+    ///
+    /// `signatures` maps the expected fs-verity digest of an EROFS image to
+    /// its PKCS#7 signature, as parsed from either inline manifest
+    /// annotations or an OCI referrers-API signature artifact. Images not
+    /// present in the map are stored unsigned, exactly as with
+    /// [`commit_images`](Self::commit_images).
+    #[context("Committing filesystem as EROFS images")]
+    pub fn commit_images_with_sig(
+        &self,
+        repository: &Repository<ObjectID>,
+        image_name: Option<&str>,
+        signatures: Option<&HashMap<ObjectID, Vec<u8>>>,
+    ) -> Result<HashMap<FormatVersion, ObjectID>> {
         // Validate once before writing any version.
         // add_overlay_whiteouts() for V1 is called inside mkfs_erofs_inner (on a clone).
         validate_filesystem(self)?;
@@ -54,7 +73,7 @@ impl<ObjectID: FsVerityHashValue> FileSystem<ObjectID> {
                 #[cfg(test)]
                 None,
             );
-            let id = repository.write_image(name, &image_data)?;
+            let id = repository.write_image_with_sig(name, &image_data, signatures)?;
             result.insert(version, id);
         }
         Ok(result)

--- a/crates/composefs/src/fsverity/formatted_digest.rs
+++ b/crates/composefs/src/fsverity/formatted_digest.rs
@@ -1,0 +1,117 @@
+//! Construction of the `fsverity_formatted_digest` byte buffer.
+//!
+//! The kernel verifies PKCS#7 signatures over a specific byte structure called
+//! `fsverity_formatted_digest`. This module provides functions to construct that
+//! structure from either typed hash values or raw algorithm + digest bytes.
+//!
+//! See <https://www.kernel.org/doc/html/latest/filesystems/fsverity.html#built-in-signature-verification>
+
+use super::FsVerityHashValue;
+
+/// The ASCII magic bytes at the start of a `fsverity_formatted_digest`.
+const FSVERITY_MAGIC: &[u8; 8] = b"FSVerity";
+
+/// Constructs the `fsverity_formatted_digest` byte buffer.
+///
+/// This is the data that must be signed with PKCS#7 to create a kernel-compatible
+/// fsverity signature. The kernel reconstructs this structure from the measured
+/// digest and verifies the signature against it.
+///
+/// Layout:
+/// - `[0..8]`: `"FSVerity"` ASCII magic
+/// - `[8..10]`: hash algorithm (u16 LE, 1=SHA-256, 2=SHA-512)
+/// - `[10..12]`: digest size in bytes (u16 LE)
+/// - `[12..]`: raw digest bytes
+pub fn format_fsverity_digest<H: FsVerityHashValue>(digest: &H) -> Vec<u8> {
+    let digest_bytes = digest.as_bytes();
+    format_fsverity_digest_raw(H::ALGORITHM.kernel_id(), digest_bytes)
+}
+
+/// Constructs the `fsverity_formatted_digest` from a raw algorithm identifier and digest bytes.
+///
+/// This is useful when the algorithm/digest are known dynamically rather than
+/// via a typed `FsVerityHashValue`.
+///
+/// # Arguments
+/// * `algorithm` - Kernel hash algorithm identifier (1=SHA-256, 2=SHA-512)
+/// * `digest` - Raw digest bytes
+pub fn format_fsverity_digest_raw(algorithm: u8, digest: &[u8]) -> Vec<u8> {
+    let digest_size = digest.len() as u16;
+
+    let mut buf = Vec::with_capacity(12 + digest.len());
+    buf.extend_from_slice(FSVERITY_MAGIC);
+    buf.extend_from_slice(&(algorithm as u16).to_le_bytes());
+    buf.extend_from_slice(&digest_size.to_le_bytes());
+    buf.extend_from_slice(digest);
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use zerocopy::IntoBytes;
+
+    use super::*;
+    use crate::fsverity::{Sha256HashValue, Sha512HashValue};
+
+    #[test]
+    fn test_format_sha256() {
+        let digest = Sha256HashValue::from_hex(
+            "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+        )
+        .unwrap();
+        let buf = format_fsverity_digest(&digest);
+
+        // Total length: 8 (magic) + 2 (alg) + 2 (size) + 32 (digest) = 44
+        assert_eq!(buf.len(), 44);
+        assert_eq!(&buf[0..8], b"FSVerity");
+        assert_eq!(u16::from_le_bytes([buf[8], buf[9]]), 1); // SHA-256
+        assert_eq!(u16::from_le_bytes([buf[10], buf[11]]), 32);
+        assert_eq!(&buf[12..], digest.as_bytes());
+    }
+
+    #[test]
+    fn test_format_sha512() {
+        let hex_str = "a".repeat(128); // 64 bytes
+        let digest = Sha512HashValue::from_hex(&hex_str).unwrap();
+        let buf = format_fsverity_digest(&digest);
+
+        // Total length: 8 + 2 + 2 + 64 = 76
+        assert_eq!(buf.len(), 76);
+        assert_eq!(&buf[0..8], b"FSVerity");
+        assert_eq!(u16::from_le_bytes([buf[8], buf[9]]), 2); // SHA-512
+        assert_eq!(u16::from_le_bytes([buf[10], buf[11]]), 64);
+        assert_eq!(&buf[12..], digest.as_bytes());
+    }
+
+    #[test]
+    fn test_format_roundtrip() {
+        let digest = Sha256HashValue::from_hex(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        )
+        .unwrap();
+        let buf = format_fsverity_digest(&digest);
+
+        // Parse the fields back out
+        let magic = &buf[0..8];
+        let alg = u16::from_le_bytes([buf[8], buf[9]]);
+        let size = u16::from_le_bytes([buf[10], buf[11]]);
+        let raw_digest = &buf[12..];
+
+        assert_eq!(magic, b"FSVerity");
+        assert_eq!(alg, 1);
+        assert_eq!(size, 32);
+        assert_eq!(raw_digest, digest.as_bytes());
+    }
+
+    #[test]
+    fn test_format_raw_matches_typed() {
+        let digest = Sha256HashValue::from_hex(
+            "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+        )
+        .unwrap();
+
+        let typed = format_fsverity_digest(&digest);
+        let raw = format_fsverity_digest_raw(1, digest.as_bytes());
+        assert_eq!(typed, raw);
+    }
+}

--- a/crates/composefs/src/fsverity/hashvalue.rs
+++ b/crates/composefs/src/fsverity/hashvalue.rs
@@ -316,6 +316,20 @@ impl Algorithm {
         }
     }
 
+    /// The Merkle-tree block size in bytes (e.g. 4096 for lg_blocksize 12).
+    pub const fn block_size(&self) -> u32 {
+        1u32 << self.lg_blocksize()
+    }
+
+    /// The digest size in bytes for this algorithm's hash
+    /// (32 for SHA-256, 64 for SHA-512).
+    pub const fn digest_size(&self) -> usize {
+        match self {
+            Self::Sha256 { .. } => 32,
+            Self::Sha512 { .. } => 64,
+        }
+    }
+
     /// Check whether this algorithm is compatible with the given hash type.
     pub fn is_compatible<H: FsVerityHashValue>(&self) -> bool {
         std::mem::discriminant(self) == std::mem::discriminant(&H::ALGORITHM)

--- a/crates/composefs/src/fsverity/ioctl.rs
+++ b/crates/composefs/src/fsverity/ioctl.rs
@@ -37,6 +37,15 @@ pub(super) fn fs_ioc_enable_verity_with_sig<H: FsVerityHashValue>(
     )
 }
 
+/// Check whether a file has a kernel-enrolled fs-verity builtin signature.
+///
+/// Unlike the other wrappers in this module, this isn't parameterized by
+/// [`FsVerityHashValue`]: `FS_IOC_READ_VERITY_METADATA` doesn't depend on
+/// the hash algorithm.
+pub(super) fn fs_ioc_has_verity_signature(fd: impl AsFd) -> std::io::Result<bool> {
+    composefs_ioctls::fsverity::fs_ioc_has_verity_signature(fd)
+}
+
 /// Measure the fsverity digest of the provided file descriptor.
 ///
 /// Returns the digest as the appropriate FsVerityHashValue type.

--- a/crates/composefs/src/fsverity/ioctl.rs
+++ b/crates/composefs/src/fsverity/ioctl.rs
@@ -21,6 +21,22 @@ pub(super) fn fs_ioc_enable_verity<H: FsVerityHashValue>(
     composefs_ioctls::fsverity::fs_ioc_enable_verity(fd.as_fd(), H::ALGORITHM.kernel_id(), 4096)
 }
 
+/// Enable fsverity on the target file with an optional PKCS#7 signature.
+///
+/// Like [`fs_ioc_enable_verity`] but also passes a DER-encoded detached
+/// signature to the kernel for validation against the `.fs-verity` keyring.
+pub(super) fn fs_ioc_enable_verity_with_sig<H: FsVerityHashValue>(
+    fd: impl AsFd,
+    signature: Option<&[u8]>,
+) -> Result<(), EnableVerityError> {
+    composefs_ioctls::fsverity::fs_ioc_enable_verity_with_sig(
+        fd.as_fd(),
+        H::ALGORITHM.kernel_id(),
+        4096,
+        signature,
+    )
+}
+
 /// Measure the fsverity digest of the provided file descriptor.
 ///
 /// Returns the digest as the appropriate FsVerityHashValue type.

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -118,9 +118,22 @@ pub fn enable_verity_raw_with_sig<H: FsVerityHashValue>(
 pub fn enable_verity_with_retry<H: FsVerityHashValue>(
     fd: impl AsFd,
 ) -> Result<(), EnableVerityError> {
+    enable_verity_with_retry_with_sig::<H>(fd, None)
+}
+
+/// Enable fs-verity on the given file, retrying if the file is opened for
+/// writing, optionally with a PKCS#7 signature.
+///
+/// Like [`enable_verity_with_retry`], but accepts an optional DER-encoded
+/// PKCS#7 detached signature, which is passed through to
+/// [`enable_verity_raw_with_sig`].
+pub fn enable_verity_with_retry_with_sig<H: FsVerityHashValue>(
+    fd: impl AsFd,
+    signature: Option<&[u8]>,
+) -> Result<(), EnableVerityError> {
     let mut attempt = 1;
     loop {
-        match enable_verity_raw::<H>(&fd) {
+        match enable_verity_raw_with_sig::<H>(&fd, signature) {
             Err(EnableVerityError::FileOpenedForWrite) if attempt < 3 => {
                 std::thread::sleep(std::time::Duration::from_millis(1));
                 attempt += 1;
@@ -155,22 +168,39 @@ pub fn enable_verity_maybe_copy<H: FsVerityHashValue>(
     dirfd: impl AsFd,
     fd: BorrowedFd,
 ) -> Result<Option<OwnedFd>, EnableVerityError> {
-    match enable_verity_with_retry::<H>(&fd) {
+    enable_verity_maybe_copy_with_sig::<H>(dirfd, fd, None)
+}
+
+/// Enable fs-verity on the given file, optionally with a PKCS#7 signature,
+/// making a copy if necessary.
+///
+/// Like [`enable_verity_maybe_copy`], but accepts an optional DER-encoded
+/// PKCS#7 detached signature, which is passed through to
+/// [`enable_verity_raw_with_sig`] (and to the retry-on-copy path, if a copy
+/// turns out to be necessary). See [`enable_verity_maybe_copy`] for the full
+/// semantics around when a copy is made.
+pub fn enable_verity_maybe_copy_with_sig<H: FsVerityHashValue>(
+    dirfd: impl AsFd,
+    fd: BorrowedFd,
+    signature: Option<&[u8]>,
+) -> Result<Option<OwnedFd>, EnableVerityError> {
+    match enable_verity_with_retry_with_sig::<H>(&fd, signature) {
         Ok(()) => Ok(None),
         Err(EnableVerityError::FileOpenedForWrite) => {
-            let fd = enable_verity_on_copy::<H>(dirfd, fd)?;
+            let fd = enable_verity_on_copy_with_sig::<H>(dirfd, fd, signature)?;
             Ok(Some(fd))
         }
         Err(other) => Err(other),
     }
 }
 
-/// Enable fs-verity on a new copy of `fd`, consuming `fd` and
-/// returning the new copy.  The copy is created via O_TMPFILE
-/// relative to `dirfd`.
-fn enable_verity_on_copy<H: FsVerityHashValue>(
+/// Enable fs-verity on a new copy of `fd`, consuming `fd` and returning the
+/// new copy, optionally enrolling a PKCS#7 signature.  The copy is created
+/// via O_TMPFILE relative to `dirfd`.
+fn enable_verity_on_copy_with_sig<H: FsVerityHashValue>(
     dirfd: impl AsFd,
     fd: BorrowedFd,
+    signature: Option<&[u8]>,
 ) -> Result<OwnedFd, EnableVerityError> {
     let fd = fd.try_clone_to_owned().map_err(EnableVerityError::Io)?;
     let mut fd = File::from(fd);
@@ -197,10 +227,28 @@ fn enable_verity_on_copy<H: FsVerityHashValue>(
         )
         .map_err(|e| EnableVerityError::Io(e.into()))?;
         drop(new_rw_fd);
-        if enable_verity_with_retry::<H>(&new_ro_fd).is_ok() {
+        if enable_verity_with_retry_with_sig::<H>(&new_ro_fd, signature).is_ok() {
             return Ok(new_ro_fd);
         }
     }
+}
+
+/// Check whether a file has a kernel-enrolled fs-verity builtin signature.
+///
+/// This is a thin wrapper for the `FS_IOC_READ_VERITY_METADATA` ioctl with
+/// `FS_VERITY_METADATA_TYPE_SIGNATURE`. It's used to observe whether
+/// [`enable_verity_raw_with_sig`] actually got a signature enrolled with the
+/// kernel, as opposed to just enabling plain verity: a repository may fall
+/// back to enabling verity without a signature when the `.fs-verity`
+/// keyring has no certificate able to verify it, so `signature.is_some()`
+/// at the call site doesn't guarantee kernel enrollment succeeded.
+///
+/// Returns `Ok(false)` if fs-verity is enabled but no signature was
+/// enrolled (kernel reports `ENODATA`), `Ok(true)` if a signature is
+/// present, and passes through any other ioctl error (e.g. fs-verity not
+/// enabled on the file, or not supported by the filesystem).
+pub fn has_verity_signature(fd: impl AsFd) -> std::io::Result<bool> {
+    ioctl::fs_ioc_has_verity_signature(fd)
 }
 
 /// Measures fs-verity on the given file.
@@ -746,6 +794,45 @@ mod tests {
             .unwrap();
 
         // The new fd has the correct data
+        assert!(
+            ensure_verity_equal(
+                fd,
+                &Sha256HashValue::from_hex(
+                    "1e2eaa4202d750a41174ee454970b92c1bc2f925b1e35076d8c7d5f56362ba64",
+                )
+                .unwrap(),
+            )
+            .is_ok()
+        );
+    }
+
+    // The following two tests mirror `test_enable_verity_maybe_copy_{without,with}_copy`
+    // above, but go through the `_with_sig` entry point with `signature: None`. This
+    // exercises the API threading added for kernel signature enrollment without
+    // requiring a fs-verity builtin-signatures-capable kernel/keyring, which isn't
+    // available in this sandboxed test environment.
+
+    #[test]
+    fn test_enable_verity_maybe_copy_with_sig_none_without_copy() {
+        let (tempdir, fd) = empty_file_in_tmpdir(OFlags::RDONLY, 0o644.into());
+        let tempdir_fd = File::open(tempdir.path()).unwrap();
+        let fd =
+            enable_verity_maybe_copy_with_sig::<Sha256HashValue>(&tempdir_fd, fd.as_fd(), None)
+                .unwrap();
+        assert!(fd.is_none());
+    }
+
+    #[test]
+    fn test_enable_verity_maybe_copy_with_sig_none_with_copy() {
+        let (tempdir, fd) = empty_file_in_tmpdir(OFlags::RDWR, 0o644.into());
+        let tempdir_fd = File::open(tempdir.path()).unwrap();
+        let mut fd = File::from(fd);
+        let _ = fd.write(b"hello world").unwrap();
+        let fd =
+            enable_verity_maybe_copy_with_sig::<Sha256HashValue>(&tempdir_fd, fd.as_fd(), None)
+                .unwrap()
+                .unwrap();
+
         assert!(
             ensure_verity_equal(
                 fd,

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -5,6 +5,7 @@
 //! verity, and hash value types for SHA-256 and SHA-512.
 
 mod digest;
+pub mod formatted_digest;
 mod hashvalue;
 mod ioctl;
 
@@ -77,6 +78,19 @@ pub fn compute_verity<H: FsVerityHashValue>(data: &[u8]) -> H {
 /// currently hardcoded to 4096.  Salt is not supported.
 pub fn enable_verity_raw<H: FsVerityHashValue>(fd: impl AsFd) -> Result<(), EnableVerityError> {
     ioctl::fs_ioc_enable_verity::<H>(fd)
+}
+
+/// Enable fs-verity on the given file, optionally with a PKCS#7 signature.
+///
+/// Like `enable_verity_raw`, but accepts an optional DER-encoded PKCS#7 detached
+/// signature over the [`formatted_digest::format_fsverity_digest`] structure. If
+/// provided, the kernel will verify it against the `.fs-verity` keyring before
+/// enabling verity.
+pub fn enable_verity_raw_with_sig<H: FsVerityHashValue>(
+    fd: impl AsFd,
+    signature: Option<&[u8]>,
+) -> Result<(), EnableVerityError> {
+    ioctl::fs_ioc_enable_verity_with_sig::<H>(fd, signature)
 }
 
 /// Enable fs-verity on the given file, retrying if file is opened for writing.
@@ -297,6 +311,10 @@ pub fn ensure_verity_equal(
         })
     }
 }
+
+// Re-export keyring from composefs-ioctls where the unsafe code lives
+#[cfg(feature = "keyring")]
+pub use composefs_ioctls::keyring::{KeyringError, inject_fsverity_cert};
 
 #[cfg(test)]
 mod tests {

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -101,7 +101,8 @@ use once_cell::sync::OnceCell;
 use rustix::{
     fs::{
         Access, AtFlags, CWD, Dir, FileType, FlockOperation, Mode, OFlags, StatVfsMountFlags,
-        accessat, flock, fstatvfs, linkat, mkdirat, openat, readlinkat, statat, syncfs, unlinkat,
+        accessat, flock, fstatvfs, linkat, mkdirat, openat, readlinkat, renameat, statat, syncfs,
+        unlinkat,
     },
     io::{Errno, Result as ErrnoResult},
 };
@@ -111,12 +112,13 @@ use crate::{
     fsverity::{
         Algorithm, CompareVerityError, DEFAULT_LG_BLOCKSIZE, EnableVerityError, FsVerityHashValue,
         FsVerityHasher, MeasureVerityError, compute_verity, enable_verity_maybe_copy,
-        ensure_verity_equal, has_verity, measure_verity, measure_verity_opt,
+        enable_verity_maybe_copy_with_sig, ensure_verity_equal, has_verity, measure_verity,
+        measure_verity_opt,
     },
     mount::{MountOptions, VerityRequirement, composefs_fsmount, mount_at},
     shared_internals::IO_BUF_CAPACITY,
     splitstream::{SplitStreamReader, SplitStreamWriter},
-    util::{ErrnoFilter, proc_self_fd, reopen_tmpfile_ro, replace_symlinkat},
+    util::{ErrnoFilter, generate_tmpname, proc_self_fd, reopen_tmpfile_ro, replace_symlinkat},
 };
 
 /// The filename used for repository metadata.
@@ -1947,59 +1949,126 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         Ok(hasher.digest())
     }
 
+    /// Atomically install a read-only fd as an object at `path`, replacing
+    /// any existing object under that name.
+    ///
+    /// This links the fd into the objects directory under a random
+    /// temporary name and then `renameat`s it over `path`. Unlike a plain
+    /// `linkat`, this always succeeds in replacing an existing entry at
+    /// `path` (renameat silently overwrites), which is what we want when
+    /// upgrading a previously-unsigned object to a signed one. Any process
+    /// holding an open fd to the previous object is unaffected, since the
+    /// old inode remains valid until closed; only the directory entry
+    /// changes.
+    fn install_object_by_rename(
+        &self,
+        dirfd: &OwnedFd,
+        ro_fd: &impl AsFd,
+        id: &ObjectID,
+        path: &str,
+    ) -> Result<()> {
+        let parent_dir = id.to_object_dir();
+        loop {
+            let tmpname = format!("{parent_dir}/.tmp-{}", generate_tmpname(""));
+            match linkat(
+                CWD,
+                proc_self_fd(ro_fd),
+                dirfd,
+                &tmpname,
+                AtFlags::SYMLINK_FOLLOW,
+            ) {
+                Ok(()) => {
+                    renameat(dirfd, &tmpname, dirfd, path)
+                        .context("Renaming signed object into place")?;
+                    return Ok(());
+                }
+                Err(Errno::EXIST) => continue,
+                Err(other) => return Err(other).context("Linking temporary object file"),
+            }
+        }
+    }
+
     /// Store an object with a pre-computed fs-verity ID.
     ///
     /// This is an internal helper that stores data assuming the caller has already
     /// computed the correct fs-verity digest. The digest is verified after storage.
+    ///
+    /// If `signature` is provided, it is enrolled with the kernel via the
+    /// `FS_IOC_ENABLE_VERITY` signature parameter. In that case, unlike the
+    /// unsigned path, an existing object with the same digest is **not**
+    /// treated as "already present and done": we always build a fresh
+    /// tmpfile, enable verity with the signature on it, and atomically
+    /// `renameat` it over the existing name. This lets an object that was
+    /// previously imported without a signature (e.g. from an earlier
+    /// unsigned pull of the same content) be upgraded in place once a
+    /// signature becomes available, without ever downgrading a
+    /// already-signed object (we simply never take this path when we don't
+    /// have a signature to offer). Any process with an open fd to the old
+    /// inode is unaffected, since `renameat` only repoints the name.
+    ///
+    /// If the kernel rejects the signature because the `.fs-verity` keyring
+    /// has no certificate that can verify it ([`EnableVerityError::SigningKeyNotFound`],
+    /// `ENOKEY`), that's treated as "kernel enrollment unavailable" rather
+    /// than a hard error: we fall back to enabling verity without the
+    /// signature. This keeps the never-downgrade guarantee (an existing
+    /// signed object won't be overwritten by this unsigned fallback, since
+    /// only a successful signature enrollment takes the atomic-rename
+    /// install path below). A signature the keyring actively rejects as
+    /// invalid ([`EnableVerityError::SignatureVerificationFailed`],
+    /// `EKEYREJECTED`/`EBADMSG`) is a real tamper-evidence signal and
+    /// remains a hard error.
     #[context("Storing object with ID {id:?}")]
     fn store_object_with_id(
         &self,
         data: &[u8],
         id: &ObjectID,
         _writable: &WritableRepo,
+        signature: Option<&[u8]>,
     ) -> Result<()> {
         let dirfd = self
             .objects_dir()
             .context("Getting objects directory for storage")?;
         let path = id.to_object_pathname();
 
-        // the usual case is that the file will already exist
-        match openat(
-            dirfd,
-            &path,
-            OFlags::RDONLY | OFlags::CLOEXEC,
-            Mode::empty(),
-        ) {
-            Ok(fd) => {
-                // measure the existing file to ensure that it's correct
-                // TODO: try to replace file if it's broken?
-                match ensure_verity_equal(&fd, id) {
-                    Ok(()) => {}
-                    Err(CompareVerityError::Measure(MeasureVerityError::VerityMissing))
-                        if self.insecure =>
-                    {
-                        match enable_verity_maybe_copy::<ObjectID>(dirfd, fd.as_fd()) {
-                            Ok(Some(fd)) => ensure_verity_equal(&fd, id)
-                                .context("Verifying verity after enabling (copied)")?,
-                            Ok(None) => ensure_verity_equal(&fd, id)
-                                .context("Verifying verity after enabling (original)")?,
-                            Err(other) => {
-                                Err(other).context("Enabling verity on existing object")?
+        if signature.is_none() {
+            // the usual case is that the file will already exist
+            match openat(
+                dirfd,
+                &path,
+                OFlags::RDONLY | OFlags::CLOEXEC,
+                Mode::empty(),
+            ) {
+                Ok(fd) => {
+                    // measure the existing file to ensure that it's correct
+                    // TODO: try to replace file if it's broken?
+                    match ensure_verity_equal(&fd, id) {
+                        Ok(()) => {}
+                        Err(CompareVerityError::Measure(MeasureVerityError::VerityMissing))
+                            if self.insecure =>
+                        {
+                            match enable_verity_maybe_copy::<ObjectID>(dirfd, fd.as_fd()) {
+                                Ok(Some(fd)) => ensure_verity_equal(&fd, id)
+                                    .context("Verifying verity after enabling (copied)")?,
+                                Ok(None) => ensure_verity_equal(&fd, id)
+                                    .context("Verifying verity after enabling (original)")?,
+                                Err(other) => {
+                                    Err(other).context("Enabling verity on existing object")?
+                                }
                             }
                         }
+                        Err(CompareVerityError::Measure(
+                            MeasureVerityError::FilesystemNotSupported,
+                        )) if self.insecure => {}
+                        Err(other) => Err(other).context("Verifying existing object integrity")?,
                     }
-                    Err(CompareVerityError::Measure(
-                        MeasureVerityError::FilesystemNotSupported,
-                    )) if self.insecure => {}
-                    Err(other) => Err(other).context("Verifying existing object integrity")?,
+                    return Ok(());
                 }
-                return Ok(());
-            }
-            Err(Errno::NOENT) => {
-                // in this case we'll create the file
-            }
-            Err(other) => {
-                return Err(other).context("Checking for existing object in repository")?;
+                Err(Errno::NOENT) => {
+                    // in this case we'll create the file
+                }
+                Err(other) => {
+                    return Err(other).context("Checking for existing object in repository")?;
+                }
             }
         }
 
@@ -2012,35 +2081,80 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         // to coordinate this at a higher level.  See .write_stream().
         let ro_fd = reopen_tmpfile_ro(file).context("Re-opening file as read-only for verity")?;
 
-        let ro_fd = match enable_verity_maybe_copy::<ObjectID>(dirfd, ro_fd.as_fd()) {
-            Ok(maybe_fd) => {
-                let ro_fd = maybe_fd.unwrap_or(ro_fd);
-                match ensure_verity_equal(&ro_fd, id) {
-                    Ok(()) => ro_fd,
-                    Err(CompareVerityError::Measure(
-                        MeasureVerityError::VerityMissing
-                        | MeasureVerityError::FilesystemNotSupported,
-                    )) if self.insecure => ro_fd,
-                    Err(other) => Err(other).context("Double-checking verity digest")?,
-                }
+        // Checks that `fd`'s verity digest matches `id`, tolerating a missing
+        // or unsupported digest when the repo is `insecure`. Shared between
+        // the normal and unsigned-fallback paths below.
+        let check_digest = |fd: &OwnedFd, context: &'static str| -> Result<()> {
+            match ensure_verity_equal(fd, id) {
+                Ok(()) => Ok(()),
+                Err(CompareVerityError::Measure(
+                    MeasureVerityError::VerityMissing | MeasureVerityError::FilesystemNotSupported,
+                )) if self.insecure => Ok(()),
+                Err(other) => Err(other).context(context),
             }
-            Err(EnableVerityError::FilesystemNotSupported) if self.insecure => ro_fd,
-            Err(other) => Err(other).context("Enabling verity digest")?,
         };
 
-        match linkat(
-            CWD,
-            proc_self_fd(&ro_fd),
-            dirfd,
-            path,
-            AtFlags::SYMLINK_FOLLOW,
-        ) {
-            Ok(()) => {}
-            Err(Errno::EXIST) => {
-                // TODO: strictly, we should measure the newly-appeared file
-            }
-            Err(other) => {
-                return Err(other).context("Linking created object file");
+        // Track whether verity actually ended up being enabled *with* the
+        // signature enrolled, since that (rather than merely `signature.is_some()`)
+        // determines whether it's safe to overwrite an existing object below
+        // (see the `ENOKEY` handling immediately below for why the two can differ).
+        let mut signature_enrolled = false;
+        let ro_fd =
+            match enable_verity_maybe_copy_with_sig::<ObjectID>(dirfd, ro_fd.as_fd(), signature) {
+                Ok(maybe_fd) => {
+                    signature_enrolled = signature.is_some();
+                    let ro_fd = maybe_fd.unwrap_or(ro_fd);
+                    check_digest(&ro_fd, "Double-checking verity digest")?;
+                    ro_fd
+                }
+                Err(EnableVerityError::FilesystemNotSupported) if self.insecure => ro_fd,
+                Err(EnableVerityError::SigningKeyNotFound) => {
+                    // The `.fs-verity` keyring has no certificate able to verify
+                    // this signature, most likely because none has been loaded
+                    // yet (see `cfsctl keyring add-cert`). This isn't evidence of
+                    // tampering, so gracefully degrade: enable verity without the
+                    // signature instead of failing the whole operation. Userspace
+                    // PKCS#7 verification (`cfsctl oci verify` / `--require-signature`)
+                    // remains the authoritative trust check regardless.
+                    match enable_verity_maybe_copy::<ObjectID>(dirfd, ro_fd.as_fd()) {
+                        Ok(maybe_fd) => {
+                            let ro_fd = maybe_fd.unwrap_or(ro_fd);
+                            check_digest(
+                                &ro_fd,
+                                "Double-checking verity digest (unsigned fallback)",
+                            )?;
+                            ro_fd
+                        }
+                        Err(EnableVerityError::FilesystemNotSupported) if self.insecure => ro_fd,
+                        Err(other) => {
+                            Err(other).context("Enabling verity digest (unsigned fallback)")?
+                        }
+                    }
+                }
+                Err(other) => Err(other).context("Enabling verity digest")?,
+            };
+
+        if signature_enrolled {
+            // The signature was actually enrolled with the kernel: atomically
+            // install this fresh, signed copy over the object's name, upgrading
+            // any previously-stored unsigned object with the same digest.
+            self.install_object_by_rename(dirfd, &ro_fd, id, &path)
+                .context("Installing signed object")?;
+        } else {
+            match linkat(
+                CWD,
+                proc_self_fd(&ro_fd),
+                dirfd,
+                &path,
+                AtFlags::SYMLINK_FOLLOW,
+            ) {
+                Ok(()) => {}
+                Err(Errno::EXIST) => {
+                    // TODO: strictly, we should measure the newly-appeared file
+                }
+                Err(other) => {
+                    return Err(other).context("Linking created object file");
+                }
             }
         }
 
@@ -2069,7 +2183,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
         writable: &WritableRepo,
     ) -> Result<ObjectID> {
         let id: ObjectID = compute_verity(data);
-        self.store_object_with_id(data, &id, writable)?;
+        self.store_object_with_id(data, &id, writable, None)?;
         Ok(id)
     }
 
@@ -2453,8 +2567,30 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     /// This function is not safe for untrusted users.
     #[context("Writing image to repository")]
     pub fn write_image(&self, name: Option<&str>, data: &[u8]) -> Result<ObjectID> {
+        self.write_image_with_sig(name, data, None)
+    }
+
+    /// Like [`write_image`](Self::write_image), but if `signatures` contains
+    /// a fs-verity PKCS#7 signature for this image's digest, that signature
+    /// is enrolled with the kernel via `FS_IOC_ENABLE_VERITY` as the object
+    /// is stored.
+    ///
+    /// This is used for EROFS image objects (per-layer, merged, and boot
+    /// artifacts) so that the kernel can enforce signature verification on
+    /// access, independent of composefs's own userspace PKCS#7
+    /// verification. It is intentionally not used for generic
+    /// content-addressed blob objects.
+    #[context("Writing image to repository")]
+    pub fn write_image_with_sig(
+        &self,
+        name: Option<&str>,
+        data: &[u8],
+        signatures: Option<&HashMap<ObjectID, Vec<u8>>>,
+    ) -> Result<ObjectID> {
         let writable = self.ensure_writable_token()?;
-        let object_id = self.ensure_object_impl(data, &writable)?;
+        let object_id: ObjectID = compute_verity(data);
+        let signature = signatures.and_then(|map| map.get(&object_id).map(Vec::as_slice));
+        self.store_object_with_id(data, &object_id, &writable, signature)?;
 
         let object_path = Self::format_object_path(&object_id);
         let image_path = format!("images/{}", object_id.to_hex());
@@ -3881,6 +4017,124 @@ mod tests {
         assert!(result.objects_bytes > 0);
         assert_eq!(result.streams_pruned, 1);
         assert_eq!(result.images_pruned, 0);
+        Ok(())
+    }
+
+    // ---- Signature-aware object storage (kernel fs-verity enrollment) ----
+
+    #[test]
+    fn test_write_image_with_sig_upgrades_unsigned_object() -> Result<()> {
+        // An image imported without a signature must be upgradeable in
+        // place once a signature for its digest becomes available (e.g. on
+        // a later pull of the same content with a signature attached),
+        // without erroring out as "already present".
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let image_data = generate_test_data(32 * 1024, 0x51);
+        let id: Sha512HashValue = compute_verity(&image_data);
+
+        let unsigned_id = repo.write_image(None, &image_data)?;
+        assert_eq!(unsigned_id, id);
+        assert!(test_object_exists(&tmp, &id)?);
+
+        let mut signatures = HashMap::new();
+        signatures.insert(id.clone(), b"fake-pkcs7-signature-bytes".to_vec());
+
+        let signed_id = repo.write_image_with_sig(None, &image_data, Some(&signatures))?;
+        assert_eq!(
+            signed_id, id,
+            "digest must not change when adding a signature"
+        );
+        assert!(test_object_exists(&tmp, &id)?);
+
+        // Content must still be exactly what was written.
+        let stored = repo.open_object(&id)?;
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut File::from(stored), &mut buf)?;
+        assert_eq!(buf, image_data);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_image_with_sig_keeps_open_fd_valid_across_upgrade() -> Result<()> {
+        // Upgrading via renameat must not disturb a reader that already has
+        // the old object open: renameat only repoints the directory entry,
+        // it doesn't touch the inode a pre-existing fd refers to.
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let image_data = generate_test_data(16 * 1024, 0x7A);
+        let id: Sha512HashValue = compute_verity(&image_data);
+        repo.write_image(None, &image_data)?;
+
+        let old_fd = repo.open_object(&id)?;
+
+        let mut signatures = HashMap::new();
+        signatures.insert(id.clone(), b"another-fake-signature".to_vec());
+        repo.write_image_with_sig(None, &image_data, Some(&signatures))?;
+
+        // The fd opened before the upgrade must still be readable and
+        // return the original content.
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut File::from(old_fd), &mut buf)?;
+        assert_eq!(buf, image_data);
+
+        // And the object must still be resolvable by digest afterwards.
+        assert!(test_object_exists(&tmp, &id)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_image_never_downgrades_signed_object() -> Result<()> {
+        // Once an object has been stored with a signature, a subsequent
+        // unsigned write of the same content must not error, and must
+        // leave the (already correct, already signed) object alone rather
+        // than attempting a downgrade.
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let image_data = generate_test_data(8 * 1024, 0x33);
+        let id: Sha512HashValue = compute_verity(&image_data);
+
+        let mut signatures = HashMap::new();
+        signatures.insert(id.clone(), b"yet-another-fake-signature".to_vec());
+        repo.write_image_with_sig(None, &image_data, Some(&signatures))?;
+        assert!(test_object_exists(&tmp, &id)?);
+
+        // Re-importing without a signature takes the existing "already
+        // present" fast path and must succeed unchanged.
+        let unsigned_id = repo.write_image(None, &image_data)?;
+        assert_eq!(unsigned_id, id);
+        assert!(test_object_exists(&tmp, &id)?);
+
+        let stored = repo.open_object(&id)?;
+        let mut buf = Vec::new();
+        std::io::Read::read_to_end(&mut File::from(stored), &mut buf)?;
+        assert_eq!(buf, image_data);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_image_with_sig_no_matching_digest_stores_unsigned() -> Result<()> {
+        // A signature map that doesn't contain this image's digest must
+        // behave exactly like the unsigned path.
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let image_data = generate_test_data(4 * 1024, 0x99);
+        let id: Sha512HashValue = compute_verity(&image_data);
+
+        let mut signatures = HashMap::new();
+        signatures.insert(Sha512HashValue::EMPTY, b"unrelated-signature".to_vec());
+
+        let written_id = repo.write_image_with_sig(None, &image_data, Some(&signatures))?;
+        assert_eq!(written_id, id);
+        assert!(test_object_exists(&tmp, &id)?);
+
         Ok(())
     }
 

--- a/crates/composefs/src/util.rs
+++ b/crates/composefs/src/util.rs
@@ -190,7 +190,7 @@ impl<T> ErrnoFilter<T> for ErrnoResult<T> {
     }
 }
 
-fn generate_tmpname(prefix: &str) -> String {
+pub(crate) fn generate_tmpname(prefix: &str) -> String {
     let rand_string: String = rand::rng()
         .sample_iter(&Alphanumeric)
         .take(12)


### PR DESCRIPTION
This is just some rough draft raw material that builds on:

- https://github.com/containers/composefs-rs/pull/216 (🆕 now requires manifest/config as external not inline splitstream objeects, also the OCI artifact and referrer support was key)
- https://github.com/containers/composefs-rs/pull/224 (Lots of updates there, I redid to go all-in on an external signature+digests by default)

