### PR TITLE
tests: Add integration test suite with bcvk VM support

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,36 @@
+# cargo-nextest configuration for composefs-rs
+# https://nexte.st/book/configuration
+#
+# Integration tests use libtest-mimic which is fully compatible with nextest
+
+[store]
+dir = "target/nextest"
+
+[profile.default]
+test-threads = "num-cpus"
+slow-timeout = { period = "30s", terminate-after = 2 }
+fail-fast = false
+failure-output = "immediate"
+success-output = "never"
+status-level = "pass"
+
+# Profile for integration tests — run with limited parallelism due to QEMU/KVM resources
+[profile.integration]
+test-threads = 2
+# 20 minutes for VM tests on slow CI runners
+slow-timeout = { period = "1200s", terminate-after = 60 }
+fail-fast = false
+failure-output = "immediate"
+success-output = "never"
+status-level = "pass"
+default-filter = "package(integration-tests)"
+
+[profile.integration.junit]
+path = "junit.xml"
+store-success-output = true
+store-failure-output = true
+
+# VM tests boot an ephemeral QEMU instance per test, limit parallelism
+[[profile.integration.overrides]]
+filter = 'test(~^vm_)'
+threads-required = 4

--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,5 @@
+# Keep the build context small: exclude everything, then allowlist sources.
+*
+!Cargo.toml
+!Cargo.lock
+!crates/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,42 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  COMPOSEFS_TEST_IMAGE: localhost/composefs-rs-test:latest
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup
+        uses: bootc-dev/actions/bootc-ubuntu-setup@main
+        with:
+          libvirt: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run unprivileged integration tests
+        run: just integration-unprivileged
+
+      - name: Run privileged integration tests (via bcvk VM)
+        run: just integration-container

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,50 @@
+# Containerfile for composefs-rs
+#
+# Builds cfsctl and integration test binaries, then produces a bootable
+# (bootc-compatible) container image suitable for privileged integration
+# testing via `bcvk ephemeral run-ssh`.
+#
+# Build:
+#   podman build --tag composefs-rs-test -f Containerfile .
+#
+# Uses BuildKit-style cache mounts for fast incremental Rust builds.
+
+# -- source snapshot (keeps layer graph clean) --
+FROM scratch AS src
+COPY . /src
+
+# -- build stage --
+FROM quay.io/centos-bootc/centos-bootc:stream10 AS build
+
+RUN dnf install -y \
+        rust cargo clippy rustfmt \
+        openssl-devel \
+        gcc \
+        composefs \
+    && dnf clean all
+
+COPY --from=src /src /src
+WORKDIR /src
+
+# Fetch dependencies (network-intensive, cached separately)
+RUN --mount=type=cache,target=/src/target \
+    --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    cargo fetch
+
+# Build cfsctl and integration test binary
+RUN --network=none \
+    --mount=type=cache,target=/src/target \
+    --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    cargo build --release -p cfsctl -p integration-tests && \
+    cp /src/target/release/cfsctl /usr/bin/cfsctl && \
+    cp /src/target/release/cfsctl-integration-tests /usr/bin/cfsctl-integration-tests
+
+# -- final bootable image --
+FROM quay.io/centos-bootc/centos-bootc:stream10
+
+RUN dnf install -y composefs openssl && dnf clean all
+
+COPY --from=build /usr/bin/cfsctl /usr/bin/cfsctl
+COPY --from=build /usr/bin/cfsctl-integration-tests /usr/bin/cfsctl-integration-tests

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "integration-tests"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "cfsctl-integration-tests"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+xshell = "0.2"
+libtest-mimic = "0.8"
+linkme = "0.3"
+paste = "1"
+rustix = { version = "1.0.0", default-features = false, features = ["process"] }
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/integration-tests/README.md
+++ b/crates/integration-tests/README.md
@@ -1,0 +1,106 @@
+# composefs-rs integration tests
+
+Integration tests for `cfsctl` that exercise the CLI as a subprocess.
+Unlike the workspace's unit tests, these run the actual binary against
+real repositories and (optionally) real kernels with fs-verity.
+
+The test binary uses `libtest-mimic` with `linkme` distributed slices
+instead of `#[test]`, following the same pattern as
+[bcvk](https://github.com/bootc-dev/bcvk).
+
+## Test tiers
+
+**CLI tests** (`test_*`) run on the host without root. They pass
+`--insecure` to skip fs-verity and use temp dirs for repositories.
+These are fast and need no special setup.
+
+**Privileged tests** (`privileged_*`) need root and real fs-verity
+support. They create loopback ext4 filesystems with the verity feature
+and run `cfsctl` without `--insecure`. When run on the host (not as
+root), each test automatically re-executes itself inside a
+[bcvk](https://github.com/bootc-dev/bcvk) ephemeral VM — no separate
+wrapper functions needed. Set `COMPOSEFS_TEST_IMAGE` to enable this.
+
+## Running
+
+```sh
+# Fast CLI tests only (no root, no VM)
+just integration-unprivileged
+
+# Everything, privileged tests auto-dispatch to bcvk VM
+just integration-container
+```
+
+The container image is built from the repo's `Containerfile` and
+includes both `cfsctl` and `cfsctl-integration-tests` at `/usr/bin/`.
+It's based on `centos-bootc:stream10` so bcvk can boot it as a VM.
+
+## Running privileged tests without bcvk
+
+If you have root and a kernel with fs-verity support (5.4+), you can
+skip the VM dispatch entirely. The tests create loopback ext4
+filesystems with the verity feature, so you need `mkfs.ext4` and
+`mount` available.
+
+**Direct execution as root** (e.g. inside a VM, a privileged
+container, or a test machine):
+
+```sh
+cfsctl-integration-tests privileged_
+```
+
+Or from the workspace:
+
+```sh
+sudo CFSCTL_PATH=$(pwd)/target/debug/cfsctl cargo run -p integration-tests -- privileged_
+```
+
+**Inside a privileged container** — useful on hosts without native
+fs-verity or when you don't want to install dependencies locally:
+
+```sh
+podman run --privileged -v $(pwd):/src:Z -w /src \
+  quay.io/fedora/fedora:41 \
+  bash -c 'dnf -y install cargo composefs e2fsprogs && \
+           cargo build -p cfsctl -p integration-tests && \
+           CFSCTL_PATH=$(pwd)/target/debug/cfsctl \
+           cargo run -p integration-tests -- privileged_'
+```
+
+### Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `CFSCTL_PATH` | Path to `cfsctl` binary. Auto-detected if not set. |
+| `COMPOSEFS_TEST_IMAGE` | Container image for VM dispatch. Setting this triggers bcvk auto-dispatch for privileged tests. |
+| `BCVK_PATH` | Path to `bcvk` binary. Found in `PATH` if not set. |
+| `COMPOSEFS_IN_VM` | Set automatically inside VMs to prevent recursive dispatch. |
+
+## Adding tests
+
+Define a function returning `anyhow::Result<()>` and register it:
+
+```rust
+fn test_my_feature() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    // ...
+    Ok(())
+}
+integration_test!(test_my_feature);
+```
+
+For privileged tests, call `require_privileged()` at the top. This
+handles both execution paths — running directly as root, or
+re-dispatching into a VM:
+
+```rust
+fn privileged_my_feature() -> Result<()> {
+    if require_privileged("privileged_my_feature")?.is_some() {
+        return Ok(());
+    }
+    // ... test body runs as root with fs-verity ...
+    Ok(())
+}
+integration_test!(privileged_my_feature);
+```

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -1,0 +1,52 @@
+//! Integration test infrastructure for composefs-rs.
+//!
+//! Provides test registration via [`linkme`] distributed slices and the
+//! [`integration_test!`] macro, collected and executed by a custom
+//! [`libtest_mimic`] harness in `main.rs`.
+
+// linkme requires unsafe for distributed slices
+#![allow(unsafe_code)]
+
+/// A test function that returns a Result.
+pub type TestFn = fn() -> anyhow::Result<()>;
+
+/// Metadata for a registered integration test.
+#[derive(Debug)]
+pub struct IntegrationTest {
+    /// Name of the integration test.
+    pub name: &'static str,
+    /// Test function to execute.
+    pub f: TestFn,
+}
+
+impl IntegrationTest {
+    /// Create a new integration test with the given name and function.
+    pub const fn new(name: &'static str, f: TestFn) -> Self {
+        Self { name, f }
+    }
+}
+
+/// Distributed slice holding all registered integration tests.
+#[linkme::distributed_slice]
+pub static INTEGRATION_TESTS: [IntegrationTest];
+
+/// Register an integration test function with less boilerplate.
+///
+/// # Examples
+///
+/// ```ignore
+/// fn test_something() -> anyhow::Result<()> {
+///     Ok(())
+/// }
+/// integration_test!(test_something);
+/// ```
+#[macro_export]
+macro_rules! integration_test {
+    ($fn_name:ident) => {
+        ::paste::paste! {
+            #[::linkme::distributed_slice($crate::INTEGRATION_TESTS)]
+            static [<$fn_name:upper>]: $crate::IntegrationTest =
+                $crate::IntegrationTest::new(stringify!($fn_name), $fn_name);
+        }
+    };
+}

--- a/crates/integration-tests/src/main.rs
+++ b/crates/integration-tests/src/main.rs
@@ -1,0 +1,85 @@
+//! Integration test runner for composefs-rs.
+//!
+//! This binary uses [`libtest_mimic`] as a custom test harness (no `#[test]`).
+//! Tests are registered via the [`integration_test!`] macro in submodules
+//! and collected from the [`INTEGRATION_TESTS`] distributed slice at startup.
+
+// linkme requires unsafe for distributed slices
+#![allow(unsafe_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+use libtest_mimic::{Arguments, Trial};
+
+pub(crate) use integration_tests::{integration_test, INTEGRATION_TESTS};
+
+mod tests;
+
+/// Return the path to the cfsctl binary.
+///
+/// Resolution order:
+/// 1. `CFSCTL_PATH` environment variable
+/// 2. `target/{release,debug}/cfsctl` relative to the workspace root
+/// 3. `/usr/bin/cfsctl` (for VM-based integration tests)
+pub(crate) fn cfsctl() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("CFSCTL_PATH") {
+        return Ok(PathBuf::from(p));
+    }
+
+    // Walk up from the crate's manifest dir to find the workspace target/
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .unwrap_or(Path::new("."));
+
+    for profile in ["release", "debug"] {
+        let candidate = workspace.join("target").join(profile).join("cfsctl");
+        if candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+
+    // In VM-based tests the binary is baked into the container image
+    let system = Path::new("/usr/bin/cfsctl");
+    if system.exists() {
+        return Ok(system.to_path_buf());
+    }
+
+    bail!(
+        "cfsctl binary not found; build it with `cargo build -p cfsctl` \
+         or set CFSCTL_PATH"
+    )
+}
+
+/// Create a test rootfs fixture inside `parent` and return its path.
+///
+/// Includes a file large enough (128 KiB) to avoid erofs inlining so that
+/// `image-objects` will report at least one external object.
+pub(crate) fn create_test_rootfs(parent: &Path) -> Result<PathBuf> {
+    let root = parent.join("rootfs");
+    fs::create_dir_all(root.join("usr/bin"))?;
+    fs::create_dir_all(root.join("usr/lib"))?;
+    fs::create_dir_all(root.join("etc"))?;
+
+    // A large-ish file that won't be inlined into the erofs image
+    fs::write(root.join("usr/bin/hello"), "x".repeat(128 * 1024))?;
+    fs::write(root.join("usr/lib/readme.txt"), "test fixture\n")?;
+    fs::write(root.join("etc/hostname"), "integration-test\n")?;
+    Ok(root)
+}
+
+fn main() {
+    let args = Arguments::from_args();
+
+    let tests: Vec<Trial> = INTEGRATION_TESTS
+        .iter()
+        .map(|t| {
+            let f = t.f;
+            Trial::test(t.name, move || f().map_err(|e| format!("{e:?}").into()))
+        })
+        .collect();
+
+    libtest_mimic::run(&args, tests).exit();
+}

--- a/crates/integration-tests/src/tests/cli.rs
+++ b/crates/integration-tests/src/tests/cli.rs
@@ -1,0 +1,162 @@
+//! CLI integration tests that run on the host without root.
+//!
+//! Each test invokes `cfsctl --insecure` as a subprocess against a fresh
+//! temp-dir repository. No network access, no fs-verity, no special
+//! privileges required — these are the fast "does the CLI basically work"
+//! smoke tests.
+
+use anyhow::Result;
+use xshell::{cmd, Shell};
+
+use crate::{cfsctl, create_test_rootfs, integration_test};
+
+fn test_gc_empty_repo() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = tempfile::tempdir()?;
+    let repo = repo_dir.path();
+
+    let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} gc").read()?;
+    assert!(
+        output.contains("Objects: 0 removed"),
+        "expected zero objects removed, got: {output}"
+    );
+    Ok(())
+}
+integration_test!(test_gc_empty_repo);
+
+fn test_create_image_from_path() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = tempfile::tempdir()?;
+    let repo = repo_dir.path();
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+
+    let output = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs}"
+    )
+    .read()?;
+    assert!(
+        !output.trim().is_empty(),
+        "expected image ID output, got nothing"
+    );
+    Ok(())
+}
+integration_test!(test_create_image_from_path);
+
+fn test_create_image_idempotent() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = tempfile::tempdir()?;
+    let repo = repo_dir.path();
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+
+    let id1 = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs}"
+    )
+    .read()?;
+    let id2 = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs}"
+    )
+    .read()?;
+    assert_eq!(
+        id1.trim(),
+        id2.trim(),
+        "creating the same image twice should produce the same ID"
+    );
+    Ok(())
+}
+integration_test!(test_create_image_idempotent);
+
+fn test_create_and_list_objects() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = tempfile::tempdir()?;
+    let repo = repo_dir.path();
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+
+    // Create with a ref name so we can look it up easily
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs} my-image"
+    )
+    .read()?;
+
+    let objects = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} image-objects refs/my-image"
+    )
+    .read()?;
+    assert!(
+        !objects.trim().is_empty(),
+        "expected at least one object, got nothing"
+    );
+    Ok(())
+}
+integration_test!(test_create_and_list_objects);
+
+fn test_gc_after_create() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = tempfile::tempdir()?;
+    let repo = repo_dir.path();
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs}"
+    )
+    .read()?;
+
+    // GC with no roots — everything should be collected
+    let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} gc").read()?;
+    assert!(
+        output.contains("removed"),
+        "expected GC output mentioning removed objects, got: {output}"
+    );
+    Ok(())
+}
+integration_test!(test_gc_after_create);
+
+fn test_gc_dry_run() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = tempfile::tempdir()?;
+    let repo = repo_dir.path();
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+
+    // Create an image with a ref name so we can reference it later
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs} my-image"
+    )
+    .read()?;
+
+    // Dry-run GC
+    let gc_output = cmd!(sh, "{cfsctl} --insecure --repo {repo} gc --dry-run").read()?;
+    assert!(
+        gc_output.contains("Dry run"),
+        "expected dry run header, got: {gc_output}"
+    );
+
+    // Image should still be accessible after dry run
+    let objects = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} image-objects refs/my-image"
+    )
+    .read()?;
+    assert!(
+        !objects.trim().is_empty(),
+        "image should still exist after dry-run GC"
+    );
+    Ok(())
+}
+integration_test!(test_gc_dry_run);

--- a/crates/integration-tests/src/tests/mod.rs
+++ b/crates/integration-tests/src/tests/mod.rs
@@ -1,0 +1,4 @@
+//! Integration test modules, organized by execution environment.
+
+pub mod cli;
+pub mod privileged;

--- a/crates/integration-tests/src/tests/privileged.rs
+++ b/crates/integration-tests/src/tests/privileged.rs
@@ -1,0 +1,169 @@
+//! Privileged integration tests requiring root and fs-verity support.
+//!
+//! These tests run `cfsctl` without `--insecure` on a real ext4 filesystem
+//! with the verity feature enabled. They need root to create loop mounts.
+//!
+//! When run on the host (not as root), each test automatically re-executes
+//! itself inside a bcvk ephemeral VM where it has real root and kernel
+//! fs-verity support. The `COMPOSEFS_IN_VM` env var prevents infinite
+//! recursion — see [`require_privileged`].
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, ensure, Result};
+use xshell::{cmd, Shell};
+
+use crate::{cfsctl, create_test_rootfs, integration_test};
+
+/// Ensure we're running as root, or re-exec this test inside a VM.
+///
+/// If already root (e.g. inside a bcvk VM), returns `Ok(None)` and the
+/// test proceeds normally.
+///
+/// If not root and `COMPOSEFS_TEST_IMAGE` is set, spawns
+/// `bcvk ephemeral run-ssh <image> -- cfsctl-integration-tests --exact <test>`
+/// and returns `Ok(Some(()))` — the caller should return immediately since
+/// the test already ran in the VM.
+///
+/// If not root and no test image is configured, returns an error.
+fn require_privileged(test_name: &str) -> Result<Option<()>> {
+    if rustix::process::getuid().is_root() {
+        return Ok(None);
+    }
+
+    // We're on the host without root — delegate to a VM.
+    if std::env::var_os("COMPOSEFS_IN_VM").is_some() {
+        bail!("COMPOSEFS_IN_VM is set but we're not root — VM setup is broken");
+    }
+
+    let image = std::env::var("COMPOSEFS_TEST_IMAGE").map_err(|_| {
+        anyhow::anyhow!(
+            "not root and COMPOSEFS_TEST_IMAGE not set; \
+             run `just build-test-image` or use `just test-integration-vm`"
+        )
+    })?;
+
+    let sh = Shell::new()?;
+    let bcvk = std::env::var("BCVK_PATH").unwrap_or_else(|_| "bcvk".into());
+    cmd!(
+        sh,
+        "{bcvk} ephemeral run-ssh {image} -- cfsctl-integration-tests --exact {test_name}"
+    )
+    .run()?;
+    Ok(Some(()))
+}
+
+/// A temporary directory backed by a loopback ext4 filesystem with verity support.
+///
+/// tmpfs doesn't support fs-verity, so privileged tests that need verity
+/// (i.e. running cfsctl without `--insecure`) must use a real filesystem.
+/// This creates a sparse file, formats it as ext4 with the verity feature,
+/// and loop-mounts it to a temp directory.
+struct VerityTempDir {
+    mountpoint: PathBuf,
+    _backing: tempfile::TempDir,
+}
+
+impl VerityTempDir {
+    fn new() -> Result<Self> {
+        let backing = tempfile::tempdir()?;
+        let img = backing.path().join("fs.img");
+        let mountpoint = backing.path().join("mnt");
+        std::fs::create_dir(&mountpoint)?;
+
+        let sh = Shell::new()?;
+        cmd!(sh, "truncate -s 256M {img}").run()?;
+        cmd!(sh, "mkfs.ext4 -q -O verity -b 4096 {img}").run()?;
+        cmd!(sh, "mount -o loop {img} {mountpoint}").run()?;
+
+        // Create a repo subdirectory (cfsctl needs it to exist)
+        std::fs::create_dir(mountpoint.join("repo"))?;
+
+        Ok(Self {
+            mountpoint,
+            _backing: backing,
+        })
+    }
+
+    fn path(&self) -> &Path {
+        &self.mountpoint
+    }
+}
+
+impl Drop for VerityTempDir {
+    fn drop(&mut self) {
+        let _ = std::process::Command::new("umount")
+            .arg(&self.mountpoint)
+            .status();
+    }
+}
+
+fn privileged_check_root() -> Result<()> {
+    if require_privileged("privileged_check_root")?.is_some() {
+        return Ok(());
+    }
+    Ok(())
+}
+integration_test!(privileged_check_root);
+
+fn privileged_repo_without_insecure() -> Result<()> {
+    if require_privileged("privileged_repo_without_insecure")?.is_some() {
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let verity_dir = VerityTempDir::new()?;
+    let repo = verity_dir.path().join("repo");
+
+    let output = cmd!(sh, "{cfsctl} --repo {repo} gc").read()?;
+    ensure!(
+        output.contains("Objects: 0 removed"),
+        "gc on fresh repo failed: {output}"
+    );
+    Ok(())
+}
+integration_test!(privileged_repo_without_insecure);
+
+fn privileged_create_image() -> Result<()> {
+    if require_privileged("privileged_create_image")?.is_some() {
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let verity_dir = VerityTempDir::new()?;
+    let repo = verity_dir.path().join("repo");
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+
+    let output = cmd!(sh, "{cfsctl} --repo {repo} create-image {rootfs}").read()?;
+    ensure!(
+        !output.trim().is_empty(),
+        "expected image ID output, got nothing"
+    );
+    Ok(())
+}
+integration_test!(privileged_create_image);
+
+fn privileged_create_image_idempotent() -> Result<()> {
+    if require_privileged("privileged_create_image_idempotent")?.is_some() {
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let verity_dir = VerityTempDir::new()?;
+    let repo = verity_dir.path().join("repo");
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+
+    let id1 = cmd!(sh, "{cfsctl} --repo {repo} create-image {rootfs}").read()?;
+    let id2 = cmd!(sh, "{cfsctl} --repo {repo} create-image {rootfs}").read()?;
+    ensure!(
+        id1.trim() == id2.trim(),
+        "creating the same image twice should produce the same ID: {id1} vs {id2}"
+    );
+    Ok(())
+}
+integration_test!(privileged_create_image_idempotent);


### PR DESCRIPTION
Add a new integration-tests crate that exercises the cfsctl CLI as a subprocess, following the libtest-mimic + linkme pattern from bcvk.

We can run in two modes:

Unprivileged:

While we have unit tests that run unprivileged, these tests can e.g. fetch containers from the network though. Plus a key thing about integration tests is that one can run them outside of a build.

VM/destructive:

These can run via bcvk ephemeral, in which we have full privileges. This is like a full generalization of the testthing code, but with I think a better foundation because:

- We're not copying a binary built on e.g. Ubuntu (or in general whatever the host is) into a target VM
- The integration tests are in Rust (but with xshell convenience for running commands) not a different language from the project
- It's possible to run the inner portion of these tests on e.g. an ephemeral cloud VM - making it easier to integrate them with a framework like Testing Farm and others outside of PRs to the project.

Assisted-by: OpenCode (Claude claude-opus-4-6)