### PR TITLE
ioctls: Extract unsafe ioctl code into composefs-ioctls crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ unsafe_code = "deny" # https://github.com/containers/composefs-rs/issues/123
 
 [workspace.dependencies]
 composefs = { version = "0.3.0", path = "crates/composefs", default-features = false }
+composefs-ioctls = { version = "0.3.0", path = "crates/composefs-ioctls", default-features = false }
 composefs-oci = { version = "0.3.0", path = "crates/composefs-oci", default-features = false }
 composefs-boot = { version = "0.3.0", path = "crates/composefs-boot", default-features = false }
 composefs-http = { version = "0.3.0", path = "crates/composefs-http", default-features = false }

--- a/crates/composefs-boot/src/lib.rs
+++ b/crates/composefs-boot/src/lib.rs
@@ -5,6 +5,7 @@
 //! bootloader entries. It supports both Boot Loader Specification (Type 1) entries
 //! and Unified Kernel Images (Type 2) for UEFI boot.
 
+#![forbid(unsafe_code)]
 #![deny(missing_debug_implementations)]
 
 pub mod bootloader;

--- a/crates/composefs-fuse/src/lib.rs
+++ b/crates/composefs-fuse/src/lib.rs
@@ -4,6 +4,8 @@
 //! directory trees through FUSE. It supports read-only access to files, directories,
 //! symlinks, and extended attributes, with data served from a composefs repository.
 
+#![forbid(unsafe_code)]
+
 use std::{
     collections::HashMap,
     ffi::OsStr,

--- a/crates/composefs-http/src/lib.rs
+++ b/crates/composefs-http/src/lib.rs
@@ -4,6 +4,8 @@
 //! referenced objects from HTTP servers. It handles recursive fetching of nested splitstream
 //! references and verifies content integrity using fsverity checksums.
 
+#![forbid(unsafe_code)]
+
 use std::{
     collections::{HashMap, HashSet},
     fs::File,

--- a/crates/composefs-ioctls/Cargo.toml
+++ b/crates/composefs-ioctls/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "composefs-ioctls"
+description = "Low-level ioctl wrappers for composefs (fs-verity, loop devices)"
+keywords = ["composefs", "fsverity", "ioctl"]
+
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[features]
+default = []
+loop-device = []
+
+[dependencies]
+rustix = { version = "1.0.0", features = ["fs"] }
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3.8.0"
+test-with = { version = "0.14", default-features = false }
+
+[lints]
+workspace = true

--- a/crates/composefs-ioctls/src/fsverity.rs
+++ b/crates/composefs-ioctls/src/fsverity.rs
@@ -1,0 +1,272 @@
+//! Low-level ioctl interfaces for fs-verity kernel operations.
+//!
+//! This module provides safe wrappers around the Linux fs-verity ioctls
+//! for enabling and measuring fs-verity on files.
+
+#![allow(unsafe_code)]
+
+use std::{io::Error, os::fd::AsFd};
+
+use rustix::{
+    io::Errno,
+    ioctl::{ioctl, opcode, Opcode, Setter, Updater},
+};
+use thiserror::Error;
+
+/// Enabling fsverity failed.
+#[derive(Error, Debug)]
+pub enum EnableVerityError {
+    /// I/O operation failed.
+    #[error("{0}")]
+    Io(#[from] Error),
+    /// The filesystem does not support fs-verity.
+    #[error("Filesystem does not support fs-verity")]
+    FilesystemNotSupported,
+    /// fs-verity is already enabled on the file.
+    #[error("fs-verity is already enabled on file")]
+    AlreadyEnabled,
+    /// The file has an open writable file descriptor.
+    #[error("File is opened for writing")]
+    FileOpenedForWrite,
+    /// Signature verification failed (when using kernel signatures).
+    #[error("Signature verification failed")]
+    SignatureVerificationFailed,
+}
+
+/// Measuring fsverity failed.
+#[derive(Error, Debug)]
+pub enum MeasureVerityError {
+    /// I/O operation failed.
+    #[error("{0}")]
+    Io(#[from] Error),
+    /// fs-verity is not enabled on the file.
+    #[error("fs-verity is not enabled on file")]
+    VerityMissing,
+    /// The filesystem does not support fs-verity.
+    #[error("fs-verity is not supported by filesystem")]
+    FilesystemNotSupported,
+    /// The hash algorithm does not match the expected algorithm.
+    #[error("Expected algorithm {expected}, found {found}")]
+    InvalidDigestAlgorithm {
+        /// The expected algorithm identifier.
+        expected: u16,
+        /// The actual algorithm identifier found.
+        found: u16,
+    },
+    /// The digest size does not match the expected size.
+    #[error("Expected digest size {expected}")]
+    InvalidDigestSize {
+        /// The expected digest size in bytes.
+        expected: u16,
+    },
+}
+
+// See /usr/include/linux/fsverity.h
+#[repr(C)]
+#[derive(Debug)]
+struct FsVerityEnableArg {
+    version: u32,
+    hash_algorithm: u32,
+    block_size: u32,
+    salt_size: u32,
+    salt_ptr: u64,
+    sig_size: u32,
+    __reserved1: u32,
+    sig_ptr: u64,
+    __reserved2: [u64; 11],
+}
+
+// #define FS_IOC_ENABLE_VERITY    _IOW('f', 133, struct fsverity_enable_arg)
+const FS_IOC_ENABLE_VERITY: Opcode = opcode::write::<FsVerityEnableArg>(b'f', 133);
+
+/// Enable fs-verity on the target file without a signature.
+///
+/// This is a thin safe wrapper for the `FS_IOC_ENABLE_VERITY` ioctl.
+/// The file descriptor must be opened `O_RDONLY` and there must be no
+/// other writable file descriptors or mappings for the file.
+///
+/// # Arguments
+/// * `fd` - File descriptor opened O_RDONLY
+/// * `hash_algorithm` - Algorithm ID (1 = SHA-256, 2 = SHA-512)
+/// * `block_size` - Block size (typically 4096)
+pub fn fs_ioc_enable_verity(
+    fd: impl AsFd,
+    hash_algorithm: u8,
+    block_size: u32,
+) -> Result<(), EnableVerityError> {
+    fs_ioc_enable_verity_with_sig(fd, hash_algorithm, block_size, None)
+}
+
+/// Enable fs-verity on the target file with an optional PKCS#7 signature.
+///
+/// When a signature is provided, the kernel will verify it against keys
+/// in the `.fs-verity` keyring before enabling verity.
+///
+/// # Arguments
+/// * `fd` - File descriptor opened O_RDONLY
+/// * `hash_algorithm` - Algorithm ID (1 = SHA-256, 2 = SHA-512)
+/// * `block_size` - Block size (typically 4096)
+/// * `signature` - Optional PKCS#7 DER-encoded signature
+pub fn fs_ioc_enable_verity_with_sig(
+    fd: impl AsFd,
+    hash_algorithm: u8,
+    block_size: u32,
+    signature: Option<&[u8]>,
+) -> Result<(), EnableVerityError> {
+    let (sig_size, sig_ptr) = match signature {
+        Some(sig) => (sig.len() as u32, sig.as_ptr() as u64),
+        None => (0, 0),
+    };
+
+    unsafe {
+        match ioctl(
+            fd,
+            Setter::<{ FS_IOC_ENABLE_VERITY }, FsVerityEnableArg>::new(FsVerityEnableArg {
+                version: 1,
+                hash_algorithm: hash_algorithm as u32,
+                block_size,
+                salt_size: 0,
+                salt_ptr: 0,
+                sig_size,
+                __reserved1: 0,
+                sig_ptr,
+                __reserved2: [0; 11],
+            }),
+        ) {
+            Err(Errno::NOTTY) | Err(Errno::OPNOTSUPP) => {
+                Err(EnableVerityError::FilesystemNotSupported)
+            }
+            Err(Errno::EXIST) => Err(EnableVerityError::AlreadyEnabled),
+            Err(Errno::TXTBSY) => Err(EnableVerityError::FileOpenedForWrite),
+            Err(Errno::KEYREJECTED) => Err(EnableVerityError::SignatureVerificationFailed),
+            Err(e) => Err(Error::from(e).into()),
+            Ok(_) => Ok(()),
+        }
+    }
+}
+
+/// Core definition of a fsverity digest returned by the kernel.
+#[repr(C)]
+#[derive(Debug)]
+struct FsVerityDigest<const N: usize> {
+    digest_algorithm: u16,
+    digest_size: u16,
+    digest: [u8; N],
+}
+
+// #define FS_IOC_MEASURE_VERITY   _IORW('f', 134, struct fsverity_digest)
+const FS_IOC_MEASURE_VERITY: Opcode = opcode::read_write::<FsVerityDigest<0>>(b'f', 134);
+
+/// Measure the fs-verity digest of a file.
+///
+/// Returns the raw digest bytes if successful. The generic parameter `N`
+/// specifies the expected digest size (32 for SHA-256, 64 for SHA-512).
+///
+/// # Arguments
+/// * `fd` - File descriptor to measure
+/// * `expected_algorithm` - Expected algorithm ID (1 = SHA-256, 2 = SHA-512)
+///
+/// # Returns
+/// The digest bytes on success.
+pub fn fs_ioc_measure_verity<const N: usize>(
+    fd: impl AsFd,
+    expected_algorithm: u8,
+) -> Result<[u8; N], MeasureVerityError> {
+    let digest_size = N as u16;
+    let digest_algorithm = expected_algorithm as u16;
+
+    let mut digest = FsVerityDigest::<N> {
+        digest_algorithm,
+        digest_size,
+        digest: [0u8; N],
+    };
+
+    let r = unsafe {
+        ioctl(
+            fd,
+            Updater::<{ FS_IOC_MEASURE_VERITY }, FsVerityDigest<N>>::new(&mut digest),
+        )
+    };
+
+    match r {
+        Ok(()) => {
+            if digest.digest_algorithm != digest_algorithm {
+                return Err(MeasureVerityError::InvalidDigestAlgorithm {
+                    expected: digest_algorithm,
+                    found: digest.digest_algorithm,
+                });
+            }
+            if digest.digest_size != digest_size {
+                return Err(MeasureVerityError::InvalidDigestSize {
+                    expected: digest_size,
+                });
+            }
+            Ok(digest.digest)
+        }
+        Err(Errno::NODATA) => Err(MeasureVerityError::VerityMissing),
+        Err(Errno::NOTTY | Errno::OPNOTSUPP) => Err(MeasureVerityError::FilesystemNotSupported),
+        Err(Errno::OVERFLOW) => Err(MeasureVerityError::InvalidDigestSize {
+            expected: digest.digest_size,
+        }),
+        Err(e) => Err(Error::from(e).into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::tempfile_in;
+
+    use super::*;
+
+    fn get_test_tmpdir() -> std::ffi::OsString {
+        if let Some(path) = std::env::var_os("CFS_TEST_TMPDIR") {
+            path
+        } else {
+            let home = std::env::var("HOME").expect("$HOME must be set when running tests");
+            let tmp = std::path::PathBuf::from(home).join(".var/tmp");
+            std::fs::create_dir_all(&tmp).expect("can't create ~/.var/tmp");
+            tmp.into()
+        }
+    }
+
+    fn test_tempfile() -> std::fs::File {
+        tempfile_in(get_test_tmpdir()).unwrap()
+    }
+
+    #[test]
+    fn test_measure_verity_missing() {
+        let mut tf = test_tempfile();
+        tf.write_all(b"test").unwrap();
+        tf.sync_all().unwrap();
+
+        // Re-open read-only
+        let path = format!("/proc/self/fd/{}", std::os::fd::AsRawFd::as_raw_fd(&tf));
+        let ro_fd =
+            rustix::fs::open(&path, rustix::fs::OFlags::RDONLY, rustix::fs::Mode::empty()).unwrap();
+
+        assert!(matches!(
+            fs_ioc_measure_verity::<32>(&ro_fd, 1),
+            Err(MeasureVerityError::VerityMissing)
+        ));
+    }
+
+    #[test_with::path(/dev/shm)]
+    #[test]
+    fn test_measure_verity_not_supported() {
+        let tf = tempfile_in("/dev/shm").unwrap();
+        assert!(matches!(
+            fs_ioc_measure_verity::<32>(&tf, 1),
+            Err(MeasureVerityError::FilesystemNotSupported)
+        ));
+    }
+
+    #[test_with::path(/dev/shm)]
+    #[test]
+    fn test_enable_verity_wrong_fs() {
+        let file = tempfile_in("/dev/shm").unwrap();
+        let err = fs_ioc_enable_verity(&file, 1, 4096).unwrap_err();
+        assert!(matches!(err, EnableVerityError::FilesystemNotSupported));
+    }
+}

--- a/crates/composefs-ioctls/src/lib.rs
+++ b/crates/composefs-ioctls/src/lib.rs
@@ -1,0 +1,37 @@
+//! Low-level ioctl wrappers for composefs operations.
+//!
+//! This crate provides safe Rust wrappers around Linux ioctls used by composefs:
+//!
+//! - **fs-verity ioctls**: Enable and measure fs-verity on files
+//! - **Loop device ioctls**: Create loop devices (behind `loop-device` feature)
+//!
+//! # Safety
+//!
+//! All unsafe ioctl code is contained within this crate, allowing dependent
+//! crates to use `#![forbid(unsafe_code)]`.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use composefs_ioctls::fsverity::{fs_ioc_enable_verity, fs_ioc_measure_verity};
+//!
+//! // Enable verity on a file
+//! fs_ioc_enable_verity(&file, 1, 4096)?; // SHA-256, 4K blocks
+//!
+//! // Measure the verity digest
+//! let digest: [u8; 32] = fs_ioc_measure_verity(&file, 1)?;
+//! ```
+
+#![deny(unsafe_code)]
+
+pub mod fsverity;
+
+#[cfg(feature = "loop-device")]
+pub mod loop_device;
+
+#[cfg(test)]
+mod test_utils;
+
+// Re-export test utilities for use in other crates' tests
+#[doc(hidden)]
+pub mod test_utils_pub;

--- a/crates/composefs-ioctls/src/loop_device.rs
+++ b/crates/composefs-ioctls/src/loop_device.rs
@@ -1,0 +1,186 @@
+//! Loop device ioctl wrappers.
+//!
+//! This module provides safe wrappers for creating loop devices,
+//! primarily used for mounting composefs images on older kernels.
+
+#![allow(unsafe_code)]
+
+use std::{
+    fs::OpenOptions,
+    io::{Error, Result},
+    os::fd::{AsFd, AsRawFd, OwnedFd},
+};
+
+use rustix::ioctl::{ioctl, opcode, Opcode, Setter};
+
+/// Flags for loop device configuration.
+pub mod flags {
+    /// Read-only loop device.
+    pub const LO_FLAGS_READ_ONLY: u32 = 1;
+    /// Automatically detach on last close.
+    pub const LO_FLAGS_AUTOCLEAR: u32 = 4;
+    /// Allow partition scanning.
+    pub const LO_FLAGS_PARTSCAN: u32 = 8;
+    /// Use direct I/O.
+    pub const LO_FLAGS_DIRECT_IO: u32 = 16;
+}
+
+const LO_NAME_SIZE: usize = 64;
+const LO_KEY_SIZE: usize = 32;
+
+// Loop device ioctl structures
+#[repr(C)]
+#[derive(Default)]
+struct LoopConfig {
+    fd: u32,
+    block_size: u32,
+    info: LoopInfo64,
+    reserved: [u64; 8],
+}
+
+#[repr(C)]
+struct LoopInfo64 {
+    lo_device: u64,
+    lo_inode: u64,
+    lo_rdevice: u64,
+    lo_offset: u64,
+    lo_sizelimit: u64,
+    lo_number: u32,
+    lo_encrypt_type: u32,
+    lo_encrypt_key_size: u32,
+    lo_flags: u32,
+    // HACK: default trait is only implemented up to [u8; 32]
+    lo_file_name: ([u8; LO_NAME_SIZE / 2], [u8; LO_NAME_SIZE / 2]),
+    lo_crypt_name: ([u8; LO_NAME_SIZE / 2], [u8; LO_NAME_SIZE / 2]),
+    lo_encrypt_key: [u8; LO_KEY_SIZE],
+    lo_init: [u64; 2],
+}
+
+impl Default for LoopInfo64 {
+    fn default() -> Self {
+        Self {
+            lo_device: 0,
+            lo_inode: 0,
+            lo_rdevice: 0,
+            lo_offset: 0,
+            lo_sizelimit: 0,
+            lo_number: 0,
+            lo_encrypt_type: 0,
+            lo_encrypt_key_size: 0,
+            lo_flags: 0,
+            lo_file_name: ([0; LO_NAME_SIZE / 2], [0; LO_NAME_SIZE / 2]),
+            lo_crypt_name: ([0; LO_NAME_SIZE / 2], [0; LO_NAME_SIZE / 2]),
+            lo_encrypt_key: [0; LO_KEY_SIZE],
+            lo_init: [0; 2],
+        }
+    }
+}
+
+// Custom ioctl for LOOP_CTL_GET_FREE which returns data in the return value
+struct LoopCtlGetFree;
+
+// Rustix seems to lack a built-in pattern for an ioctl that returns data by the syscall return
+// value instead of the usual return-by-reference on the args parameter.  Bake our own.
+unsafe impl rustix::ioctl::Ioctl for LoopCtlGetFree {
+    type Output = std::ffi::c_int;
+
+    const IS_MUTATING: bool = false;
+
+    fn opcode(&self) -> rustix::ioctl::Opcode {
+        LOOP_CTL_GET_FREE
+    }
+
+    fn as_ptr(&mut self) -> *mut std::ffi::c_void {
+        std::ptr::null_mut()
+    }
+
+    unsafe fn output_from_ptr(
+        out: rustix::ioctl::IoctlOutput,
+        _ptr: *mut std::ffi::c_void,
+    ) -> rustix::io::Result<std::ffi::c_int> {
+        Ok(out)
+    }
+}
+
+const LOOP_CTL_GET_FREE: Opcode = opcode::none(0x4C, 0x82);
+// #define LOOP_CONFIGURE         0x4C0A
+const LOOP_CONFIGURE: Opcode = opcode::write::<LoopConfig>(0x4C, 0x0A);
+
+/// Creates a loop device backed by the given file.
+///
+/// Returns an owned file descriptor for the loop device.
+/// Uses default flags: read-only, autoclear, and direct I/O.
+pub fn loopify(fd: impl AsFd) -> Result<OwnedFd> {
+    loopify_with_flags(
+        fd,
+        flags::LO_FLAGS_READ_ONLY | flags::LO_FLAGS_AUTOCLEAR | flags::LO_FLAGS_DIRECT_IO,
+    )
+}
+
+/// Creates a loop device with custom flags.
+///
+/// # Arguments
+/// * `fd` - File descriptor of the backing file
+/// * `lo_flags` - Loop device flags (see `flags` module)
+pub fn loopify_with_flags(fd: impl AsFd, lo_flags: u32) -> Result<OwnedFd> {
+    let control = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/loop-control")?;
+
+    // Get a free loop device number
+    let free: i32 = unsafe { ioctl(&control, LoopCtlGetFree) }.map_err(Error::other)?;
+
+    if free < 0 {
+        return Err(Error::other("no free loop device"));
+    }
+
+    // Open the loop device
+    let loop_path = format!("/dev/loop{free}");
+    let loop_dev = OpenOptions::new().read(true).write(true).open(&loop_path)?;
+
+    // Configure the loop device
+    let config = LoopConfig {
+        fd: fd.as_fd().as_raw_fd() as u32,
+        block_size: 4096,
+        info: LoopInfo64 {
+            lo_flags,
+            ..Default::default()
+        },
+        reserved: [0; 8],
+    };
+
+    unsafe {
+        ioctl(
+            &loop_dev,
+            Setter::<{ LOOP_CONFIGURE }, LoopConfig>::new(config),
+        )
+        .map_err(Error::other)?;
+    }
+
+    Ok(loop_dev.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_loopify_not_root() {
+        // This test just verifies the code compiles and runs
+        // It will fail without root, but shouldn't panic
+        let mut tf = NamedTempFile::new().unwrap();
+        tf.write_all(&[0u8; 4096]).unwrap();
+        tf.flush().unwrap();
+
+        let file = std::fs::File::open(tf.path()).unwrap();
+        let result = loopify(&file);
+
+        // Without root, we expect permission denied
+        if !rustix::process::getuid().is_root() {
+            assert!(result.is_err());
+        }
+    }
+}

--- a/crates/composefs-ioctls/src/test_utils.rs
+++ b/crates/composefs-ioctls/src/test_utils.rs
@@ -1,0 +1,8 @@
+//! Test utilities that require unsafe code.
+//!
+//! These are used internally by the crate's tests.
+
+#![allow(unsafe_code)]
+#![allow(unused_imports)]
+
+pub use crate::test_utils_pub::*;

--- a/crates/composefs-ioctls/src/test_utils_pub.rs
+++ b/crates/composefs-ioctls/src/test_utils_pub.rs
@@ -1,0 +1,38 @@
+//! Test utilities that require unsafe code.
+//!
+//! This module provides helpers for tests that need unsafe operations,
+//! allowing dependent crates to remain `#![forbid(unsafe_code)]`.
+
+#![allow(unsafe_code)]
+
+use std::os::unix::process::CommandExt as _;
+use std::process::Command;
+use std::time::Duration;
+
+/// Extension trait for Command that adds a pre-exec sleep.
+pub trait CommandExt {
+    /// Sleep for the given duration before exec.
+    ///
+    /// This is useful for introducing random delays in fork tests,
+    /// simulating scenarios where forked processes hold file descriptors
+    /// briefly before exec.
+    ///
+    /// # Safety
+    ///
+    /// This uses `pre_exec` internally which requires unsafe. The sleep
+    /// operation itself is safe, but `pre_exec` callbacks run in a
+    /// delicate state between fork and exec.
+    fn pre_exec_sleep(&mut self, delay: Duration) -> &mut Self;
+}
+
+impl CommandExt for Command {
+    fn pre_exec_sleep(&mut self, delay: Duration) -> &mut Self {
+        unsafe {
+            self.pre_exec(move || {
+                std::thread::sleep(delay);
+                Ok(())
+            })
+        };
+        self
+    }
+}

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -10,6 +10,8 @@
 //! - Creating mountable filesystems from OCI image configurations
 //! - Sealing containers with fs-verity hashes for integrity verification
 
+#![forbid(unsafe_code)]
+
 pub mod image;
 pub mod oci_image;
 pub mod skopeo;

--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -11,12 +11,13 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
-'pre-6.15' = ['tempfile']
+'pre-6.15' = ['tempfile', 'composefs-ioctls/loop-device']
 rhel9 = ['pre-6.15']
 test = ["tempfile"]
 
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
+composefs-ioctls = { workspace = true }
 fn-error-context = "0.2"
 hex = { version = "0.4.0", default-features = false, features = ["std"] }
 log = { version = "0.4.8", default-features = false }

--- a/crates/composefs/src/lib.rs
+++ b/crates/composefs/src/lib.rs
@@ -4,6 +4,8 @@
 //! of container filesystem layers by using content-addressable storage
 //! and fs-verity for integrity verification.
 
+#![forbid(unsafe_code)]
+
 pub mod dumpfile;
 pub mod dumpfile_parse;
 pub mod erofs;


### PR DESCRIPTION
Move all ioctl-related unsafe code (fs-verity ioctls, loop device ioctls) into a dedicated crate. This allows the main composefs crate and all other crates to use `#![forbid(unsafe_code)]`.

Relates to: https://github.com/containers/composefs-rs/issues/123

Assisted-by: OpenCode (Claude claude-opus-4-5@20251101)