### PR TITLE
generic_tree: Replace Rc/RefCell with flat index-based FileSystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       options: "--privileged --pid=host -v /var/tmp:/var/tmp --tmpfs /tmp:rw,exec,nosuid,nodev -v /:/run/host"
 
     steps:
-    - run: dnf -y install cargo clippy composefs-devel e2fsprogs just rustfmt
+    - run: dnf -y install cargo clippy composefs-devel e2fsprogs just rustfmt gcc-c++
     - name: Enable fs-verity on /
       run: tune2fs -O verity $(findmnt -vno SOURCE /run/host)
     - uses: actions/checkout@v6

--- a/Justfile
+++ b/Justfile
@@ -36,8 +36,12 @@ fmt-check:
 fmt:
     cargo fmt --all
 
-# Run all checks (clippy + fmt + test)
-check: clippy check-feature-combos fmt-check test
+# Check that fuzz targets compile
+check-fuzz:
+    cargo check --manifest-path crates/composefs/fuzz/Cargo.toml
+
+# Run all checks (clippy + fmt + test + fuzz build)
+check: clippy check-feature-combos fmt-check test check-fuzz
 
 # Base image for test container builds.
 # Override to test on a different distro, e.g.:

--- a/crates/cfsctl/src/lib.rs
+++ b/crates/cfsctl/src/lib.rs
@@ -772,6 +772,7 @@ fn dump_file_impl(
     backing_path_only: bool,
 ) -> Result<()> {
     let mut out = Vec::new();
+    let nlink_map = fs.nlinks();
 
     for file_path in files {
         let (dir, file) = fs.root.split(file_path.as_os_str())?;
@@ -787,14 +788,15 @@ fn dump_file_impl(
                     anyhow::bail!("{} is a directory", file_path.display());
                 }
 
-                dump_single_dir(&mut out, directory, file_path.clone())?
+                dump_single_dir(&mut out, directory, &fs, &nlink_map, file_path.clone())?
             }
 
-            Inode::Leaf(leaf) => {
+            Inode::Leaf(leaf_id, _) => {
                 use composefs::generic_tree::LeafContent::*;
                 use composefs::tree::RegularFile::*;
 
                 if backing_path_only {
+                    let leaf = fs.leaf(*leaf_id);
                     match &leaf.content {
                         Regular(f) => match f {
                             Inline(..) => println!("{} inline", file_path.display()),
@@ -810,7 +812,7 @@ fn dump_file_impl(
                     continue;
                 }
 
-                dump_single_file(&mut out, leaf, file_path.clone())?
+                dump_single_file(&mut out, *leaf_id, &fs, &nlink_map, file_path.clone())?
             }
         };
     }

--- a/crates/composefs-boot/src/bootloader.rs
+++ b/crates/composefs-boot/src/bootloader.rs
@@ -16,7 +16,7 @@ use anyhow::{Result, bail};
 use composefs::{
     fsverity::FsVerityHashValue,
     repository::Repository,
-    tree::{Directory, FileSystem, ImageError, Inode, LeafContent, RegularFile},
+    tree::{DirectoryRef, FileSystem, ImageError, Inode, LeafContent, RegularFile},
 };
 
 use crate::cmdline::{make_cmdline_composefs, split_cmdline};
@@ -226,7 +226,7 @@ impl<ObjectID: FsVerityHashValue> Type1Entry<ObjectID> {
     pub fn load(
         filename: &OsStr,
         file: &RegularFile<ObjectID>,
-        root: &Directory<ObjectID>,
+        root: DirectoryRef<'_, ObjectID>,
         repo: &Repository<ObjectID>,
     ) -> Result<Self> {
         let entry = BootLoaderEntryFile::new(from_utf8(&composefs::fs::read_file(file, repo)?)?);
@@ -234,7 +234,7 @@ impl<ObjectID: FsVerityHashValue> Type1Entry<ObjectID> {
         let mut files = HashMap::new();
         for key in ["linux", "initrd", "efi"] {
             for pathname in entry.get_values(key) {
-                let (dir, filename) = root.split(pathname.as_ref())?;
+                let (dir, filename) = root.split_ref(pathname.as_ref())?;
                 files.insert(Box::from(pathname), dir.get_file(filename)?.clone());
             }
         }
@@ -256,20 +256,22 @@ impl<ObjectID: FsVerityHashValue> Type1Entry<ObjectID> {
     /// # Returns
     ///
     /// A vector of all Type1Entry objects found in /boot/loader/entries
-    pub fn load_all(root: &Directory<ObjectID>, repo: &Repository<ObjectID>) -> Result<Vec<Self>> {
+    pub fn load_all(fs: &FileSystem<ObjectID>, repo: &Repository<ObjectID>) -> Result<Vec<Self>> {
         let mut entries = vec![];
+        let root = fs.as_dir();
 
-        match root.get_directory("/boot/loader/entries".as_ref()) {
+        match root.get_directory_ref("/boot/loader/entries".as_ref()) {
             Ok(entries_dir) => {
                 for (filename, inode) in entries_dir.entries() {
                     if !filename.as_bytes().ends_with(b".conf") {
                         continue;
                     }
 
-                    let Inode::Leaf(leaf) = inode else {
+                    let Inode::Leaf(leaf_id, _) = inode else {
                         bail!("/boot/loader/entries/{filename:?} is a directory");
                     };
 
+                    let leaf = fs.leaf(*leaf_id);
                     let LeafContent::Regular(file) = &leaf.content else {
                         bail!("/boot/loader/entries/{filename:?} is not a regular file");
                     };
@@ -336,7 +338,7 @@ impl<ObjectID: FsVerityHashValue> Type2Entry<ObjectID> {
     // Find UKI components, the UKI PE binary and other UKI addons,
     // if any, in the provided directory
     fn find_uki_components(
-        dir: &Directory<ObjectID>,
+        dir: DirectoryRef<'_, ObjectID>,
         entries: &mut Vec<Self>,
         path: &mut PathBuf,
         kver: &Option<Box<OsStr>>,
@@ -347,8 +349,9 @@ impl<ObjectID: FsVerityHashValue> Type2Entry<ObjectID> {
             // Collect all UKI extensions
             // Usually we'll find them in the root with directories ending in `.efi.extra.d` for kernel
             // specific addons. Global addons are found in `loader/addons`
-            if let Inode::Directory(dir) = inode {
-                Self::find_uki_components(dir, entries, path, kver)?;
+            if let Inode::Directory(subdir) = inode {
+                let subdir_ref = DirectoryRef::from_parts(subdir, dir.leaves());
+                Self::find_uki_components(subdir_ref, entries, path, kver)?;
                 path.pop();
                 continue;
             }
@@ -358,10 +361,11 @@ impl<ObjectID: FsVerityHashValue> Type2Entry<ObjectID> {
                 continue;
             }
 
-            let Inode::Leaf(leaf) = inode else {
+            let Inode::Leaf(leaf_id, _) = inode else {
                 bail!("{filename:?} is a directory");
             };
 
+            let leaf = dir.leaf(*leaf_id);
             let LeafContent::Regular(file) = &leaf.content else {
                 bail!("{filename:?} is not a regular file");
             };
@@ -392,10 +396,11 @@ impl<ObjectID: FsVerityHashValue> Type2Entry<ObjectID> {
     /// # Returns
     ///
     /// A vector of all Type2Entry objects found
-    pub fn load_all(root: &Directory<ObjectID>) -> Result<Vec<Self>> {
+    pub fn load_all(fs: &FileSystem<ObjectID>) -> Result<Vec<Self>> {
         let mut entries = vec![];
+        let root = fs.as_dir();
 
-        match root.get_directory("/boot/EFI/Linux".as_ref()) {
+        match root.get_directory_ref("/boot/EFI/Linux".as_ref()) {
             Ok(entries_dir) => {
                 Self::find_uki_components(entries_dir, &mut entries, &mut PathBuf::new(), &None)?
             }
@@ -403,15 +408,16 @@ impl<ObjectID: FsVerityHashValue> Type2Entry<ObjectID> {
             Err(other) => Err(other)?,
         };
 
-        match root.get_directory("/usr/lib/modules".as_ref()) {
+        match root.get_directory_ref("/usr/lib/modules".as_ref()) {
             Ok(modules_dir) => {
                 for (kver, inode) in modules_dir.entries() {
                     let Inode::Directory(dir) = inode else {
                         continue;
                     };
 
+                    let dir_ref = DirectoryRef::from_parts(dir, root.leaves());
                     Self::find_uki_components(
-                        dir,
+                        dir_ref,
                         &mut entries,
                         &mut PathBuf::new(),
                         &Some(Box::from(kver)),
@@ -490,20 +496,22 @@ initrd /{id}/initramfs.img
     /// # Returns
     ///
     /// A vector of all UsrLibModulesVmlinuz entries found
-    pub fn load_all(root: &Directory<ObjectID>) -> Result<Vec<Self>> {
+    pub fn load_all(fs: &FileSystem<ObjectID>) -> Result<Vec<Self>> {
         let mut entries = vec![];
+        let root = fs.as_dir();
 
-        match root.get_directory("/usr/lib/modules".as_ref()) {
+        match root.get_directory_ref("/usr/lib/modules".as_ref()) {
             Ok(modules_dir) => {
                 for (kver, inode) in modules_dir.entries() {
                     let Inode::Directory(dir) = inode else {
                         continue;
                     };
 
-                    if let Ok(vmlinuz) = dir.get_file("vmlinuz".as_ref()) {
+                    let dir_ref = DirectoryRef::from_parts(dir, root.leaves());
+                    if let Ok(vmlinuz) = dir_ref.get_file("vmlinuz".as_ref()) {
                         // TODO: maybe initramfs should be mandatory: the kernel isn't useful
                         // without it
-                        let initramfs = dir.get_file("initramfs.img".as_ref()).ok();
+                        let initramfs = dir_ref.get_file("initramfs.img".as_ref()).ok();
                         let os_release = root.get_file("/usr/lib/os-release".as_ref()).ok();
                         entries.push(Self {
                             kver: Box::from(std::str::from_utf8(kver.as_bytes())?),
@@ -556,13 +564,13 @@ pub fn get_boot_resources<ObjectID: FsVerityHashValue>(
 ) -> Result<Vec<BootEntry<ObjectID>>> {
     let mut entries = vec![];
 
-    for e in Type1Entry::load_all(&image.root, repo)? {
+    for e in Type1Entry::load_all(image, repo)? {
         entries.push(BootEntry::Type1(e));
     }
-    for e in Type2Entry::load_all(&image.root)? {
+    for e in Type2Entry::load_all(image)? {
         entries.push(BootEntry::Type2(e));
     }
-    for e in UsrLibModulesVmlinuz::load_all(&image.root)? {
+    for e in UsrLibModulesVmlinuz::load_all(image)? {
         entries.push(BootEntry::UsrLibModulesVmLinuz(e));
     }
 

--- a/crates/composefs-boot/src/selabel.rs
+++ b/crates/composefs-boot/src/selabel.rs
@@ -26,7 +26,7 @@ use rustix::{
 use composefs::{
     fsverity::FsVerityHashValue,
     repository::Repository,
-    tree::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
+    tree::{Directory, DirectoryRef, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
 };
 
 /// The SELinux security context extended attribute name.
@@ -129,7 +129,7 @@ struct Policy {
 
 /// Open a file in the composefs store, handling inline vs external files.
 pub fn open_file<H: FsVerityHashValue>(
-    dir: &Directory<H>,
+    dir: DirectoryRef<'_, H>,
     filename: impl AsRef<OsStr>,
     repo: &Repository<H>,
 ) -> Result<Option<Box<dyn Read>>> {
@@ -238,18 +238,18 @@ impl Policy {
     }
 }
 
-fn relabel(stat: &Stat, path: &Path, ifmt: u8, policy: &mut Policy) {
-    let mut xattrs = stat.xattrs.borrow_mut();
+fn relabel(stat: &mut Stat, path: &Path, ifmt: u8, policy: &mut Policy) {
     let key = OsStr::new(XATTR_SECURITY_SELINUX);
 
     if let Some(label) = policy.lookup(path.as_os_str(), ifmt) {
-        xattrs.insert(Box::from(key), Box::from(label.as_bytes()));
+        stat.xattrs
+            .insert(Box::from(key), Box::from(label.as_bytes()));
     } else {
-        xattrs.remove(key);
+        stat.xattrs.remove(key);
     }
 }
 
-fn relabel_leaf<H: FsVerityHashValue>(leaf: &Leaf<H>, path: &Path, policy: &mut Policy) {
+fn relabel_leaf<H: FsVerityHashValue>(leaf: &mut Leaf<H>, path: &Path, policy: &mut Policy) {
     let ifmt = match leaf.content {
         LeafContent::Regular(..) => b'-',
         LeafContent::Fifo => b'p', // NB: 'pipe', not 'fifo'
@@ -258,25 +258,44 @@ fn relabel_leaf<H: FsVerityHashValue>(leaf: &Leaf<H>, path: &Path, policy: &mut 
         LeafContent::BlockDevice(..) => b'b',
         LeafContent::CharacterDevice(..) => b'c',
     };
-    relabel(&leaf.stat, path, ifmt, policy);
+    relabel(&mut leaf.stat, path, ifmt, policy);
 }
 
-fn relabel_inode<H: FsVerityHashValue>(inode: &Inode<H>, path: &mut PathBuf, policy: &mut Policy) {
-    match inode {
-        Inode::Directory(dir) => relabel_dir(dir, path, policy),
-        Inode::Leaf(leaf) => relabel_leaf(leaf, path, policy),
-    }
-}
+fn relabel_dir<H: FsVerityHashValue>(
+    dir: &mut Directory<H>,
+    leaves: &mut [Leaf<H>],
+    path: &mut PathBuf,
+    policy: &mut Policy,
+) {
+    use composefs::generic_tree::LeafId;
 
-fn relabel_dir<H: FsVerityHashValue>(dir: &Directory<H>, path: &mut PathBuf, policy: &mut Policy) {
-    relabel(&dir.stat, path, b'd', policy);
+    relabel(&mut dir.stat, path, b'd', policy);
 
-    for (name, inode) in dir.sorted_entries() {
-        path.push(name);
-        match policy.check_aliased(path.as_os_str()) {
-            Some(original) => relabel_inode(inode, &mut PathBuf::from(original), policy),
-            None => relabel_inode(inode, path, policy),
+    // Collect entry names and types to avoid borrow conflicts during mutation.
+    let children: Vec<(Box<OsStr>, Option<LeafId>)> = dir
+        .sorted_entries()
+        .map(|(name, inode)| {
+            let id = match inode {
+                Inode::Leaf(id, _) => Some(*id),
+                Inode::Directory(_) => None,
+            };
+            (Box::from(name), id)
+        })
+        .collect();
+
+    for (name, leaf_id) in children {
+        path.push(Path::new(&name));
+        let aliased_path = policy.check_aliased(path.as_os_str()).map(PathBuf::from);
+        let effective_path = aliased_path.as_deref().unwrap_or(path.as_path());
+
+        if let Some(id) = leaf_id {
+            relabel_leaf(&mut leaves[id.0], effective_path, policy);
+        } else {
+            let mut sub_path = effective_path.to_path_buf();
+            let subdir = dir.get_directory_mut(name.as_ref()).unwrap();
+            relabel_dir(subdir, leaves, &mut sub_path, policy);
         }
+
         path.pop();
     }
 }
@@ -293,11 +312,9 @@ fn parse_config(file: impl Read) -> Result<Option<String>> {
     Ok(None)
 }
 
-fn strip_selinux_labels<H: FsVerityHashValue>(fs: &FileSystem<H>) {
-    fs.for_each_stat(|stat| {
-        stat.xattrs
-            .borrow_mut()
-            .remove(OsStr::new(XATTR_SECURITY_SELINUX));
+fn strip_selinux_labels<H: FsVerityHashValue>(fs: &mut FileSystem<H>) {
+    fs.for_each_stat_mut(|stat| {
+        stat.xattrs.remove(OsStr::new(XATTR_SECURITY_SELINUX));
     });
 }
 
@@ -324,7 +341,8 @@ fn apply_policy<H: FsVerityHashValue>(fs: &mut FileSystem<H>, policy: Option<Pol
     match policy {
         Some(mut policy) => {
             let mut path = PathBuf::from("/");
-            relabel_dir(&fs.root, &mut path, &mut policy);
+            let FileSystem { root, leaves } = fs;
+            relabel_dir(root, leaves, &mut path, &mut policy);
             true
         }
         None => {
@@ -356,7 +374,8 @@ fn apply_policy<H: FsVerityHashValue>(fs: &mut FileSystem<H>, policy: Option<Pol
 pub fn selabel<H: FsVerityHashValue>(fs: &mut FileSystem<H>, repo: &Repository<H>) -> Result<bool> {
     // Build the policy while only borrowing fs.root immutably.
     let policy = {
-        let Some(etc_selinux) = fs.root.get_directory_opt("etc/selinux".as_ref())? else {
+        let root = fs.as_dir();
+        let Some(etc_selinux) = root.get_directory_ref_opt("etc/selinux".as_ref())? else {
             strip_selinux_labels(fs);
             return Ok(false);
         };
@@ -365,8 +384,8 @@ pub fn selabel<H: FsVerityHashValue>(fs: &mut FileSystem<H>, repo: &Repository<H
             |filename| open_file(etc_selinux, filename, repo),
             |policy_name, filename| {
                 let dir = etc_selinux
-                    .get_directory(policy_name.as_ref())?
-                    .get_directory("contexts/files".as_ref())?;
+                    .get_directory_ref(policy_name.as_ref())?
+                    .get_directory_ref("contexts/files".as_ref())?;
                 open_file(dir, filename, repo)
             },
         )?
@@ -438,7 +457,6 @@ mod tests {
     /// Get the SELinux label from a Stat's xattrs, if any.
     fn selinux_label(stat: &Stat) -> Option<String> {
         stat.xattrs
-            .borrow()
             .get(OsStr::new(XATTR_SECURITY_SELINUX))
             .map(|v| String::from_utf8_lossy(v).into())
     }
@@ -454,17 +472,18 @@ mod tests {
         let p = Path::new(path);
         let parent = p.parent().unwrap();
         let name = p.file_name().unwrap();
+        let root = fs.as_dir();
         let dir = if parent == Path::new("/") {
-            &fs.root
+            root
         } else {
-            fs.root.get_directory(parent.as_os_str()).unwrap()
+            root.get_directory_ref(parent.as_os_str()).unwrap()
         };
         match dir
             .lookup(name)
             .unwrap_or_else(|| panic!("{path} not found"))
         {
             Inode::Directory(d) => selinux_label(&d.stat),
-            Inode::Leaf(l) => selinux_label(&l.stat),
+            Inode::Leaf(leaf_id, _) => selinux_label(&fs.leaf(*leaf_id).stat),
         }
     }
 
@@ -484,26 +503,6 @@ mod tests {
     ) -> FileSystem<Sha256HashValue> {
         use composefs::dumpfile::write_dumpfile;
 
-        // Build a tree containing the SELinux policy files, serialize it
-        // via the dumpfile writer so escaping is handled correctly, then
-        // append the caller's additional entries and parse the whole thing.
-        let selinux_config = b"SELINUX=enforcing\nSELINUXTYPE=targeted\n";
-
-        let inline = |data: &[u8]| {
-            Inode::Leaf(std::rc::Rc::new(Leaf {
-                stat: Stat {
-                    st_mode: 0o100644,
-                    st_uid: 0,
-                    st_gid: 0,
-                    st_mtim_sec: 0,
-                    xattrs: Default::default(),
-                },
-                content: LeafContent::Regular(RegularFile::Inline(
-                    data.to_vec().into_boxed_slice(),
-                )),
-            }))
-        };
-
         let dir_stat = || Stat {
             st_mode: 0o40755,
             st_uid: 0,
@@ -513,6 +512,27 @@ mod tests {
         };
 
         let mut fs = FileSystem::<Sha256HashValue>::new(dir_stat());
+
+        // Helper: push an inline file leaf and return its Inode.
+        let push_inline =
+            |fs: &mut FileSystem<Sha256HashValue>, data: &[u8]| -> Inode<Sha256HashValue> {
+                let id = fs.push_leaf(
+                    Stat {
+                        st_mode: 0o100644,
+                        st_uid: 0,
+                        st_gid: 0,
+                        st_mtim_sec: 0,
+                        xattrs: Default::default(),
+                    },
+                    LeafContent::Regular(RegularFile::Inline(data.to_vec().into_boxed_slice())),
+                );
+                Inode::leaf(id)
+            };
+
+        // Build a tree containing the SELinux policy files, serialize it
+        // via the dumpfile writer so escaping is handled correctly, then
+        // append the caller's additional entries and parse the whole thing.
+        let selinux_config = b"SELINUX=enforcing\nSELINUXTYPE=targeted\n";
 
         // Create the directory tree
         for path in [
@@ -525,19 +545,26 @@ mod tests {
             let (dir, name) = fs.root.split_mut(path.as_ref()).unwrap();
             dir.insert(name, Inode::Directory(Box::new(Directory::new(dir_stat()))));
         }
+        let config_inode = push_inline(&mut fs, selinux_config);
         fs.root
             .get_directory_mut("etc/selinux".as_ref())
             .unwrap()
-            .insert(OsStr::new("config"), inline(selinux_config));
+            .insert(OsStr::new("config"), config_inode);
 
         // Insert file_contexts and extra policy files
+        let fc_inode = push_inline(&mut fs, file_contexts);
+        let extra_inodes: Vec<_> = extra_policy_files
+            .iter()
+            .map(|(name, content)| (name.to_string(), push_inline(&mut fs, content)))
+            .collect();
+
         let files_dir = fs
             .root
             .get_directory_mut("etc/selinux/targeted/contexts/files".as_ref())
             .unwrap();
-        files_dir.insert(OsStr::new("file_contexts"), inline(file_contexts));
-        for (name, content) in extra_policy_files {
-            files_dir.insert(OsStr::new(name), inline(content));
+        files_dir.insert(OsStr::new("file_contexts"), fc_inode);
+        for (name, inode) in extra_inodes {
+            files_dir.insert(OsStr::new(&name), inode);
         }
 
         // Serialize via the proper dumpfile writer, append extra entries, re-parse

--- a/crates/composefs-fuse/src/lib.rs
+++ b/crates/composefs-fuse/src/lib.rs
@@ -13,7 +13,6 @@ use std::{
         fd::{AsFd, AsRawFd, OwnedFd},
         unix::ffi::OsStrExt,
     },
-    rc::Rc,
     time::{Duration, SystemTime},
 };
 
@@ -34,41 +33,98 @@ use rustix::{
 
 use composefs::{
     fsverity::FsVerityHashValue,
+    generic_tree::LeafId,
     mount::FsHandle,
     repository::Repository,
-    tree::{Directory, Inode, Leaf, LeafContent, RegularFile, Stat},
+    tree::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
 };
 
 const TTL: Duration = Duration::from_secs(1_000_000);
 
-#[derive(Debug, Clone)]
-enum InodeRef<'a, ObjectID: FsVerityHashValue> {
-    Directory(&'a Directory<ObjectID>, u64),
-    Leaf(&'a Rc<Leaf<ObjectID>>),
+/// FUSE inode number. Assigned eagerly at mount time.
+///
+/// Inode 1 is the root directory, then all other nodes get sequential
+/// numbers from a depth-first walk. The numbering is an internal FUSE
+/// concern and not exposed in the public API.
+type Ino = u64;
+
+/// Precomputed inode number assignments for the entire filesystem tree.
+///
+/// Directories are identified by pointer (stable because the tree is
+/// borrowed immutably for the lifetime of the FUSE session). Leaves
+/// are identified by `LeafId`.
+#[derive(Debug)]
+struct InodeMap<ObjectID: FsVerityHashValue> {
+    /// Directory pointer → inode number.
+    dir_inos: HashMap<*const Directory<ObjectID>, Ino>,
+    /// LeafId → inode number. Indexed by `LeafId.0`.
+    /// Hardlinked leaves (same `LeafId`) naturally get the same ino.
+    leaf_inos: Vec<Ino>,
 }
 
-#[derive(Debug)]
-enum OpenHandle {
-    Fd(OwnedFd),
-    Data(Box<[u8]>),
+impl<ObjectID: FsVerityHashValue> InodeMap<ObjectID> {
+    /// Walk the tree and assign sequential inode numbers.
+    fn build(fs: &FileSystem<ObjectID>) -> Self {
+        let mut next_ino: Ino = 1; // root = 1
+        let mut dir_inos = HashMap::new();
+        let mut leaf_inos = vec![0u64; fs.leaves.len()];
+
+        fn walk<O: FsVerityHashValue>(
+            dir: &Directory<O>,
+            next_ino: &mut Ino,
+            dir_inos: &mut HashMap<*const Directory<O>, Ino>,
+            leaf_inos: &mut [Ino],
+        ) {
+            let ino = *next_ino;
+            *next_ino += 1;
+            dir_inos.insert(dir as *const _, ino);
+
+            for (_, inode) in dir.entries() {
+                match inode {
+                    Inode::Directory(subdir) => walk(subdir, next_ino, dir_inos, leaf_inos),
+                    Inode::Leaf(id, _) => {
+                        if leaf_inos[id.0] == 0 {
+                            leaf_inos[id.0] = *next_ino;
+                            *next_ino += 1;
+                        }
+                        // Hardlinks: same LeafId keeps the same ino.
+                    }
+                }
+            }
+        }
+
+        walk(&fs.root, &mut next_ino, &mut dir_inos, &mut leaf_inos);
+        InodeMap {
+            dir_inos,
+            leaf_inos,
+        }
+    }
+
+    fn dir_ino(&self, dir: &Directory<ObjectID>) -> Ino {
+        self.dir_inos[&(dir as *const _)]
+    }
+
+    fn leaf_ino(&self, id: LeafId) -> Ino {
+        self.leaf_inos[id.0]
+    }
+
+    fn inode_ino(&self, inode: &Inode<ObjectID>) -> Ino {
+        match inode {
+            Inode::Directory(dir) => self.dir_ino(dir),
+            Inode::Leaf(id, _) => self.leaf_ino(*id),
+        }
+    }
+}
+
+/// A reference to a filesystem node, used for FUSE inode lookup.
+#[derive(Debug, Clone)]
+enum InodeRef<'a, ObjectID: FsVerityHashValue> {
+    Directory(&'a Directory<ObjectID>, Ino),
+    Leaf(LeafId, &'a Leaf<ObjectID>),
 }
 
 impl<'a, ObjectID: FsVerityHashValue> InodeRef<'a, ObjectID> {
-    fn new(inode: &'a Inode<ObjectID>, parent: u64) -> Self {
-        match inode {
-            Inode::Directory(dir) => InodeRef::Directory(dir, parent),
-            Inode::Leaf(leaf) => InodeRef::Leaf(leaf),
-        }
-    }
-
-    fn ino(&self) -> u64 {
-        match self {
-            InodeRef::Directory(dir, ..) => *dir as *const Directory<ObjectID> as u64,
-            InodeRef::Leaf(leaf) => Rc::as_ptr(leaf) as u64,
-        }
-    }
-
-    fn nlink(&self) -> u32 {
+    fn nlink(&self, nlink_map: &[u32]) -> u32 {
         (match self {
             InodeRef::Directory(dir, ..) => {
                 2 + dir
@@ -76,14 +132,14 @@ impl<'a, ObjectID: FsVerityHashValue> InodeRef<'a, ObjectID> {
                     .filter(|i| matches!(i, Inode::Directory(..)))
                     .count()
             }
-            InodeRef::Leaf(leaf) => Rc::strong_count(leaf),
+            InodeRef::Leaf(leaf_id, _) => nlink_map[leaf_id.0] as usize,
         }) as u32
     }
 
     fn rdev(&self) -> u32 {
         (match self {
             InodeRef::Directory(..) => 0,
-            InodeRef::Leaf(leaf) => match &leaf.content {
+            InodeRef::Leaf(_, leaf) => match &leaf.content {
                 LeafContent::BlockDevice(rdev) | LeafContent::CharacterDevice(rdev) => *rdev,
                 _ => 0,
             },
@@ -93,32 +149,28 @@ impl<'a, ObjectID: FsVerityHashValue> InodeRef<'a, ObjectID> {
     fn kind(&self) -> FileType {
         match self {
             InodeRef::Directory(..) => FileType::Directory,
-            InodeRef::Leaf(leaf) => Self::leaf_kind(leaf),
-        }
-    }
-
-    fn leaf_kind(leaf: &Leaf<ObjectID>) -> FileType {
-        match leaf.content {
-            LeafContent::BlockDevice(..) => FileType::BlockDevice,
-            LeafContent::CharacterDevice(..) => FileType::CharDevice,
-            LeafContent::Fifo => FileType::NamedPipe,
-            LeafContent::Regular(..) => FileType::RegularFile,
-            LeafContent::Socket => FileType::Socket,
-            LeafContent::Symlink(..) => FileType::Symlink,
+            InodeRef::Leaf(_, leaf) => match leaf.content {
+                LeafContent::BlockDevice(..) => FileType::BlockDevice,
+                LeafContent::CharacterDevice(..) => FileType::CharDevice,
+                LeafContent::Fifo => FileType::NamedPipe,
+                LeafContent::Regular(..) => FileType::RegularFile,
+                LeafContent::Socket => FileType::Socket,
+                LeafContent::Symlink(..) => FileType::Symlink,
+            },
         }
     }
 
     fn stat(&self) -> &'a Stat {
         match self {
             InodeRef::Directory(dir, ..) => &dir.stat,
-            InodeRef::Leaf(leaf) => &leaf.stat,
+            InodeRef::Leaf(_, leaf) => &leaf.stat,
         }
     }
 
     fn size(&self) -> u64 {
         match self {
             InodeRef::Directory(..) => 0,
-            InodeRef::Leaf(leaf) => match &leaf.content {
+            InodeRef::Leaf(_, leaf) => match &leaf.content {
                 LeafContent::Regular(RegularFile::Inline(data)) => data.len() as u64,
                 LeafContent::Regular(RegularFile::External(.., size)) => *size,
                 _ => 0,
@@ -126,12 +178,12 @@ impl<'a, ObjectID: FsVerityHashValue> InodeRef<'a, ObjectID> {
         }
     }
 
-    fn fileattr(&self) -> FileAttr {
+    fn fileattr(&self, ino: Ino, nlink_map: &[u32]) -> FileAttr {
         let stat = self.stat();
         let mtime = SystemTime::UNIX_EPOCH + Duration::from_secs(stat.st_mtim_sec as u64);
 
         FileAttr {
-            ino: self.ino(),
+            ino,
             size: self.size(),
             blocks: 1,
             atime: mtime,
@@ -140,7 +192,7 @@ impl<'a, ObjectID: FsVerityHashValue> InodeRef<'a, ObjectID> {
             crtime: mtime,
             kind: self.kind(),
             perm: stat.st_mode as u16,
-            nlink: self.nlink(),
+            nlink: self.nlink(nlink_map),
             uid: stat.st_uid,
             gid: stat.st_gid,
             rdev: self.rdev(),
@@ -151,30 +203,34 @@ impl<'a, ObjectID: FsVerityHashValue> InodeRef<'a, ObjectID> {
 }
 
 #[derive(Debug)]
+enum OpenHandle {
+    Fd(OwnedFd),
+    Data(Box<[u8]>),
+}
+
+#[derive(Debug)]
 struct TreeFuse<'a, ObjectID: FsVerityHashValue> {
     repo: &'a Repository<ObjectID>,
-    inodes: HashMap<u64, InodeRef<'a, ObjectID>>,
-    attrs: HashMap<u64, FileAttr>,
+    fs: &'a FileSystem<ObjectID>,
+    inode_map: InodeMap<ObjectID>,
+    nlink_map: Vec<u32>,
+    inodes: HashMap<Ino, InodeRef<'a, ObjectID>>,
+    attrs: HashMap<Ino, FileAttr>,
     handles: HashMap<u64, OpenHandle>,
     next_fh: u64,
 }
 
 impl<'a, ObjectID: FsVerityHashValue> TreeFuse<'a, ObjectID> {
-    fn inode_ref(&mut self, inode: &'a Inode<ObjectID>, parent: u64) -> InodeRef<'a, ObjectID> {
-        let iref = InodeRef::new(inode, parent);
-        self.inodes.insert(iref.ino(), iref.clone());
-        iref
-    }
-
-    fn iref_fileattr(&mut self, iref: &InodeRef<ObjectID>) -> &FileAttr {
-        self.attrs.insert(iref.ino(), iref.fileattr());
-        self.attrs.get(&iref.ino()).unwrap()
-    }
-
-    fn inode_fileattr(&mut self, inode: &'a Inode<ObjectID>, parent: u64) -> &FileAttr {
-        let iref = self.inode_ref(inode, parent);
-        self.attrs.insert(iref.ino(), iref.fileattr());
-        self.attrs.get(&iref.ino()).unwrap()
+    fn register_inode(&mut self, inode: &'a Inode<ObjectID>, parent: Ino) -> (Ino, FileType) {
+        let ino = self.inode_map.inode_ino(inode);
+        let iref = match inode {
+            Inode::Directory(dir) => InodeRef::Directory(dir, parent),
+            Inode::Leaf(leaf_id, _) => InodeRef::Leaf(*leaf_id, self.fs.leaf(*leaf_id)),
+        };
+        let kind = iref.kind();
+        self.attrs.insert(ino, iref.fileattr(ino, &self.nlink_map));
+        self.inodes.insert(ino, iref);
+        (ino, kind)
     }
 }
 
@@ -189,13 +245,13 @@ impl<ObjectID: FsVerityHashValue> Filesystem for TreeFuse<'_, ObjectID> {
             log::error!("lookup({parent}, {name:?}) parent does not exist");
             return reply.error(Errno::BADF.raw_os_error());
         };
-
-        // dir is &&Directory which means it holds a reference to the image and also a reference to
-        // self.  Dereference to drop the spurious self-reference to allow further mutability.
         let dir = *dir;
 
         match dir.lookup(name) {
-            Some(inode) => reply.entry(&TTL, self.inode_fileattr(inode, parent), 0),
+            Some(inode) => {
+                let (ino, _) = self.register_inode(inode, parent);
+                reply.entry(&TTL, self.attrs.get(&ino).unwrap(), 0);
+            }
             None => reply.error(Errno::NOENT.raw_os_error()),
         }
     }
@@ -209,15 +265,15 @@ impl<ObjectID: FsVerityHashValue> Filesystem for TreeFuse<'_, ObjectID> {
             log::error!("getattr({ino}) inode does not exist");
             return reply.error(Errno::BADF.raw_os_error());
         };
-
-        // iref is &InodeRef which means it holds a reference to self.  Drop that.
         let iref = iref.clone();
 
-        reply.attr(&TTL, self.iref_fileattr(&iref));
+        let attr = iref.fileattr(ino, &self.nlink_map);
+        self.attrs.insert(ino, attr);
+        reply.attr(&TTL, self.attrs.get(&ino).unwrap());
     }
 
     fn readlink(&mut self, _req: &Request<'_>, ino: u64, reply: ReplyData) {
-        let Some(InodeRef::Leaf(leaf, ..)) = self.inodes.get(&ino) else {
+        let Some(InodeRef::Leaf(_, leaf)) = self.inodes.get(&ino) else {
             return reply.error(Errno::INVAL.raw_os_error());
         };
 
@@ -244,6 +300,7 @@ impl<ObjectID: FsVerityHashValue> Filesystem for TreeFuse<'_, ObjectID> {
             log::error!("readdir({ino}) inode is not a directory");
             return reply.error(Errno::BADF.raw_os_error());
         };
+        let (dir, parent) = (*dir, *parent);
 
         if offset == 0 {
             offset += 1;
@@ -254,16 +311,16 @@ impl<ObjectID: FsVerityHashValue> Filesystem for TreeFuse<'_, ObjectID> {
 
         if offset == 1 {
             offset += 1;
-            if reply.add(*parent, offset, FileType::Directory, "..") {
+            if reply.add(parent, offset, FileType::Directory, "..") {
                 return reply.ok();
             }
         }
 
         for (name, inode) in dir.sorted_entries().skip(offset as usize - 2) {
-            let iref = self.inode_ref(inode, ino);
+            let (child_ino, kind) = self.register_inode(inode, ino);
 
             offset += 1;
-            if reply.add(iref.ino(), offset, iref.kind(), name) {
+            if reply.add(child_ino, offset, kind, name) {
                 break;
             }
         }
@@ -295,7 +352,7 @@ impl<ObjectID: FsVerityHashValue> Filesystem for TreeFuse<'_, ObjectID> {
             return reply.error(Errno::BADF.raw_os_error());
         };
 
-        let xattrs = iref.stat().xattrs.borrow();
+        let xattrs = &iref.stat().xattrs;
         let Some(value) = xattrs.get(name) else {
             return reply.error(Errno::NODATA.raw_os_error());
         };
@@ -316,7 +373,7 @@ impl<ObjectID: FsVerityHashValue> Filesystem for TreeFuse<'_, ObjectID> {
         };
 
         let mut list = vec![];
-        for name in iref.stat().xattrs.borrow().keys() {
+        for name in iref.stat().xattrs.keys() {
             list.extend_from_slice(name.as_bytes());
             list.push(b'\0');
         }
@@ -337,7 +394,7 @@ impl<ObjectID: FsVerityHashValue> Filesystem for TreeFuse<'_, ObjectID> {
             return reply.error(Errno::BADF.raw_os_error());
         };
 
-        let InodeRef::Leaf(leaf) = iref else {
+        let InodeRef::Leaf(_, leaf) = iref else {
             log::error!("open({ino}) inode is a directory");
             return reply.error(Errno::BADF.raw_os_error());
         };
@@ -458,20 +515,30 @@ pub fn mount_fuse(dev_fuse: impl AsFd) -> anyhow::Result<OwnedFd> {
     )?)
 }
 
-/// Serves a FUSE filesystem exposing the content of `root`, backed by `repo`.
+/// Serves a FUSE filesystem exposing the content of `filesystem`, backed by `repo`.
 ///
 /// You should have called mount_fuse() on the dev_fuse fd to establish a mount point.
 pub fn serve_tree_fuse<'a, ObjectID: FsVerityHashValue>(
     dev_fuse: OwnedFd,
-    root: &'a Directory<ObjectID>,
+    filesystem: &'a FileSystem<ObjectID>,
     repo: &'a Repository<ObjectID>,
 ) -> std::io::Result<()> {
-    let fs = TreeFuse::<ObjectID> {
+    let inode_map = InodeMap::build(filesystem);
+    let nlink_map = filesystem.nlinks();
+
+    let root_ino = inode_map.dir_ino(&filesystem.root);
+    let root_ref = InodeRef::Directory(&filesystem.root, root_ino);
+    let root_attr = root_ref.fileattr(root_ino, &nlink_map);
+
+    let tf = TreeFuse::<ObjectID> {
         repo,
-        inodes: HashMap::from([(1, InodeRef::Directory(root, 1))]),
-        attrs: Default::default(),
+        fs: filesystem,
+        inode_map,
+        nlink_map,
+        inodes: HashMap::from([(root_ino, root_ref)]),
+        attrs: HashMap::from([(root_ino, root_attr)]),
         handles: Default::default(),
         next_fh: 1,
     };
-    Session::from_fd(fs, dev_fuse, SessionACL::All).run()
+    Session::from_fd(tf, dev_fuse, SessionACL::All).run()
 }

--- a/crates/composefs-oci/src/image.rs
+++ b/crates/composefs-oci/src/image.rs
@@ -8,7 +8,7 @@
 //! and builds a complete filesystem by processing all layers in order. The `process_entry()` function
 //! handles individual tar entries and implements overlayfs whiteout semantics for proper layer merging.
 
-use std::{ffi::OsStr, os::unix::ffi::OsStrExt, rc::Rc};
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use anyhow::{Context, Result, ensure};
 use composefs::util::DigestWrite;
@@ -18,7 +18,7 @@ use sha2::{Digest, Sha256};
 use composefs::{
     fsverity::FsVerityHashValue,
     repository::Repository,
-    tree::{Directory, FileSystem, Inode, Leaf, Stat},
+    tree::{Directory, FileSystem, Inode, Stat},
 };
 
 use containers_image_proxy::oci_spec::image::Digest as OciDigest;
@@ -53,13 +53,13 @@ pub fn process_entry<ObjectID: FsVerityHashValue>(
 
     let inode = match entry.item {
         TarItem::Directory => Inode::Directory(Box::from(Directory::new(entry.stat))),
-        TarItem::Leaf(content) => Inode::Leaf(Rc::new(Leaf {
-            stat: entry.stat,
-            content,
-        })),
+        TarItem::Leaf(content) => {
+            let id = filesystem.push_leaf(entry.stat, content);
+            Inode::leaf(id)
+        }
         TarItem::Hardlink(target) => {
             let (dir, filename) = filesystem.root.split(&target)?;
-            Inode::Leaf(dir.ref_leaf(filename)?)
+            Inode::leaf(dir.leaf_id(filename)?)
         }
     };
 
@@ -142,6 +142,13 @@ pub fn create_filesystem<ObjectID: FsVerityHashValue>(
     // See https://github.com/containers/composefs-rs/issues/132
     filesystem.transform_for_oci()?;
 
+    // Whiteout processing and layer merging can leave orphaned leaves.
+    filesystem.compact();
+
+    debug_assert!(
+        filesystem.fsck().is_ok(),
+        "create_filesystem produced invalid filesystem"
+    );
     Ok(filesystem)
 }
 
@@ -152,7 +159,7 @@ mod test {
         fsverity::Sha256HashValue,
         tree::{LeafContent, RegularFile, Stat},
     };
-    use std::{cell::RefCell, collections::BTreeMap, io::BufRead, path::PathBuf};
+    use std::{collections::BTreeMap, io::BufRead, path::PathBuf};
 
     use super::*;
 
@@ -164,7 +171,7 @@ mod test {
                 st_uid: 0,
                 st_gid: 0,
                 st_mtim_sec: 0,
-                xattrs: RefCell::new(BTreeMap::new()),
+                xattrs: BTreeMap::new(),
             },
             item: TarItem::Leaf(LeafContent::Regular(RegularFile::Inline([].into()))),
         }
@@ -178,7 +185,7 @@ mod test {
                 st_uid: 0,
                 st_gid: 0,
                 st_mtim_sec: 0,
-                xattrs: RefCell::new(BTreeMap::new()),
+                xattrs: BTreeMap::new(),
             },
             item: TarItem::Directory,
         }

--- a/crates/composefs-oci/src/tar.rs
+++ b/crates/composefs-oci/src/tar.rs
@@ -10,7 +10,6 @@
 //! The `TarEntry` and `TarItem` types represent processed tar entries in composefs format.
 
 use std::{
-    cell::RefCell,
     collections::BTreeMap,
     ffi::{OsStr, OsString},
     fmt,
@@ -437,7 +436,7 @@ pub fn get_entry<ObjectID: FsVerityHashValue>(
                             st_gid: entry.gid as u32,
                             st_mode: entry.mode,
                             st_mtim_sec: entry.mtime as i64,
-                            xattrs: RefCell::new(xattrs),
+                            xattrs,
                         },
                         item,
                     }));

--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -33,6 +33,7 @@ xxhash-rust = { version = "0.8.2", default-features = false, features = ["xxh32"
 zerocopy = { version = "0.8.0", default-features = false, features = ["derive", "std"] }
 zstd = { version = "0.13.0", default-features = false }
 rand = { version = "0.10.0", default-features = true }
+tokio-stream = "0.1.18"
 
 [dev-dependencies]
 cap-std = { version = "4.0.0", default-features = false }

--- a/crates/composefs/fuzz/Cargo.lock
+++ b/crates/composefs/fuzz/Cargo.lock
@@ -77,9 +77,11 @@ dependencies = [
  "rand",
  "rustix",
  "serde",
+ "serde_json",
  "sha2",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "xxhash-rust",
  "zerocopy",
  "zstd",
@@ -167,6 +169,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "getrandom"
@@ -534,6 +542,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/composefs/fuzz/generate_corpus.rs
+++ b/crates/composefs/fuzz/generate_corpus.rs
@@ -7,22 +7,18 @@
 //! Run via: `cargo run --manifest-path crates/composefs/fuzz/Cargo.toml --bin generate-corpus`
 //! or:      `just generate-corpus`
 
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::path::Path;
-use std::rc::Rc;
 
 use composefs::erofs::writer::mkfs_erofs;
 use composefs::fsverity::{FsVerityHashValue, Sha256HashValue};
-use composefs::generic_tree::{self, Stat};
+use composefs::generic_tree::{self, LeafContent, Stat};
 use composefs::tree::{self, FileSystem, RegularFile};
 
 type Dir = tree::Directory<Sha256HashValue>;
-type Leaf = tree::Leaf<Sha256HashValue>;
 type Inode = tree::Inode<Sha256HashValue>;
-type LeafContent = tree::LeafContent<Sha256HashValue>;
 
 /// Create a Stat with the given mode, uid, gid, mtime.
 fn stat(mode: u32, uid: u32, gid: u32, mtime: i64) -> Stat {
@@ -31,7 +27,7 @@ fn stat(mode: u32, uid: u32, gid: u32, mtime: i64) -> Stat {
         st_uid: uid,
         st_gid: gid,
         st_mtim_sec: mtime,
-        xattrs: RefCell::new(BTreeMap::new()),
+        xattrs: BTreeMap::new(),
     }
 }
 
@@ -48,11 +44,6 @@ fn file_stat() -> Stat {
 /// Build a FileSystem with just an empty root directory.
 fn empty_root() -> FileSystem<Sha256HashValue> {
     FileSystem::new(dir_stat())
-}
-
-/// Insert a leaf into a directory.
-fn insert_leaf(dir: &mut Dir, name: &str, leaf: Leaf) {
-    dir.insert(OsStr::new(name), Inode::Leaf(Rc::new(leaf)));
 }
 
 /// Insert a subdirectory into a directory, returning a mutable reference to it.
@@ -79,16 +70,13 @@ fn main() {
     // 2. Single inline file (small content stored in inode)
     {
         let mut fs = empty_root();
-        insert_leaf(
-            &mut fs.root,
-            "hello.txt",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Regular(RegularFile::Inline(
-                    b"Hello, world!".to_vec().into_boxed_slice(),
-                )),
-            },
+        let id = fs.push_leaf(
+            file_stat(),
+            LeafContent::Regular(RegularFile::Inline(
+                b"Hello, world!".to_vec().into_boxed_slice(),
+            )),
         );
+        fs.root.insert(OsStr::new("hello.txt"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("single_inline_file", image.into()));
     }
@@ -96,16 +84,12 @@ fn main() {
     // 3. Single external (chunk-based) regular file
     {
         let mut fs = empty_root();
-        // Use a dummy hash and a realistic file size
         let hash = Sha256HashValue::EMPTY;
-        insert_leaf(
-            &mut fs.root,
-            "data.bin",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Regular(RegularFile::External(hash, 65536)),
-            },
+        let id = fs.push_leaf(
+            file_stat(),
+            LeafContent::Regular(RegularFile::External(hash, 65536)),
         );
+        fs.root.insert(OsStr::new("data.bin"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("single_external_file", image.into()));
     }
@@ -113,14 +97,11 @@ fn main() {
     // 4. Symlink
     {
         let mut fs = empty_root();
-        insert_leaf(
-            &mut fs.root,
-            "link",
-            Leaf {
-                stat: stat(0o777, 0, 0, 0),
-                content: LeafContent::Symlink(OsString::from("/target/path").into_boxed_os_str()),
-            },
+        let id = fs.push_leaf(
+            stat(0o777, 0, 0, 0),
+            LeafContent::Symlink(OsString::from("/target/path").into_boxed_os_str()),
         );
+        fs.root.insert(OsStr::new("link"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("symlink", image.into()));
     }
@@ -128,14 +109,8 @@ fn main() {
     // 5. FIFO
     {
         let mut fs = empty_root();
-        insert_leaf(
-            &mut fs.root,
-            "mypipe",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Fifo,
-            },
-        );
+        let id = fs.push_leaf(file_stat(), LeafContent::Fifo);
+        fs.root.insert(OsStr::new("mypipe"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("fifo", image.into()));
     }
@@ -143,14 +118,11 @@ fn main() {
     // 6. Character device
     {
         let mut fs = empty_root();
-        insert_leaf(
-            &mut fs.root,
-            "null",
-            Leaf {
-                stat: stat(0o666, 0, 0, 0),
-                content: LeafContent::CharacterDevice(makedev(1, 3)),
-            },
+        let id = fs.push_leaf(
+            stat(0o666, 0, 0, 0),
+            LeafContent::CharacterDevice(makedev(1, 3)),
         );
+        fs.root.insert(OsStr::new("null"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("chardev", image.into()));
     }
@@ -158,14 +130,11 @@ fn main() {
     // 7. Block device
     {
         let mut fs = empty_root();
-        insert_leaf(
-            &mut fs.root,
-            "sda",
-            Leaf {
-                stat: stat(0o660, 0, 6, 0),
-                content: LeafContent::BlockDevice(makedev(8, 0)),
-            },
+        let id = fs.push_leaf(
+            stat(0o660, 0, 6, 0),
+            LeafContent::BlockDevice(makedev(8, 0)),
         );
+        fs.root.insert(OsStr::new("sda"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("blockdev", image.into()));
     }
@@ -173,14 +142,8 @@ fn main() {
     // 8. Socket
     {
         let mut fs = empty_root();
-        insert_leaf(
-            &mut fs.root,
-            "mysock",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Socket,
-            },
-        );
+        let id = fs.push_leaf(file_stat(), LeafContent::Socket);
+        fs.root.insert(OsStr::new("mysock"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("socket", image.into()));
     }
@@ -188,19 +151,16 @@ fn main() {
     // 9. Nested directories: /a/b/c/file
     {
         let mut fs = empty_root();
+        let id = fs.push_leaf(
+            file_stat(),
+            LeafContent::Regular(RegularFile::Inline(
+                b"nested content".to_vec().into_boxed_slice(),
+            )),
+        );
         let a = insert_dir(&mut fs.root, "a", dir_stat());
         let b = insert_dir(a, "b", dir_stat());
         let c = insert_dir(b, "c", dir_stat());
-        insert_leaf(
-            c,
-            "file",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Regular(RegularFile::Inline(
-                    b"nested content".to_vec().into_boxed_slice(),
-                )),
-            },
-        );
+        c.insert(OsStr::new("file"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("nested_dirs", image.into()));
     }
@@ -211,16 +171,13 @@ fn main() {
         for i in 0..25 {
             let name = format!("file_{i:03}");
             let content = format!("content of file {i}");
-            insert_leaf(
-                &mut fs.root,
-                &name,
-                Leaf {
-                    stat: file_stat(),
-                    content: LeafContent::Regular(RegularFile::Inline(
-                        content.into_bytes().into_boxed_slice(),
-                    )),
-                },
+            let id = fs.push_leaf(
+                file_stat(),
+                LeafContent::Regular(RegularFile::Inline(
+                    content.into_bytes().into_boxed_slice(),
+                )),
             );
+            fs.root.insert(OsStr::new(&name), Inode::leaf(id));
         }
         let image = mkfs_erofs(&fs);
         seeds.push(("many_entries", image.into()));
@@ -229,28 +186,26 @@ fn main() {
     // 11. Extended attributes
     {
         let mut fs = empty_root();
-        let xattr_stat = file_stat();
-        {
-            let mut xattrs = xattr_stat.xattrs.borrow_mut();
-            xattrs.insert(
-                Box::from(OsStr::new("security.selinux")),
-                Box::from(b"system_u:object_r:usr_t:s0".as_slice()),
-            );
-            xattrs.insert(
-                Box::from(OsStr::new("user.test")),
-                Box::from(b"test_value".as_slice()),
-            );
-        }
-        insert_leaf(
-            &mut fs.root,
-            "xattr_file",
-            Leaf {
-                stat: xattr_stat,
-                content: LeafContent::Regular(RegularFile::Inline(
-                    b"has xattrs".to_vec().into_boxed_slice(),
-                )),
-            },
+        let mut xattrs = BTreeMap::new();
+        xattrs.insert(
+            Box::from(OsStr::new("security.selinux")),
+            Box::from(b"system_u:object_r:usr_t:s0".as_slice()),
         );
+        xattrs.insert(
+            Box::from(OsStr::new("user.test")),
+            Box::from(b"test_value".as_slice()),
+        );
+        let xattr_stat = Stat {
+            xattrs,
+            ..file_stat()
+        };
+        let id = fs.push_leaf(
+            xattr_stat,
+            LeafContent::Regular(RegularFile::Inline(
+                b"has xattrs".to_vec().into_boxed_slice(),
+            )),
+        );
+        fs.root.insert(OsStr::new("xattr_file"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("xattrs", image.into()));
     }
@@ -258,85 +213,56 @@ fn main() {
     // 12. Mixed types — one of every file type in a single directory
     {
         let mut fs = empty_root();
-        insert_leaf(
-            &mut fs.root,
-            "regular",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Regular(RegularFile::Inline(
+        let ids = [
+            fs.push_leaf(
+                file_stat(),
+                LeafContent::Regular(RegularFile::Inline(
                     b"data".to_vec().into_boxed_slice(),
                 )),
-            },
-        );
-        insert_leaf(
-            &mut fs.root,
-            "link",
-            Leaf {
-                stat: stat(0o777, 0, 0, 0),
-                content: LeafContent::Symlink(OsString::from("regular").into_boxed_os_str()),
-            },
-        );
-        insert_leaf(
-            &mut fs.root,
-            "pipe",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Fifo,
-            },
-        );
-        insert_leaf(
-            &mut fs.root,
-            "sock",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Socket,
-            },
-        );
-        insert_leaf(
-            &mut fs.root,
-            "chrdev",
-            Leaf {
-                stat: stat(0o666, 0, 0, 0),
-                content: LeafContent::CharacterDevice(makedev(1, 3)),
-            },
-        );
-        insert_leaf(
-            &mut fs.root,
-            "blkdev",
-            Leaf {
-                stat: stat(0o660, 0, 6, 0),
-                content: LeafContent::BlockDevice(makedev(8, 0)),
-            },
-        );
+            ),
+            fs.push_leaf(
+                stat(0o777, 0, 0, 0),
+                LeafContent::Symlink(OsString::from("regular").into_boxed_os_str()),
+            ),
+            fs.push_leaf(file_stat(), LeafContent::Fifo),
+            fs.push_leaf(file_stat(), LeafContent::Socket),
+            fs.push_leaf(
+                stat(0o666, 0, 0, 0),
+                LeafContent::CharacterDevice(makedev(1, 3)),
+            ),
+            fs.push_leaf(
+                stat(0o660, 0, 6, 0),
+                LeafContent::BlockDevice(makedev(8, 0)),
+            ),
+        ];
+        let names = ["regular", "link", "pipe", "sock", "chrdev", "blkdev"];
+        for (name, id) in names.iter().zip(ids.iter()) {
+            fs.root.insert(OsStr::new(name), Inode::leaf(*id));
+        }
         insert_dir(&mut fs.root, "subdir", dir_stat());
         let hash = Sha256HashValue::EMPTY;
-        insert_leaf(
-            &mut fs.root,
-            "external",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Regular(RegularFile::External(hash, 4096)),
-            },
+        let ext_id = fs.push_leaf(
+            file_stat(),
+            LeafContent::Regular(RegularFile::External(hash, 4096)),
         );
+        fs.root.insert(OsStr::new("external"), Inode::leaf(ext_id));
         let image = mkfs_erofs(&fs);
         seeds.push(("mixed_types", image.into()));
     }
 
-    // 13. Hardlink — two entries sharing the same Rc<Leaf> (nlink > 1)
+    // 13. Hardlink — two entries sharing the same LeafId (nlink > 1)
     {
         let mut fs = empty_root();
-        let shared = Rc::new(Leaf {
-            stat: file_stat(),
-            content: LeafContent::Regular(RegularFile::Inline(
+        let shared_id = fs.push_leaf(
+            file_stat(),
+            LeafContent::Regular(RegularFile::Inline(
                 b"shared content".to_vec().into_boxed_slice(),
             )),
-        });
-        fs.root.insert(
-            OsStr::new("original").into(),
-            Inode::Leaf(Rc::clone(&shared)),
         );
         fs.root
-            .insert(OsStr::new("hardlink").into(), Inode::Leaf(shared));
+            .insert(OsStr::new("original"), Inode::leaf(shared_id));
+        fs.root
+            .insert(OsStr::new("hardlink"), Inode::leaf(shared_id));
         let image = mkfs_erofs(&fs);
         seeds.push(("hardlink", image.into()));
     }
@@ -345,14 +271,12 @@ fn main() {
     {
         let mut fs = empty_root();
         let content = vec![0xABu8; 4000]; // just under block size
-        insert_leaf(
-            &mut fs.root,
-            "large_inline.bin",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Regular(RegularFile::Inline(content.into_boxed_slice())),
-            },
+        let id = fs.push_leaf(
+            file_stat(),
+            LeafContent::Regular(RegularFile::Inline(content.into_boxed_slice())),
         );
+        fs.root
+            .insert(OsStr::new("large_inline.bin"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("large_inline", image.into()));
     }
@@ -360,21 +284,18 @@ fn main() {
     // 15. Deep nesting — 8 levels of directories
     {
         let mut fs = empty_root();
+        let id = fs.push_leaf(
+            file_stat(),
+            LeafContent::Regular(RegularFile::Inline(
+                b"deep".to_vec().into_boxed_slice(),
+            )),
+        );
         let names = ["d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8"];
         let mut current = &mut fs.root;
         for name in &names {
             current = insert_dir(current, name, dir_stat());
         }
-        insert_leaf(
-            current,
-            "deep_file",
-            Leaf {
-                stat: file_stat(),
-                content: LeafContent::Regular(RegularFile::Inline(
-                    b"deep".to_vec().into_boxed_slice(),
-                )),
-            },
-        );
+        current.insert(OsStr::new("deep_file"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("deep_nesting", image.into()));
     }
@@ -382,26 +303,20 @@ fn main() {
     // 16. Nonzero mtime
     {
         let mut fs = FileSystem::new(stat(0o755, 0, 0, 1000000));
-        insert_leaf(
-            &mut fs.root,
-            "old",
-            Leaf {
-                stat: stat(0o644, 0, 0, 500000),
-                content: LeafContent::Regular(RegularFile::Inline(
-                    b"old file".to_vec().into_boxed_slice(),
-                )),
-            },
+        let id1 = fs.push_leaf(
+            stat(0o644, 0, 0, 500000),
+            LeafContent::Regular(RegularFile::Inline(
+                b"old file".to_vec().into_boxed_slice(),
+            )),
         );
-        insert_leaf(
-            &mut fs.root,
-            "new",
-            Leaf {
-                stat: stat(0o644, 0, 0, 1700000000),
-                content: LeafContent::Regular(RegularFile::Inline(
-                    b"new file".to_vec().into_boxed_slice(),
-                )),
-            },
+        let id2 = fs.push_leaf(
+            stat(0o644, 0, 0, 1700000000),
+            LeafContent::Regular(RegularFile::Inline(
+                b"new file".to_vec().into_boxed_slice(),
+            )),
         );
+        fs.root.insert(OsStr::new("old"), Inode::leaf(id1));
+        fs.root.insert(OsStr::new("new"), Inode::leaf(id2));
         let image = mkfs_erofs(&fs);
         seeds.push(("nonzero_mtime", image.into()));
     }
@@ -410,16 +325,13 @@ fn main() {
     {
         let big_id = u16::MAX as u32 + 1; // 65536, won't fit in u16
         let mut fs = FileSystem::new(stat(0o755, big_id, big_id, 0));
-        insert_leaf(
-            &mut fs.root,
-            "bigids.txt",
-            Leaf {
-                stat: stat(0o644, big_id, big_id, 0),
-                content: LeafContent::Regular(RegularFile::Inline(
-                    b"big ids".to_vec().into_boxed_slice(),
-                )),
-            },
+        let id = fs.push_leaf(
+            stat(0o644, big_id, big_id, 0),
+            LeafContent::Regular(RegularFile::Inline(
+                b"big ids".to_vec().into_boxed_slice(),
+            )),
         );
+        fs.root.insert(OsStr::new("bigids.txt"), Inode::leaf(id));
         let image = mkfs_erofs(&fs);
         seeds.push(("large_uid_gid", image.into()));
     }

--- a/crates/composefs/src/dumpfile.rs
+++ b/crates/composefs/src/dumpfile.rs
@@ -7,14 +7,12 @@
 //! The module handles file metadata, extended attributes, and hardlink tracking.
 
 use std::{
-    cell::RefCell,
     collections::{BTreeMap, HashMap},
     ffi::{OsStr, OsString},
     fmt,
     io::{BufWriter, Write},
     os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
-    rc::Rc,
 };
 
 use anyhow::{Context, Result, ensure};
@@ -24,7 +22,8 @@ use rustix::fs::FileType;
 use crate::{
     dumpfile_parse::{Entry, Item},
     fsverity::FsVerityHashValue,
-    tree::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
+    generic_tree::LeafId,
+    tree::{Directory, FileSystem, Inode, LeafContent, RegularFile, Stat},
 };
 
 fn write_empty(writer: &mut impl fmt::Write) -> fmt::Result {
@@ -131,7 +130,7 @@ fn write_entry(
         write_empty(writer)?;
     }
 
-    for (key, value) in &*stat.xattrs.borrow() {
+    for (key, value) in &stat.xattrs {
         write!(writer, " ")?;
         write_escaped_raw(writer, key.as_bytes(), EscapeEquals::Yes)?;
         write!(writer, "=")?;
@@ -282,7 +281,9 @@ pub fn write_hardlink(writer: &mut impl fmt::Write, path: &Path, target: &OsStr)
 }
 
 struct DumpfileWriter<'a, W: Write, ObjectID: FsVerityHashValue> {
-    hardlinks: HashMap<*const Leaf<ObjectID>, OsString>,
+    hardlinks: HashMap<LeafId, OsString>,
+    fs: &'a FileSystem<ObjectID>,
+    nlink_map: &'a [u32],
     writer: &'a mut W,
 }
 
@@ -294,9 +295,11 @@ fn writeln_fmt(writer: &mut impl Write, f: impl Fn(&mut String) -> fmt::Result) 
 }
 
 impl<'a, W: Write, ObjectID: FsVerityHashValue> DumpfileWriter<'a, W, ObjectID> {
-    fn new(writer: &'a mut W) -> Self {
+    fn new(writer: &'a mut W, fs: &'a FileSystem<ObjectID>, nlink_map: &'a [u32]) -> Self {
         Self {
             hardlinks: HashMap::new(),
+            fs,
+            nlink_map,
             writer,
         }
     }
@@ -325,8 +328,8 @@ impl<'a, W: Write, ObjectID: FsVerityHashValue> DumpfileWriter<'a, W, ObjectID> 
                 Inode::Directory(dir) => {
                     self.write_dir(path, dir)?;
                 }
-                Inode::Leaf(leaf) => {
-                    self.write_leaf(path, leaf)?;
+                Inode::Leaf(leaf_id, _) => {
+                    self.write_leaf(path, *leaf_id)?;
                 }
             }
 
@@ -336,20 +339,20 @@ impl<'a, W: Write, ObjectID: FsVerityHashValue> DumpfileWriter<'a, W, ObjectID> 
     }
 
     #[context("Writing leaf to dumpfile: {}", path.display())]
-    fn write_leaf(&mut self, path: &Path, leaf: &Rc<Leaf<ObjectID>>) -> Result<()> {
-        let nlink = Rc::strong_count(leaf);
+    fn write_leaf(&mut self, path: &Path, leaf_id: LeafId) -> Result<()> {
+        let nlink = self.nlink_map[leaf_id.0] as usize;
 
         if nlink > 1 {
             // This is a hardlink.  We need to handle that specially.
-            let ptr = Rc::as_ptr(leaf);
-            if let Some(target) = self.hardlinks.get(&ptr) {
+            if let Some(target) = self.hardlinks.get(&leaf_id) {
                 return writeln_fmt(self.writer, |fmt| write_hardlink(fmt, path, target));
             }
 
             // @path gets modified all the time, so take a copy
-            self.hardlinks.insert(ptr, OsString::from(&path));
+            self.hardlinks.insert(leaf_id, OsString::from(&path));
         }
 
+        let leaf = self.fs.leaf(leaf_id);
         writeln_fmt(self.writer, |fmt| {
             write_leaf(fmt, path, &leaf.stat, &leaf.content, nlink)
         })
@@ -364,20 +367,23 @@ pub fn write_dumpfile(
     writer: &mut impl Write,
     fs: &FileSystem<impl FsVerityHashValue>,
 ) -> Result<()> {
+    let nlink_map = fs.nlinks();
     let path = PathBuf::from("/");
-    dump_single_dir(writer, &fs.root, path)
+    dump_single_dir(writer, &fs.root, fs, &nlink_map, path)
 }
 
 /// Write a single dir
-pub fn dump_single_dir(
+pub fn dump_single_dir<ObjectID: FsVerityHashValue>(
     writer: &mut impl Write,
-    dir: &Directory<impl FsVerityHashValue>,
+    dir: &Directory<ObjectID>,
+    fs: &FileSystem<ObjectID>,
+    nlink_map: &[u32],
     mut path: PathBuf,
 ) -> Result<()> {
     // default pipe capacity on Linux is 16 pages (65536 bytes), but
     // sometimes the BufWriter will write more than its capacity...
     let mut buffer = BufWriter::with_capacity(32768, writer);
-    let mut dfw = DumpfileWriter::new(&mut buffer);
+    let mut dfw = DumpfileWriter::new(&mut buffer, fs, nlink_map);
 
     dfw.write_dir(&mut path, dir)?;
     buffer.flush()?;
@@ -386,17 +392,19 @@ pub fn dump_single_dir(
 }
 
 /// Write a single file
-pub fn dump_single_file(
+pub fn dump_single_file<ObjectID: FsVerityHashValue>(
     writer: &mut impl Write,
-    file: &Rc<Leaf<impl FsVerityHashValue>>,
+    leaf_id: LeafId,
+    fs: &FileSystem<ObjectID>,
+    nlink_map: &[u32],
     path: PathBuf,
 ) -> Result<()> {
     // default pipe capacity on Linux is 16 pages (65536 bytes), but
     // sometimes the BufWriter will write more than its capacity...
     let mut buffer = BufWriter::with_capacity(32768, writer);
-    let mut dfw = DumpfileWriter::new(&mut buffer);
+    let mut dfw = DumpfileWriter::new(&mut buffer, fs, nlink_map);
 
-    dfw.write_leaf(&path, file)?;
+    dfw.write_leaf(&path, leaf_id)?;
     buffer.flush()?;
 
     Ok(())
@@ -408,7 +416,7 @@ pub fn dump_single_file(
 pub fn add_entry_to_filesystem<ObjectID: FsVerityHashValue>(
     fs: &mut FileSystem<ObjectID>,
     entry: Entry<'_>,
-    hardlinks: &mut HashMap<PathBuf, Rc<Leaf<ObjectID>>>,
+    hardlinks: &mut HashMap<PathBuf, LeafId>,
 ) -> Result<()> {
     let path = entry.path.as_ref();
 
@@ -425,14 +433,8 @@ pub fn add_entry_to_filesystem<ObjectID: FsVerityHashValue>(
         .file_name()
         .ok_or_else(|| anyhow::anyhow!("Path has no filename: {path:?}"))?;
 
-    // Get or create parent directory
-    let parent_dir = if parent == Path::new("/") {
-        &mut fs.root
-    } else {
-        fs.root
-            .get_directory_mut(parent.as_os_str())
-            .with_context(|| format!("Parent directory not found: {parent:?}"))?
-    };
+    // Helper to push a leaf into the filesystem and return a LeafId
+    let push_leaf = |fs: &mut FileSystem<ObjectID>, stat, content| fs.push_leaf(stat, content);
 
     // Convert the entry to an inode
     let inode = match entry.item {
@@ -441,12 +443,11 @@ pub fn add_entry_to_filesystem<ObjectID: FsVerityHashValue>(
             Inode::Directory(Box::new(Directory::new(stat)))
         }
         Item::Hardlink { ref target } => {
-            // Look up the target in our hardlinks map and clone the Rc
-            let target_leaf = hardlinks
+            // Look up the target in our hardlinks map and reuse the LeafId
+            let existing_id = *hardlinks
                 .get(target.as_ref())
-                .ok_or_else(|| anyhow::anyhow!("Hardlink target not found: {target:?}"))?
-                .clone();
-            Inode::Leaf(target_leaf)
+                .ok_or_else(|| anyhow::anyhow!("Hardlink target not found: {target:?}"))?;
+            Inode::leaf(existing_id)
         }
         Item::RegularInline { ref content, .. } => {
             let stat = entry_to_stat(&entry);
@@ -455,7 +456,8 @@ pub fn add_entry_to_filesystem<ObjectID: FsVerityHashValue>(
                 std::borrow::Cow::Owned(d) => d.clone().into_boxed_slice(),
             };
             let content = LeafContent::Regular(RegularFile::Inline(data));
-            Inode::Leaf(Rc::new(Leaf { stat, content }))
+            let id = push_leaf(fs, stat, content);
+            Inode::leaf(id)
         }
         Item::Regular {
             size,
@@ -468,7 +470,8 @@ pub fn add_entry_to_filesystem<ObjectID: FsVerityHashValue>(
                 .ok_or_else(|| anyhow::anyhow!("External file missing fsverity digest"))?;
             let object_id = ObjectID::from_hex(digest)?;
             let content = LeafContent::Regular(RegularFile::External(object_id, size));
-            Inode::Leaf(Rc::new(Leaf { stat, content }))
+            let id = push_leaf(fs, stat, content);
+            Inode::leaf(id)
         }
         Item::Device { rdev, .. } => {
             let stat = entry_to_stat(&entry);
@@ -478,7 +481,8 @@ pub fn add_entry_to_filesystem<ObjectID: FsVerityHashValue>(
             } else {
                 LeafContent::CharacterDevice(rdev)
             };
-            Inode::Leaf(Rc::new(Leaf { stat, content }))
+            let id = push_leaf(fs, stat, content);
+            Inode::leaf(id)
         }
         Item::Symlink { ref target, .. } => {
             let stat = entry_to_stat(&entry);
@@ -487,19 +491,30 @@ pub fn add_entry_to_filesystem<ObjectID: FsVerityHashValue>(
                 std::borrow::Cow::Owned(t) => Box::from(t.as_os_str()),
             };
             let content = LeafContent::Symlink(target_os);
-            Inode::Leaf(Rc::new(Leaf { stat, content }))
+            let id = push_leaf(fs, stat, content);
+            Inode::leaf(id)
         }
         Item::Fifo { .. } => {
             let stat = entry_to_stat(&entry);
             let content = LeafContent::Fifo;
-            Inode::Leaf(Rc::new(Leaf { stat, content }))
+            let id = push_leaf(fs, stat, content);
+            Inode::leaf(id)
         }
     };
 
-    // Store Leafs in the hardlinks map for future hardlink lookups
-    if let Inode::Leaf(ref leaf) = inode {
-        hardlinks.insert(path.to_path_buf(), leaf.clone());
+    // Store LeafIds in the hardlinks map for future hardlink lookups
+    if let Inode::Leaf(id, _) = inode {
+        hardlinks.insert(path.to_path_buf(), id);
     }
+
+    // We need to get the parent_dir after pushing leaves (borrow checker)
+    let parent_dir = if parent == Path::new("/") {
+        &mut fs.root
+    } else {
+        fs.root
+            .get_directory_mut(parent.as_os_str())
+            .with_context(|| format!("Parent directory not found: {parent:?}"))?
+    };
 
     parent_dir.insert(filename, inode);
     Ok(())
@@ -525,7 +540,7 @@ fn entry_to_stat(entry: &Entry<'_>) -> Stat {
         st_uid: entry.uid,
         st_gid: entry.gid,
         st_mtim_sec: entry.mtime.sec as i64,
-        xattrs: RefCell::new(xattrs),
+        xattrs,
     }
 }
 
@@ -569,6 +584,10 @@ pub fn dumpfile_to_filesystem<ObjectID: FsVerityHashValue>(
         add_entry_to_filesystem(&mut fs, entry, &mut hardlinks)?;
     }
 
+    debug_assert!(
+        fs.fsck().is_ok(),
+        "dumpfile parsing produced invalid filesystem"
+    );
     Ok(fs)
 }
 
@@ -593,7 +612,7 @@ mod tests {
         assert!(fs.root.lookup(OsStr::new("symlink")).is_some());
 
         // Check inline file content
-        let small_file = fs.root.get_file(OsStr::new("small_file"))?;
+        let small_file = fs.as_dir().get_file(OsStr::new("small_file"))?;
         if let RegularFile::Inline(data) = small_file {
             assert_eq!(&**data, b"hello");
         } else {
@@ -625,29 +644,29 @@ mod tests {
         let dir1 = fs.root.get_directory(OsStr::new("dir1"))?;
         let hardlink2 = dir1.lookup(OsStr::new("hardlink2")).unwrap();
 
-        // All three should be Leaf inodes
-        let original_leaf = match original {
-            Inode::Leaf(l) => l,
+        // All three should be Leaf inodes with the same LeafId
+        let original_id = match original {
+            Inode::Leaf(id, _) => *id,
             _ => panic!("Expected Leaf inode"),
         };
-        let hardlink1_leaf = match hardlink1 {
-            Inode::Leaf(l) => l,
+        let hardlink1_id = match hardlink1 {
+            Inode::Leaf(id, _) => *id,
             _ => panic!("Expected Leaf inode"),
         };
-        let hardlink2_leaf = match hardlink2 {
-            Inode::Leaf(l) => l,
+        let hardlink2_id = match hardlink2 {
+            Inode::Leaf(id, _) => *id,
             _ => panic!("Expected Leaf inode"),
         };
 
-        // They should all point to the same Rc (same pointer)
-        assert!(Rc::ptr_eq(original_leaf, hardlink1_leaf));
-        assert!(Rc::ptr_eq(original_leaf, hardlink2_leaf));
+        // They should all share the same LeafId
+        assert_eq!(original_id, hardlink1_id);
+        assert_eq!(original_id, hardlink2_id);
 
-        // Verify the strong count is 3 (original + 2 hardlinks)
-        assert_eq!(Rc::strong_count(original_leaf), 3);
+        // Verify nlink count is 3 (original + 2 hardlinks)
+        assert_eq!(fs.nlinks()[original_id.0], 3);
 
         // Verify content
-        if let LeafContent::Regular(RegularFile::Inline(data)) = &original_leaf.content {
+        if let LeafContent::Regular(RegularFile::Inline(data)) = &fs.leaf(original_id).content {
             assert_eq!(&**data, b"hello_world");
         } else {
             panic!("Expected inline regular file");
@@ -666,7 +685,7 @@ mod tests {
         let fs = dumpfile_to_filesystem::<Sha256HashValue>(dumpfile)?;
         let link = fs.root.lookup(OsStr::new("link")).unwrap();
         match link {
-            Inode::Leaf(l) => match &l.content {
+            Inode::Leaf(id, _) => match &fs.leaf(*id).content {
                 LeafContent::Symlink(target) => assert_eq!(target.as_ref(), OsStr::new("-")),
                 other => panic!("expected symlink, got {other:?}"),
             },
@@ -690,9 +709,6 @@ mod tests {
     /// not treat specially.
     #[test]
     fn test_xattr_empty_and_dash_values_round_trip() -> Result<()> {
-        use std::cell::RefCell;
-        use std::collections::BTreeMap;
-
         let mut xattrs = BTreeMap::new();
         xattrs.insert(
             Box::from(OsStr::new("user.empty")),
@@ -708,19 +724,19 @@ mod tests {
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: RefCell::new(BTreeMap::new()),
+            xattrs: BTreeMap::new(),
         });
-        let leaf = std::rc::Rc::new(Leaf {
-            stat: Stat {
+        let leaf_id = fs.push_leaf(
+            Stat {
                 st_mode: 0o644,
                 st_uid: 0,
                 st_gid: 0,
                 st_mtim_sec: 0,
-                xattrs: RefCell::new(xattrs),
+                xattrs,
             },
-            content: LeafContent::Regular(RegularFile::Inline(b"test".to_vec().into())),
-        });
-        fs.root.insert(OsStr::new("f"), Inode::Leaf(leaf));
+            LeafContent::Regular(RegularFile::Inline(b"test".to_vec().into())),
+        );
+        fs.root.insert(OsStr::new("f"), Inode::leaf(leaf_id));
 
         let mut out = Vec::new();
         write_dumpfile(&mut out, &fs)?;
@@ -736,29 +752,25 @@ mod tests {
     /// hardlinks correctly.
     #[test]
     fn test_hardlink_write_round_trip() -> Result<()> {
-        use std::cell::RefCell;
-        use std::collections::BTreeMap;
-
         let stat = || Stat {
             st_mode: 0o644,
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: RefCell::new(BTreeMap::new()),
+            xattrs: BTreeMap::new(),
         };
 
         let mut fs = FileSystem::<Sha256HashValue>::new(Stat {
             st_mode: 0o755,
             ..stat()
         });
-        let leaf = std::rc::Rc::new(Leaf {
-            stat: stat(),
-            content: LeafContent::Regular(RegularFile::Inline(b"data".to_vec().into())),
-        });
-        // Insert original + hardlink (same Rc)
-        fs.root
-            .insert(OsStr::new("original"), Inode::Leaf(leaf.clone()));
-        fs.root.insert(OsStr::new("link"), Inode::Leaf(leaf));
+        let leaf_id = fs.push_leaf(
+            stat(),
+            LeafContent::Regular(RegularFile::Inline(b"data".to_vec().into())),
+        );
+        // Insert original + hardlink (same LeafId)
+        fs.root.insert(OsStr::new("original"), Inode::leaf(leaf_id));
+        fs.root.insert(OsStr::new("link"), Inode::leaf(leaf_id));
 
         let mut out = Vec::new();
         write_dumpfile(&mut out, &fs)?;
@@ -766,11 +778,11 @@ mod tests {
 
         let fs2 = dumpfile_to_filesystem::<Sha256HashValue>(out_str)?;
 
-        // Verify the hardlink is preserved
+        // Verify the hardlink is preserved (same LeafId)
         let orig = fs2.root.lookup(OsStr::new("original")).unwrap();
         let link = fs2.root.lookup(OsStr::new("link")).unwrap();
         match (orig, link) {
-            (Inode::Leaf(a), Inode::Leaf(b)) => assert!(Rc::ptr_eq(a, b)),
+            (Inode::Leaf(a, _), Inode::Leaf(b, _)) => assert_eq!(a, b),
             _ => panic!("expected both to be leaves"),
         }
 

--- a/crates/composefs/src/erofs/reader.rs
+++ b/crates/composefs/src/erofs/reader.rs
@@ -952,6 +952,9 @@ pub enum ErofsReaderError {
     /// File type in directory entry doesn't match inode
     #[error("File type in dirent doesn't match type in inode")]
     FileTypeMismatch,
+    /// Duplicate directory entry name
+    #[error("Duplicate directory entry {0:?}")]
+    DuplicateEntry(Box<OsStr>),
 }
 
 type ReadResult<T> = Result<T, ErofsReaderError>;
@@ -1406,11 +1409,15 @@ fn populate_directory<ObjectID: FsVerityHashValue>(
                 depth + 1,
             )
             .with_context(|| format!("reading directory {:?}", name))?;
-            dir.insert(name, tree::Inode::Directory(Box::new(child_dir)));
+            if !dir.insert(name, tree::Inode::Directory(Box::new(child_dir))) {
+                return Err(ErofsReaderError::DuplicateEntry(Box::from(name)).into());
+            }
         } else {
             // Check if this is a hardlink (same nid seen before)
             if let Some(&existing_leaf_id) = builder.hardlinks.get(&nid) {
-                dir.insert(name, tree::Inode::leaf(existing_leaf_id));
+                if !dir.insert(name, tree::Inode::leaf(existing_leaf_id)) {
+                    return Err(ErofsReaderError::DuplicateEntry(Box::from(name)).into());
+                }
                 continue;
             }
 
@@ -1478,7 +1485,9 @@ fn populate_directory<ObjectID: FsVerityHashValue>(
                     leaf_id,
                 });
 
-            dir.insert(name, tree::Inode::leaf(leaf_id));
+            if !dir.insert(name, tree::Inode::leaf(leaf_id)) {
+                return Err(ErofsReaderError::DuplicateEntry(Box::from(name)).into());
+            }
         }
     }
 
@@ -2539,5 +2548,38 @@ mod tests {
                 round_trip_filesystem(&fs);
             }
         }
+    }
+
+    /// Regression test for a fuzzer-found crash where duplicate directory entry
+    /// names caused orphaned leaves (the second insert silently replaced the
+    /// first in the BTreeMap, leaving the first leaf unreferenced).
+    #[test]
+    fn test_duplicate_dirent_rejected() {
+        // Build a valid image with two files
+        let dumpfile = r#"/ 0 40755 2 0 0 0 1000.0 - - -
+/aaa 5 100644 1 0 0 0 1000.0 - hello -
+/bbb 5 100644 1 0 0 0 1000.0 - world -
+"#;
+        let fs = dumpfile_to_filesystem::<Sha256HashValue>(dumpfile).unwrap();
+        let image = mkfs_erofs(&fs);
+
+        // Sanity: the unmodified image round-trips fine
+        erofs_to_filesystem::<Sha256HashValue>(&image).unwrap();
+
+        // Corrupt the image: rename "bbb" to "aaa" so there's a duplicate
+        let mut bad = image.clone();
+        let needle = b"bbb";
+        let pos = bad
+            .windows(needle.len())
+            .position(|w| w == needle)
+            .expect("filename not found in image");
+        bad[pos..pos + needle.len()].copy_from_slice(b"aaa");
+
+        let err = erofs_to_filesystem::<Sha256HashValue>(&bad).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Duplicate directory entry"),
+            "unexpected error: {msg}"
+        );
     }
 }

--- a/crates/composefs/src/erofs/reader.rs
+++ b/crates/composefs/src/erofs/reader.rs
@@ -5,12 +5,10 @@
 //! reference collection for garbage collection.
 
 use core::mem::size_of;
-use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::ops::Range;
 use std::os::unix::ffi::OsStrExt;
-use std::rc::Rc;
 
 use anyhow::Context;
 use thiserror::Error;
@@ -27,6 +25,7 @@ use super::{
 };
 use crate::MAX_INLINE_CONTENT;
 use crate::fsverity::FsVerityHashValue;
+use crate::generic_tree::LeafId;
 use crate::tree;
 
 /// Rounds up a value to the nearest multiple of `to`
@@ -1118,7 +1117,7 @@ fn stat_from_inode_for_tree(img: &Image, inode: &InodeType) -> anyhow::Result<tr
         st_uid,
         st_gid,
         st_mtim_sec,
-        xattrs: RefCell::new(xattrs),
+        xattrs,
     })
 }
 
@@ -1313,19 +1312,21 @@ fn dir_entries<'a>(
 const MAX_DIRECTORY_DEPTH: usize = 4096 / 2;
 
 /// Per-leaf nlink tracking for post-traversal validation.
-struct NlinkEntry<ObjectID: FsVerityHashValue> {
+struct NlinkEntry {
     /// The on-disk nlink value from the inode header.
     expected: u32,
-    /// Reference to the leaf so we can check Rc::strong_count() later.
-    leaf: Rc<tree::Leaf<ObjectID>>,
+    /// The leaf ID for looking up actual nlink from the filesystem.
+    leaf_id: LeafId,
 }
 
 /// Mutable state threaded through the recursive directory traversal.
 struct TreeBuilder<ObjectID: FsVerityHashValue> {
-    /// Map from nid to first-seen leaf for hardlink detection.
-    hardlinks: HashMap<u64, Rc<tree::Leaf<ObjectID>>>,
+    /// Map from nid to first-seen LeafId for hardlink detection.
+    hardlinks: HashMap<u64, LeafId>,
     /// Map from nid to nlink tracking entry for post-traversal validation.
-    nlink_tracker: HashMap<u64, NlinkEntry<ObjectID>>,
+    nlink_tracker: HashMap<u64, NlinkEntry>,
+    /// Accumulated leaves for the filesystem being built.
+    leaves: Vec<tree::Leaf<ObjectID>>,
 }
 
 impl<ObjectID: FsVerityHashValue> TreeBuilder<ObjectID> {
@@ -1333,31 +1334,15 @@ impl<ObjectID: FsVerityHashValue> TreeBuilder<ObjectID> {
         Self {
             hardlinks: HashMap::new(),
             nlink_tracker: HashMap::new(),
+            leaves: Vec::new(),
         }
     }
 
-    /// Validate that every leaf's on-disk nlink matches the number of
-    /// references found during traversal.
-    fn validate_nlink(&self) -> anyhow::Result<()> {
-        for (nid, entry) in &self.nlink_tracker {
-            // strong_count includes: one per tree insertion + one held by
-            // nlink_tracker + possibly one in the hardlinks map.
-            let tracker_refs: usize = 1 + usize::from(self.hardlinks.contains_key(nid));
-            let tree_refs = Rc::strong_count(&entry.leaf)
-                .checked_sub(tracker_refs)
-                .expect("strong_count must be >= tracker_refs");
-            let tree_nlink: u32 = tree_refs
-                .try_into()
-                .map_err(|_| anyhow::anyhow!("nlink overflow for inode nid {nid}"))?;
-            if entry.expected != tree_nlink {
-                anyhow::bail!(
-                    "nlink mismatch for inode nid {nid}: on-disk nlink is {}, \
-                     but found {tree_nlink} reference(s) in the directory tree",
-                    entry.expected,
-                );
-            }
-        }
-        Ok(())
+    /// Push a new leaf and return its LeafId.
+    fn push_leaf(&mut self, stat: tree::Stat, content: tree::LeafContent<ObjectID>) -> LeafId {
+        let id = LeafId(self.leaves.len());
+        self.leaves.push(tree::Leaf { stat, content });
+        id
     }
 }
 
@@ -1424,8 +1409,8 @@ fn populate_directory<ObjectID: FsVerityHashValue>(
             dir.insert(name, tree::Inode::Directory(Box::new(child_dir)));
         } else {
             // Check if this is a hardlink (same nid seen before)
-            if let Some(existing_leaf) = builder.hardlinks.get(&nid) {
-                dir.insert(name, tree::Inode::Leaf(Rc::clone(existing_leaf)));
+            if let Some(&existing_leaf_id) = builder.hardlinks.get(&nid) {
+                dir.insert(name, tree::Inode::leaf(existing_leaf_id));
                 continue;
             }
 
@@ -1476,12 +1461,12 @@ fn populate_directory<ObjectID: FsVerityHashValue>(
                 _ => anyhow::bail!("unknown file type {:#o} for {:?}", file_type, name),
             };
 
-            let leaf = Rc::new(tree::Leaf { stat, content });
+            let leaf_id = builder.push_leaf(stat, content);
 
             // Track for hardlink detection if nlink > 1
             let on_disk_nlink = child_inode.nlink();
             if on_disk_nlink > 1 {
-                builder.hardlinks.insert(nid, Rc::clone(&leaf));
+                builder.hardlinks.insert(nid, leaf_id);
             }
 
             // Track for post-traversal nlink validation
@@ -1490,10 +1475,10 @@ fn populate_directory<ObjectID: FsVerityHashValue>(
                 .entry(nid)
                 .or_insert_with(|| NlinkEntry {
                     expected: on_disk_nlink,
-                    leaf: Rc::clone(&leaf),
+                    leaf_id,
                 });
 
-            dir.insert(name, tree::Inode::Leaf(leaf));
+            dir.insert(name, tree::Inode::leaf(leaf_id));
         }
     }
 
@@ -1532,7 +1517,7 @@ pub fn erofs_to_filesystem<ObjectID: FsVerityHashValue>(
     let root_inode = img.inode(root_nid)?;
 
     let root_stat = stat_from_inode_for_tree(&img, &root_inode)?;
-    let mut fs = tree::FileSystem::new(root_stat);
+    let mut root = tree::Directory::new(root_stat);
 
     let mut builder = TreeBuilder::new();
 
@@ -1542,14 +1527,34 @@ pub fn erofs_to_filesystem<ObjectID: FsVerityHashValue>(
         root_nid,
         root_nid,
         &root_inode,
-        &mut fs.root,
+        &mut root,
         &mut builder,
         0,
     )
     .context("reading root directory")?;
 
-    builder.validate_nlink()?;
+    let fs = tree::FileSystem {
+        root,
+        leaves: builder.leaves,
+    };
 
+    let nlink_map = fs.nlinks();
+    builder.nlink_tracker.iter().try_for_each(|(nid, entry)| {
+        let tree_nlink = nlink_map[entry.leaf_id.0];
+        if entry.expected != tree_nlink {
+            anyhow::bail!(
+                "nlink mismatch for inode nid {nid}: on-disk nlink is {}, \
+                 but found {tree_nlink} reference(s) in the directory tree",
+                entry.expected,
+            );
+        }
+        Ok(())
+    })?;
+
+    debug_assert!(
+        fs.fsck().is_ok(),
+        "erofs_to_filesystem produced invalid filesystem"
+    );
     Ok(fs)
 }
 
@@ -2094,14 +2099,13 @@ mod tests {
         let image = mkfs_erofs(&fs_orig);
         let fs_rt = erofs_to_filesystem::<Sha256HashValue>(&image).unwrap();
 
-        // Verify hardlink Rc sharing (scope the extra refs so strong_count
-        // is correct when write_dumpfile checks nlink)
+        // Verify hardlink sharing via LeafId
         {
-            let orig_leaf = fs_rt.root.ref_leaf(OsStr::new("original")).unwrap();
-            let hardlink_leaf = fs_rt.root.ref_leaf(OsStr::new("hardlink")).unwrap();
-            assert!(
-                Rc::ptr_eq(&orig_leaf, &hardlink_leaf),
-                "hardlink entries should share the same Rc"
+            let orig_id = fs_rt.root.leaf_id(OsStr::new("original")).unwrap();
+            let hardlink_id = fs_rt.root.leaf_id(OsStr::new("hardlink")).unwrap();
+            assert_eq!(
+                orig_id, hardlink_id,
+                "hardlink entries should share the same LeafId"
             );
         }
 

--- a/crates/composefs/src/erofs/writer.rs
+++ b/crates/composefs/src/erofs/writer.rs
@@ -5,11 +5,9 @@
 //! and metadata serialization.
 
 use std::{
-    cell::RefCell,
     collections::{BTreeMap, HashMap},
     mem::size_of,
     os::unix::ffi::OsStrExt,
-    rc::Rc,
 };
 
 use log::trace;
@@ -19,6 +17,7 @@ use zerocopy::{Immutable, IntoBytes};
 use crate::{
     erofs::{composefs::OverlayMetacopy, format, reader::round_up},
     fsverity::FsVerityHashValue,
+    generic_tree::LeafId,
     tree,
 };
 
@@ -419,7 +418,9 @@ impl<ObjectID: FsVerityHashValue> Inode<'_, ObjectID> {
 
 struct InodeCollector<'a, ObjectID: FsVerityHashValue> {
     inodes: Vec<Inode<'a, ObjectID>>,
-    hardlinks: HashMap<*const tree::Leaf<ObjectID>, usize>,
+    hardlinks: HashMap<LeafId, usize>,
+    fs: &'a tree::FileSystem<ObjectID>,
+    nlink_map: &'a [u32],
 }
 
 impl<'a, ObjectID: FsVerityHashValue> InodeCollector<'a, ObjectID> {
@@ -442,7 +443,7 @@ impl<'a, ObjectID: FsVerityHashValue> InodeCollector<'a, ObjectID> {
         }
 
         // Add the normal xattrs.  They're already listed in sorted order.
-        for (name, value) in RefCell::borrow(&stat.xattrs).iter() {
+        for (name, value) in stat.xattrs.iter() {
             let name = name.as_bytes();
 
             if let Some(escapee) = name.strip_prefix(b"trusted.overlay.") {
@@ -464,15 +465,16 @@ impl<'a, ObjectID: FsVerityHashValue> InodeCollector<'a, ObjectID> {
         inode
     }
 
-    fn collect_leaf(&mut self, leaf: &'a Rc<tree::Leaf<ObjectID>>) -> usize {
-        let nlink = Rc::strong_count(leaf);
+    fn collect_leaf(&mut self, leaf_id: LeafId) -> usize {
+        let nlink = self.nlink_map[leaf_id.0] as usize;
 
         if nlink > 1
-            && let Some(inode) = self.hardlinks.get(&Rc::as_ptr(leaf))
+            && let Some(inode) = self.hardlinks.get(&leaf_id)
         {
             return *inode;
         }
 
+        let leaf = self.fs.leaf(leaf_id);
         let inode = self.push_inode(
             &leaf.stat,
             InodeContent::Leaf(Leaf {
@@ -482,7 +484,7 @@ impl<'a, ObjectID: FsVerityHashValue> InodeCollector<'a, ObjectID> {
         );
 
         if nlink > 1 {
-            self.hardlinks.insert(Rc::as_ptr(leaf), inode);
+            self.hardlinks.insert(leaf_id, inode);
         }
 
         inode
@@ -513,7 +515,7 @@ impl<'a, ObjectID: FsVerityHashValue> InodeCollector<'a, ObjectID> {
         for (name, inode) in dir.sorted_entries() {
             let child = match inode {
                 tree::Inode::Directory(dir) => self.collect_dir(dir, me),
-                tree::Inode::Leaf(leaf) => self.collect_leaf(leaf),
+                tree::Inode::Leaf(leaf_id, _) => self.collect_leaf(*leaf_id),
             };
             entries.push(DirEnt {
                 name: name.as_bytes(),
@@ -531,10 +533,15 @@ impl<'a, ObjectID: FsVerityHashValue> InodeCollector<'a, ObjectID> {
         me
     }
 
-    pub fn collect(fs: &'a tree::FileSystem<ObjectID>) -> Vec<Inode<'a, ObjectID>> {
+    pub fn collect(
+        fs: &'a tree::FileSystem<ObjectID>,
+        nlink_map: &'a [u32],
+    ) -> Vec<Inode<'a, ObjectID>> {
         let mut this = Self {
             inodes: vec![],
             hardlinks: HashMap::new(),
+            fs,
+            nlink_map,
         };
 
         // '..' of the root directory is the root directory again
@@ -719,7 +726,8 @@ impl Output for FirstPass {
 /// Returns the complete EROFS image as a byte array.
 pub fn mkfs_erofs<ObjectID: FsVerityHashValue>(fs: &tree::FileSystem<ObjectID>) -> Box<[u8]> {
     // Create the intermediate representation: flattened inodes and shared xattrs
-    let mut inodes = InodeCollector::collect(fs);
+    let nlink_map = fs.nlinks();
+    let mut inodes = InodeCollector::collect(fs, &nlink_map);
     let xattrs = share_xattrs(&mut inodes);
 
     // Do a first pass with the writer to determine the layout

--- a/crates/composefs/src/fs.rs
+++ b/crates/composefs/src/fs.rs
@@ -5,7 +5,6 @@
 //! handling of hardlinks, extended attributes, and repository integration.
 
 use std::{
-    cell::RefCell,
     collections::{BTreeMap, HashMap},
     ffi::{CStr, OsStr},
     fs::File,
@@ -13,7 +12,6 @@ use std::{
     mem::MaybeUninit,
     os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::Arc,
     thread::available_parallelism,
 };
@@ -31,6 +29,7 @@ use rustix::{
 };
 use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
+use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use zerocopy::IntoBytes;
 
 use crate::{
@@ -90,6 +89,7 @@ fn write_directory<ObjectID: FsVerityHashValue>(
     dir: &Directory<ObjectID>,
     dirfd: &OwnedFd,
     name: &OsStr,
+    fs: &FileSystem<ObjectID>,
     repo: &Repository<ObjectID>,
 ) -> Result<()> {
     match mkdirat(dirfd, name, dir.stat.st_mode.into()) {
@@ -98,7 +98,7 @@ fn write_directory<ObjectID: FsVerityHashValue>(
     }
 
     let fd = openat(dirfd, name, OFlags::PATH | OFlags::DIRECTORY, 0.into())?;
-    write_directory_contents(dir, &fd, repo)
+    write_directory_contents(dir, &fd, fs, repo)
 }
 
 #[context("Writing leaf {}", name.to_string_lossy())]
@@ -139,12 +139,13 @@ fn write_leaf<ObjectID: FsVerityHashValue>(
 fn write_directory_contents<ObjectID: FsVerityHashValue>(
     dir: &Directory<ObjectID>,
     fd: &OwnedFd,
+    fs: &FileSystem<ObjectID>,
     repo: &Repository<ObjectID>,
 ) -> Result<()> {
     for (name, inode) in dir.entries() {
         match inode {
-            Inode::Directory(dir) => write_directory(dir, fd, name, repo),
-            Inode::Leaf(leaf) => write_leaf(leaf, fd, name, repo),
+            Inode::Directory(dir) => write_directory(dir, fd, name, fs, repo),
+            Inode::Leaf(id, _) => write_leaf(fs.leaf(*id), fd, name, repo),
         }?;
     }
 
@@ -159,11 +160,11 @@ fn write_directory_contents<ObjectID: FsVerityHashValue>(
 #[context("Writing to path {}", output_dir.display())]
 pub fn write_to_path<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
-    dir: &Directory<ObjectID>,
+    fs: &FileSystem<ObjectID>,
     output_dir: &Path,
 ) -> Result<()> {
     let fd = openat(CWD, output_dir, OFlags::PATH | OFlags::DIRECTORY, 0.into())?;
-    write_directory_contents(dir, &fd, repo)
+    write_directory_contents(&fs.root, &fd, fs, repo)
 }
 
 // ---------------------------------------------------------------------------
@@ -200,7 +201,7 @@ fn read_xattrs(fd: &OwnedFd) -> Result<BTreeMap<Box<OsStr>, Box<[u8]>>> {
 
 /// Read file metadata and verify the file type matches expectations.
 #[context("Getting file stats")]
-fn stat_fd(fd: &OwnedFd, ifmt: FileType) -> Result<(rustix::fs::Stat, Stat)> {
+fn stat_fd(fd: &OwnedFd, ifmt: FileType) -> Result<(rustix::fs::Stat, generic_tree::Stat)> {
     let buf = fstat(fd)?;
 
     ensure!(
@@ -210,12 +211,12 @@ fn stat_fd(fd: &OwnedFd, ifmt: FileType) -> Result<(rustix::fs::Stat, Stat)> {
 
     Ok((
         buf,
-        Stat {
+        generic_tree::Stat {
             st_mode: buf.st_mode & 0o7777,
             st_uid: buf.st_uid,
             st_gid: buf.st_gid,
             st_mtim_sec: buf.st_mtime as i64,
-            xattrs: RefCell::new(read_xattrs(fd)?),
+            xattrs: read_xattrs(fd)?,
         },
     ))
 }
@@ -246,64 +247,44 @@ enum PendingFile {
     External { inode_key: FileDevIno, size: u64 },
 }
 
-/// Trait for handling large (external) files encountered during scanning.
+/// Sends large-file descriptors for concurrent async processing.
 ///
-/// The scanner calls [`handle`](Self::handle) for each large file,
-/// allowing the caller to control how files are processed — e.g.
-/// spawning async worker tasks for pipelined verity computation.
-trait ExternalFileHandler {
-    fn handle(&mut self, key: FileDevIno, fd: OwnedFd, size: u64);
+/// During the synchronous scan phase, large files are sent over a
+/// channel as they're discovered, allowing verity computation to
+/// begin while the scan is still running.
+struct ChannelHandler {
+    tx: tokio::sync::mpsc::Sender<(FileDevIno, OwnedFd, u64)>,
 }
 
-/// Spawns a tokio task for each large file as soon as the scanner
-/// encounters it, enabling overlap between scanning and I/O.
+/// Walks a directory tree synchronously, collecting metadata and recording
+/// large files in a [`CollectHandler`] for deferred async processing.
 ///
-/// Tasks are spawned into an externally-owned [`JoinSet`] so the
-/// caller can drain completed results while the scan continues.
-///
-/// Used by [`read_filesystem`] to pipeline verity computation
-/// with the directory walk.
-struct SpawnHandler<'a, ObjectID: FsVerityHashValue> {
-    semaphore: Arc<Semaphore>,
-    repo: Option<Arc<Repository<ObjectID>>>,
-    tasks: &'a mut JoinSet<Result<(FileDevIno, ObjectID)>>,
+/// This is the single scan implementation used by the async filesystem
+/// reading path. Small files are read inline during the scan; large files
+/// are pushed into the handler's pending list.
+struct FilesystemScanner {
+    inodes: HashMap<FileDevIno, generic_tree::LeafId>,
+    leaves: Vec<generic_tree::Leaf<PendingFile>>,
+    handler: ChannelHandler,
 }
 
-impl<ObjectID: FsVerityHashValue> ExternalFileHandler for SpawnHandler<'_, ObjectID> {
-    fn handle(&mut self, key: FileDevIno, fd: OwnedFd, size: u64) {
-        let repo = self.repo.clone();
-        let sem = self.semaphore.clone();
-        self.tasks.spawn(async move {
-            let _permit = sem.acquire().await.map_err(|e| anyhow::anyhow!("{e}"))?;
-            let id = if let Some(repo) = repo {
-                tokio::task::spawn_blocking(move || repo.ensure_object_from_fd(fd, size)).await??
-            } else {
-                tokio::task::spawn_blocking(move || compute_verity_from_fd::<ObjectID>(fd))
-                    .await??
-            };
-            Ok((key, id))
-        });
-    }
-}
-
-/// Walks a directory tree synchronously, collecting metadata and dispatching
-/// large files via an [`ExternalFileHandler`].
-///
-/// This is the single scan implementation used by both the sync and async
-/// filesystem reading paths. Small files are read inline during the scan;
-/// large files are dispatched to the handler, which may collect them for
-/// later processing or spawn tasks immediately.
-struct FilesystemScanner<H: ExternalFileHandler> {
-    inodes: HashMap<FileDevIno, Rc<generic_tree::Leaf<PendingFile>>>,
-    handler: H,
-}
-
-impl<H: ExternalFileHandler> FilesystemScanner<H> {
-    fn new(handler: H) -> Self {
+impl FilesystemScanner {
+    fn new(handler: ChannelHandler) -> Self {
         Self {
             inodes: HashMap::new(),
+            leaves: Vec::new(),
             handler,
         }
+    }
+
+    fn push_leaf(
+        &mut self,
+        stat: generic_tree::Stat,
+        content: generic_tree::LeafContent<PendingFile>,
+    ) -> generic_tree::LeafId {
+        let id = generic_tree::LeafId(self.leaves.len());
+        self.leaves.push(generic_tree::Leaf { stat, content });
+        id
     }
 
     /// Scan the directory tree rooted at `name` (relative to `dirfd`).
@@ -313,7 +294,10 @@ impl<H: ExternalFileHandler> FilesystemScanner<H> {
         name: &OsStr,
     ) -> Result<generic_tree::FileSystem<PendingFile>> {
         let root = self.scan_directory(dirfd, name)?;
-        Ok(generic_tree::FileSystem { root })
+        Ok(generic_tree::FileSystem {
+            root,
+            leaves: std::mem::take(&mut self.leaves),
+        })
     }
 
     #[context("Scanning directory {}", name.to_string_lossy())]
@@ -330,7 +314,7 @@ impl<H: ExternalFileHandler> FilesystemScanner<H> {
         )?;
 
         let (_, stat) = stat_fd(&fd, FileType::Directory)?;
-        let mut directory = generic_tree::Directory::new(stat);
+        let mut entries = BTreeMap::new();
 
         for item in Dir::read_from(&fd)? {
             let entry = item?;
@@ -341,10 +325,10 @@ impl<H: ExternalFileHandler> FilesystemScanner<H> {
             }
 
             let inode = self.scan_inode(&fd, child_name, entry.file_type())?;
-            directory.insert(child_name, inode);
+            entries.insert(Box::from(child_name), inode);
         }
 
-        Ok(directory)
+        Ok(generic_tree::Directory { stat, entries })
     }
 
     #[context("Scanning inode {}", name.to_string_lossy())]
@@ -358,8 +342,8 @@ impl<H: ExternalFileHandler> FilesystemScanner<H> {
             let dir = self.scan_directory(dirfd, name)?;
             Ok(generic_tree::Inode::Directory(Box::new(dir)))
         } else {
-            let leaf = self.scan_leaf(dirfd, name, ifmt)?;
-            Ok(generic_tree::Inode::Leaf(leaf))
+            let id = self.scan_leaf(dirfd, name, ifmt)?;
+            Ok(generic_tree::Inode::leaf(id))
         }
     }
 
@@ -369,7 +353,7 @@ impl<H: ExternalFileHandler> FilesystemScanner<H> {
         dirfd: &OwnedFd,
         name: &OsStr,
         ifmt: FileType,
-    ) -> Result<Rc<generic_tree::Leaf<PendingFile>>> {
+    ) -> Result<generic_tree::LeafId> {
         let oflags = match ifmt {
             FileType::RegularFile => OFlags::RDONLY,
             _ => OFlags::PATH,
@@ -391,13 +375,13 @@ impl<H: ExternalFileHandler> FilesystemScanner<H> {
             dev: buf.st_dev,
             ino: buf.st_ino,
         };
-        if let Some(leafref) = self.inodes.get(&key) {
-            Ok(Rc::clone(leafref))
+        if let Some(&id) = self.inodes.get(&key) {
+            Ok(id)
         } else {
             let content = self.scan_leaf_content(fd, &buf)?;
-            let leaf = Rc::new(generic_tree::Leaf { stat, content });
-            self.inodes.insert(key, Rc::clone(&leaf));
-            Ok(leaf)
+            let id = self.push_leaf(stat, content);
+            self.inodes.insert(key, id);
+            Ok(id)
         }
     }
 
@@ -411,12 +395,14 @@ impl<H: ExternalFileHandler> FilesystemScanner<H> {
             FileType::Directory | FileType::Unknown => unreachable!(),
             FileType::RegularFile => {
                 if buf.st_size > INLINE_CONTENT_MAX_V0 as i64 {
-                    // Large file: dispatch to handler for processing
+                    // Large file: record for deferred async processing
                     let key = FileDevIno {
                         dev: buf.st_dev,
                         ino: buf.st_ino,
                     };
-                    self.handler.handle(key, fd, buf.st_size as u64);
+                    // Ignore send errors — the receiver may have been
+                    // dropped if the async side hit an error and cancelled.
+                    let _ = self.handler.tx.blocking_send((key, fd, buf.st_size as u64));
                     generic_tree::LeafContent::Regular(PendingFile::External {
                         inode_key: key,
                         size: buf.st_size as u64,
@@ -539,11 +525,14 @@ pub fn read_file<ObjectID: FsVerityHashValue>(
 /// Load a filesystem tree from the given path, parallelizing verity
 /// computation and object storage across available cores.
 ///
+/// The directory scan and verity computation run concurrently: as the
+/// scan discovers large files, they are immediately dispatched for
+/// verity hashing on the async runtime while the scan continues.
+///
 /// Hardlinks are deduplicated — each unique inode is processed only once.
 ///
 /// If `repo` is `Some`, file objects are stored in the repository.
 /// If `None`, fsverity digests are computed without writing to disk.
-#[context("Async reading filesystem from {}", path.display())]
 pub async fn read_filesystem<ObjectID: FsVerityHashValue>(
     dirfd: OwnedFd,
     path: PathBuf,
@@ -557,32 +546,94 @@ pub async fn read_filesystem<ObjectID: FsVerityHashValue>(
             Arc::new(Semaphore::new(n))
         });
 
-    // The JoinSet lives here so completed tasks are drained after the
-    // scan returns, while structured concurrency ensures all tasks are
-    // cancelled on early exit.
-    let mut tasks = JoinSet::new();
+    // Channel for streaming work items from the scan thread to the
+    // async runtime. The scan sends (key, fd, size) as files are
+    // discovered; the async side spawns verity tasks immediately.
+    // The channel bound limits how far the scan can race ahead of
+    // verity processing, providing natural backpressure.
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<(FileDevIno, OwnedFd, u64)>(semaphore.available_permits());
 
-    // Phase 1: Scan with pipelined dispatch — worker tasks start while we
-    // are still walking the directory tree.
-    let pending_fs = tokio::task::block_in_place(|| {
-        let handler = SpawnHandler {
-            semaphore,
-            repo,
-            tasks: &mut tasks,
-        };
-        let mut scanner = FilesystemScanner::new(handler);
-        scanner.scan(&dirfd, path.as_os_str())
-    })?;
-
-    // Phase 2: Collect results as workers complete
-    let mut results = HashMap::new();
-    while let Some(result) = tasks.join_next().await {
-        let (key, id) = result??;
-        results.insert(key, id);
+    /// Result from a task in the join set — either the scan completed
+    /// or a verity computation finished.
+    enum TaskResult<ObjectID> {
+        Scan(generic_tree::FileSystem<PendingFile>),
+        Verity(FileDevIno, ObjectID),
     }
 
-    // Phase 3: Convert PendingFile -> RegularFile<ObjectID>
-    pending_fs.try_map_regular(|pf| resolve_pending_file(pf, &results))
+    // All work goes into a single JoinSet for structured concurrency.
+    let mut tasks: JoinSet<Result<TaskResult<ObjectID>>> = JoinSet::new();
+
+    // Scan the directory tree on a blocking thread, streaming work
+    // items over the channel as files are discovered.
+    tasks.spawn_blocking(move || {
+        let handler = ChannelHandler { tx };
+        let mut scanner = FilesystemScanner::new(handler);
+        let fs = scanner
+            .scan(&dirfd, path.as_os_str())
+            .with_context(|| format!("Async reading filesystem from {}", path.display()))?;
+        // Drop the sender so the receiver sees the channel close.
+        drop(scanner.handler);
+        Ok(TaskResult::Scan(fs))
+    });
+
+    // Map the channel into a stream that acquires a semaphore permit
+    // for each item, gating concurrency before we spawn blocking work.
+    let items = ReceiverStream::new(rx).then(|item| {
+        let sem = semaphore.clone();
+        async move {
+            let permit = sem.acquire_owned().await.unwrap();
+            (item, permit)
+        }
+    });
+    tokio::pin!(items);
+
+    // Spawn verity tasks as work items arrive from the scan,
+    // and collect results from completed tasks — all concurrently.
+    let mut results = HashMap::new();
+    let mut pending_fs = None;
+    let mut items_open = true;
+    loop {
+        tokio::select! {
+            item = items.next(), if items_open => {
+                match item {
+                    Some(((key, fd, size), permit)) => {
+                        let repo = repo.clone();
+                        tasks.spawn_blocking(move || {
+                            let _permit = permit;
+                            let id = if let Some(repo) = repo {
+                                repo.ensure_object_from_fd(fd, size)?
+                            } else {
+                                compute_verity_from_fd::<ObjectID>(fd)?
+                            };
+                            Ok(TaskResult::Verity(key, id))
+                        });
+                    }
+                    None => items_open = false,
+                }
+            }
+            result = tasks.join_next(), if !tasks.is_empty() => {
+                match result.expect("JoinSet not empty")?? {
+                    TaskResult::Scan(fs) => {
+                        assert!(pending_fs.is_none(), "scan task completed twice");
+                        pending_fs = Some(fs);
+                    }
+                    TaskResult::Verity(key, id) => { results.insert(key, id); }
+                }
+            }
+            else => break,
+        }
+    }
+
+    // Resolve PendingFile -> RegularFile using the computed verity digests.
+    let fs = pending_fs
+        .expect("scan task completed")
+        .try_map_regular(|pf| resolve_pending_file(pf, &results))?;
+    debug_assert!(
+        fs.fsck().is_ok(),
+        "read_filesystem produced invalid filesystem"
+    );
+    Ok(fs)
 }
 
 /// Like [`read_filesystem`] but filters extended attributes using
@@ -597,7 +648,7 @@ where
     ObjectID: FsVerityHashValue,
     F: Fn(&OsStr) -> bool,
 {
-    let fs = read_filesystem(dirfd, path, repo)
+    let mut fs = read_filesystem(dirfd, path, repo)
         .await
         .context("Reading filtered filesystem")?;
     fs.filter_xattrs(xattr_filter);

--- a/crates/composefs/src/generic_tree.rs
+++ b/crates/composefs/src/generic_tree.rs
@@ -2,11 +2,10 @@
 //! however the caller wants.
 
 use std::{
-    cell::RefCell,
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     ffi::OsStr,
+    marker::PhantomData,
     path::{Component, Path},
-    rc::Rc,
 };
 
 use thiserror::Error;
@@ -23,7 +22,13 @@ pub struct Stat {
     /// Modification time in seconds since Unix epoch.
     pub st_mtim_sec: i64,
     /// Extended attributes as key-value pairs.
-    pub xattrs: RefCell<BTreeMap<Box<OsStr>, Box<[u8]>>>,
+    pub xattrs: BTreeMap<Box<OsStr>, Box<[u8]>>,
+}
+
+impl Default for Stat {
+    fn default() -> Self {
+        Self::uninitialized()
+    }
 }
 
 impl Stat {
@@ -41,10 +46,14 @@ impl Stat {
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: RefCell::new(BTreeMap::new()),
+            xattrs: BTreeMap::new(),
         }
     }
 }
+
+/// Index into [`FileSystem`]'s leaves table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LeafId(pub usize);
 
 /// Content types for leaf nodes (non-directory files).
 #[derive(Debug)]
@@ -66,7 +75,10 @@ pub enum LeafContent<T> {
 impl<T> LeafContent<T> {
     /// Maps `Regular(&T)` to `Regular(U)` via a fallible function,
     /// passing all other variants through unchanged.
-    fn try_map_ref<U, E>(&self, f: impl FnOnce(&T) -> Result<U, E>) -> Result<LeafContent<U>, E> {
+    pub fn try_map_ref<U, E>(
+        &self,
+        f: impl FnOnce(&T) -> Result<U, E>,
+    ) -> Result<LeafContent<U>, E> {
         match self {
             LeafContent::Regular(t) => Ok(LeafContent::Regular(f(t)?)),
             LeafContent::BlockDevice(rdev) => Ok(LeafContent::BlockDevice(*rdev)),
@@ -101,8 +113,19 @@ pub struct Directory<T> {
 pub enum Inode<T> {
     /// A directory inode.
     Directory(Box<Directory<T>>),
-    /// A leaf inode (reference-counted to support hardlinks).
-    Leaf(Rc<Leaf<T>>),
+    /// A leaf inode, referencing an entry in the leaves table by index.
+    ///
+    /// The `PhantomData` ties the type parameter `T` to the enum without
+    /// requiring it to appear directly (since `LeafId` is type-erased).
+    /// Use [`Inode::leaf`] to construct this variant.
+    Leaf(LeafId, PhantomData<T>),
+}
+
+impl<T> Inode<T> {
+    /// Create a leaf inode referencing the given leaf table index.
+    pub fn leaf(id: LeafId) -> Self {
+        Inode::Leaf(id, PhantomData)
+    }
 }
 
 /// Errors that can occur when working with filesystem images.
@@ -123,60 +146,38 @@ pub enum ImageError {
     /// The entry exists but is not a regular file when a regular file was expected.
     #[error("Directory entry {0:?} is not a regular file")]
     IsNotRegular(Box<OsStr>),
+    /// A LeafId in the directory tree is out of bounds.
+    #[error("LeafId {0} is out of bounds (leaves table has {1} entries)")]
+    LeafIdOutOfBounds(usize, usize),
+    /// Leaves in the table are not referenced by any directory entry.
+    #[error("Orphaned leaves at indices {0:?}")]
+    OrphanedLeaves(Vec<usize>),
 }
 
 impl<T> Inode<T> {
     /// Returns a reference to the metadata for this inode.
-    pub fn stat(&self) -> &Stat {
+    ///
+    /// For leaf inodes, the `leaves` table is needed to resolve the `LeafId`.
+    pub fn stat<'a>(&'a self, leaves: &'a [Leaf<T>]) -> &'a Stat {
         match self {
             Inode::Directory(dir) => &dir.stat,
-            Inode::Leaf(leaf) => &leaf.stat,
+            Inode::Leaf(id, _) => &leaves[id.0].stat,
         }
     }
 
-    fn try_map_regular_impl<U, E>(
-        self,
-        f: &mut impl FnMut(&T) -> Result<U, E>,
-        rc_map: &mut HashMap<*const Leaf<T>, Rc<Leaf<U>>>,
-    ) -> Result<Inode<U>, E> {
+    /// Recursively changes the type parameter of an inode tree.
+    ///
+    /// [`LeafId`] indices pass through unchanged — only the phantom type
+    /// parameter on [`Inode::Leaf`] is updated.
+    fn retype<U>(self) -> Inode<U> {
         match self {
-            Inode::Directory(dir) => {
-                let new_dir = dir.try_map_regular_impl(f, rc_map)?;
-                Ok(Inode::Directory(Box::new(new_dir)))
-            }
-            Inode::Leaf(leaf_rc) => {
-                let ptr = Rc::as_ptr(&leaf_rc);
-                if let Some(existing) = rc_map.get(&ptr) {
-                    return Ok(Inode::Leaf(Rc::clone(existing)));
-                }
-                let new_content = leaf_rc.content.try_map_ref(f)?;
-                let new_leaf = Rc::new(Leaf {
-                    stat: leaf_rc.stat.clone(),
-                    content: new_content,
-                });
-                rc_map.insert(ptr, Rc::clone(&new_leaf));
-                Ok(Inode::Leaf(new_leaf))
-            }
+            Inode::Directory(dir) => Inode::Directory(Box::new(dir.retype::<U>())),
+            Inode::Leaf(id, _) => Inode::leaf(id),
         }
     }
 }
 
 impl<T> Directory<T> {
-    fn try_map_regular_impl<U, E>(
-        self,
-        f: &mut impl FnMut(&T) -> Result<U, E>,
-        rc_map: &mut HashMap<*const Leaf<T>, Rc<Leaf<U>>>,
-    ) -> Result<Directory<U>, E> {
-        let mut new_entries = BTreeMap::new();
-        for (name, inode) in self.entries {
-            new_entries.insert(name, inode.try_map_regular_impl(f, rc_map)?);
-        }
-        Ok(Directory {
-            stat: self.stat,
-            entries: new_entries,
-        })
-    }
-
     /// Creates a new directory with the given metadata.
     pub fn new(stat: Stat) -> Self {
         Self {
@@ -347,9 +348,10 @@ impl<T> Directory<T> {
         Ok((dir, filename))
     }
 
-    /// Takes a reference to the "leaf" file (not directory) with the given filename directly
-    /// contained in this directory.  This is usually done in preparation for creating a hardlink
-    /// or in order to avoid issues with the borrow checker when mutating the tree.
+    /// Returns the `LeafId` for the named non-directory entry.
+    ///
+    /// This is typically used to create hardlinks: directory entries sharing
+    /// the same `LeafId` are hardlinks to the same underlying leaf.
     ///
     /// # Arguments
     ///
@@ -358,13 +360,12 @@ impl<T> Directory<T> {
     ///
     /// # Return value
     ///
-    /// On success (the entry exists and is not a directory) the Rc is cloned and a new reference
-    /// is returned.
+    /// On success (the entry exists and is not a directory) the LeafId is returned.
     ///
     /// On failure, can return any number of errors from ImageError.
-    pub fn ref_leaf(&self, filename: &OsStr) -> Result<Rc<Leaf<T>>, ImageError> {
+    pub fn leaf_id(&self, filename: &OsStr) -> Result<LeafId, ImageError> {
         match self.entries.get(filename) {
-            Some(Inode::Leaf(leaf)) => Ok(Rc::clone(leaf)),
+            Some(Inode::Leaf(id, _)) => Ok(*id),
             Some(Inode::Directory(..)) => Err(ImageError::IsADirectory(Box::from(filename))),
             None => Err(ImageError::NotFound(Box::from(filename))),
         }
@@ -377,23 +378,31 @@ impl<T> Directory<T> {
     ///
     ///  * `filename`: the filename in the current directory.  If you need to support full
     ///    pathnames then you should call `Directory::split()` first.
+    ///  * `leaves`: the leaves table from the containing [`FileSystem`].
     ///
     /// # Return value
     ///
-    /// On success (the entry exists and is a regular file) then the return value is either:
-    ///  * the inline data
-    ///  * an external reference, with size information
+    /// On success (the entry exists and is a regular file) then a reference to the file
+    /// content `T` is returned.
     ///
     /// On failure, can return any number of errors from ImageError.
-    pub fn get_file<'a>(&'a self, filename: &OsStr) -> Result<&'a T, ImageError> {
-        self.get_file_opt(filename)?
+    pub fn get_file<'a>(
+        &'a self,
+        filename: &OsStr,
+        leaves: &'a [Leaf<T>],
+    ) -> Result<&'a T, ImageError> {
+        self.get_file_opt(filename, leaves)?
             .ok_or_else(|| ImageError::NotFound(Box::from(filename)))
     }
 
     /// Like [`Self::get_file()`] but maps [`ImageError::NotFound`] to [`Option`].
-    pub fn get_file_opt<'a>(&'a self, filename: &OsStr) -> Result<Option<&'a T>, ImageError> {
+    pub fn get_file_opt<'a>(
+        &'a self,
+        filename: &OsStr,
+        leaves: &'a [Leaf<T>],
+    ) -> Result<Option<&'a T>, ImageError> {
         match self.entries.get(filename) {
-            Some(Inode::Leaf(leaf)) => match &leaf.content {
+            Some(Inode::Leaf(id, _)) => match &leaves[id.0].content {
                 LeafContent::Regular(file) => Ok(Some(file)),
                 _ => Err(ImageError::IsNotRegular(filename.into())),
             },
@@ -489,12 +498,14 @@ impl<T> Directory<T> {
     ///
     /// Returns the maximum modification time among this directory's metadata
     /// and all files and subdirectories it contains.
-    pub fn newest_file(&self) -> i64 {
+    ///
+    /// The `leaves` table is needed to resolve leaf mtimes.
+    pub fn newest_file(&self, leaves: &[Leaf<T>]) -> i64 {
         let mut newest = self.stat.st_mtim_sec;
         for inode in self.entries.values() {
             let mtime = match inode {
-                Inode::Leaf(leaf) => leaf.stat.st_mtim_sec,
-                Inode::Directory(dir) => dir.newest_file(),
+                Inode::Leaf(id, _) => leaves[id.0].stat.st_mtim_sec,
+                Inode::Directory(dir) => dir.newest_file(leaves),
             };
             if mtime > newest {
                 newest = mtime;
@@ -502,13 +513,71 @@ impl<T> Directory<T> {
         }
         newest
     }
+
+    /// Recursively changes the type parameter of the directory tree.
+    ///
+    /// [`LeafId`] indices pass through unchanged — only the phantom type
+    /// parameter on [`Inode::Leaf`] is updated.
+    fn retype<U>(self) -> Directory<U> {
+        let entries = self
+            .entries
+            .into_iter()
+            .map(|(name, inode)| (name, inode.retype::<U>()))
+            .collect();
+        Directory {
+            stat: self.stat,
+            entries,
+        }
+    }
+
+    /// Counts how many times each LeafId is referenced in this directory tree.
+    fn count_leaf_refs(&self, refcount: &mut [u32]) {
+        for inode in self.entries.values() {
+            match inode {
+                Inode::Directory(dir) => dir.count_leaf_refs(refcount),
+                Inode::Leaf(id, _) => refcount[id.0] += 1,
+            }
+        }
+    }
+
+    /// Validates that all LeafIds are in bounds and counts references.
+    fn fsck_refs(&self, num_leaves: usize, refcount: &mut [u32]) -> Result<(), ImageError> {
+        for inode in self.entries.values() {
+            match inode {
+                Inode::Directory(dir) => dir.fsck_refs(num_leaves, refcount)?,
+                Inode::Leaf(id, _) => {
+                    if id.0 >= num_leaves {
+                        return Err(ImageError::LeafIdOutOfBounds(id.0, num_leaves));
+                    }
+                    refcount[id.0] += 1;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Remaps all LeafIds in this directory tree using the given mapping.
+    fn remap_leaf_ids(&mut self, id_map: &[LeafId]) {
+        for inode in self.entries.values_mut() {
+            match inode {
+                Inode::Directory(dir) => dir.remap_leaf_ids(id_map),
+                Inode::Leaf(id, _) => *id = id_map[id.0],
+            }
+        }
+    }
 }
 
-/// A complete filesystem tree with a root directory.
+/// A complete filesystem tree with a root directory and a flat table of leaves.
+///
+/// Leaf nodes (non-directory files) are stored in a flat `Vec` and referenced
+/// by [`LeafId`] indices from the directory tree. This design is `Send + Sync`,
+/// supports hardlinks via shared `LeafId`, and avoids reference counting.
 #[derive(Debug)]
 pub struct FileSystem<T> {
     /// The root directory of the filesystem.
     pub root: Directory<T>,
+    /// Table of all leaf nodes; [`LeafId`] indexes into this vector.
+    pub leaves: Vec<Leaf<T>>,
 }
 
 impl<T> FileSystem<T> {
@@ -516,12 +585,20 @@ impl<T> FileSystem<T> {
     pub fn new(root_stat: Stat) -> Self {
         Self {
             root: Directory::new(root_stat),
+            leaves: Vec::new(),
         }
     }
 
     /// Sets the metadata for the root directory.
     pub fn set_root_stat(&mut self, stat: Stat) {
         self.root.stat = stat;
+    }
+
+    /// Pushes a new leaf into the leaves table and returns its [`LeafId`].
+    pub fn push_leaf(&mut self, stat: Stat, content: LeafContent<T>) -> LeafId {
+        let id = LeafId(self.leaves.len());
+        self.leaves.push(Leaf { stat, content });
+        id
     }
 
     /// Copies metadata from `/usr` to the root directory.
@@ -566,27 +643,50 @@ impl<T> FileSystem<T> {
 
     /// Applies a function to every [`Stat`] in the filesystem tree.
     ///
-    /// This visits the root directory and all descendants (directories and leaves),
-    /// calling the provided function with each node's `Stat`.
+    /// This visits the root directory and all descendant directories via the tree,
+    /// and each leaf stat exactly once via the flat leaves table.
     pub fn for_each_stat<F>(&self, f: F)
     where
         F: Fn(&Stat),
     {
-        fn visit_inode<T, F: Fn(&Stat)>(inode: &Inode<T>, f: &F) {
-            match inode {
-                Inode::Directory(dir) => visit_dir(dir, f),
-                Inode::Leaf(leaf) => f(&leaf.stat),
-            }
-        }
-
         fn visit_dir<T, F: Fn(&Stat)>(dir: &Directory<T>, f: &F) {
             f(&dir.stat);
-            for (_name, inode) in dir.entries.iter() {
-                visit_inode(inode, f);
+            for inode in dir.entries.values() {
+                if let Inode::Directory(subdir) = inode {
+                    visit_dir(subdir, f);
+                }
             }
         }
 
         visit_dir(&self.root, &f);
+        for leaf in &self.leaves {
+            f(&leaf.stat);
+        }
+    }
+
+    /// Applies a function to every [`Stat`] in the filesystem tree, mutably.
+    ///
+    /// This visits each directory stat via the tree, and each leaf stat exactly
+    /// once via the flat leaves table. No dedup needed since each leaf appears
+    /// exactly once in the table regardless of how many directory entries
+    /// reference it.
+    pub fn for_each_stat_mut<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&mut Stat),
+    {
+        fn visit_dir_mut<T, F: FnMut(&mut Stat)>(dir: &mut Directory<T>, f: &mut F) {
+            f(&mut dir.stat);
+            for inode in dir.entries.values_mut() {
+                if let Inode::Directory(subdir) = inode {
+                    visit_dir_mut(subdir, f);
+                }
+            }
+        }
+
+        visit_dir_mut(&mut self.root, &mut f);
+        for leaf in &mut self.leaves {
+            f(&mut leaf.stat);
+        }
     }
 
     /// Filters extended attributes across the entire filesystem tree.
@@ -595,12 +695,12 @@ impl<T> FileSystem<T> {
     /// This is useful for stripping build-time xattrs that shouldn't
     /// leak into the final image (e.g., `security.selinux` labels from
     /// the build host).
-    pub fn filter_xattrs<F>(&self, predicate: F)
+    pub fn filter_xattrs<F>(&mut self, predicate: F)
     where
         F: Fn(&OsStr) -> bool,
     {
-        self.for_each_stat(|stat| {
-            stat.xattrs.borrow_mut().retain(|k, _| predicate(k));
+        self.for_each_stat_mut(|stat| {
+            stat.xattrs.retain(|k, _| predicate(k));
         });
     }
 
@@ -655,26 +755,238 @@ impl<T> FileSystem<T> {
     /// Applies `f` to each `LeafContent::Regular(T)` to produce `LeafContent::Regular(U)`.
     /// All other leaf content variants (symlinks, devices, etc.) are passed through unchanged.
     ///
-    /// Hardlink sharing is preserved: if multiple directory entries point to the same
-    /// `Rc<Leaf<T>>`, the resulting tree will have entries pointing to the same `Rc<Leaf<U>>`.
+    /// Because hardlinks are index-based, directory tree indices pass through unchanged.
     /// The mapping function is called exactly once per unique leaf.
     pub fn try_map_regular<U, E>(
         self,
         mut f: impl FnMut(&T) -> Result<U, E>,
     ) -> Result<FileSystem<U>, E> {
-        let mut rc_map: HashMap<*const Leaf<T>, Rc<Leaf<U>>> = HashMap::new();
-        let root = self.root.try_map_regular_impl(&mut f, &mut rc_map)?;
-        Ok(FileSystem { root })
+        let new_leaves = self
+            .leaves
+            .into_iter()
+            .map(|leaf| {
+                let new_content = leaf.content.try_map_ref(&mut f)?;
+                Ok(Leaf {
+                    stat: leaf.stat,
+                    content: new_content,
+                })
+            })
+            .collect::<Result<_, E>>()?;
+        let root = self.root.retype::<U>();
+        Ok(FileSystem {
+            root,
+            leaves: new_leaves,
+        })
+    }
+
+    /// Removes unreferenced leaves and remaps all LeafIds.
+    ///
+    /// After removing entries from the tree, some leaves may become
+    /// unreferenced. This method compacts the leaves table by removing
+    /// dead entries and updating all LeafIds in the tree accordingly.
+    pub fn compact(&mut self) {
+        // 1. Count references to each LeafId
+        let mut refcount = vec![0u32; self.leaves.len()];
+        self.root.count_leaf_refs(&mut refcount);
+
+        // 2. Build old_id → new_id mapping, skipping dead entries
+        let mut id_map = vec![LeafId(0); self.leaves.len()];
+        let mut write_pos = 0;
+        for (old_id, &count) in refcount.iter().enumerate() {
+            if count > 0 {
+                id_map[old_id] = LeafId(write_pos);
+                write_pos += 1;
+            }
+        }
+
+        // 3. Compact the leaves vec (keep only live entries)
+        let mut new_leaves = Vec::with_capacity(write_pos);
+        for (old_id, leaf) in self.leaves.drain(..).enumerate() {
+            if refcount[old_id] > 0 {
+                new_leaves.push(leaf);
+            }
+        }
+        self.leaves = new_leaves;
+
+        // 4. Remap all LeafIds in the tree
+        self.root.remap_leaf_ids(&id_map);
+
+        debug_assert!(self.fsck().is_ok(), "compact() produced invalid filesystem");
+    }
+
+    /// Compute nlink counts for all leaves at once.
+    ///
+    /// Returns a `Vec` indexed by [`LeafId`] where each entry is the
+    /// number of directory entries referencing that leaf (i.e. the
+    /// hard link count).
+    pub fn nlinks(&self) -> Vec<u32> {
+        let mut refcount = vec![0u32; self.leaves.len()];
+        self.root.count_leaf_refs(&mut refcount);
+        refcount
+    }
+
+    /// Verify internal consistency of the filesystem.
+    ///
+    /// Checks that:
+    /// - All [`LeafId`] indices in the directory tree are within bounds
+    ///   of the leaves table
+    /// - All leaves in the table are referenced by at least one
+    ///   directory entry (no orphans)
+    ///
+    /// Returns `Ok(())` if the filesystem is consistent, or an error
+    /// describing the first inconsistency found.
+    pub fn fsck(&self) -> Result<(), ImageError> {
+        // Validate bounds and count references in one pass.
+        let mut refcount = vec![0u32; self.leaves.len()];
+        self.root.fsck_refs(self.leaves.len(), &mut refcount)?;
+
+        let orphans: Vec<usize> = refcount
+            .iter()
+            .enumerate()
+            .filter(|(_, count)| **count == 0)
+            .map(|(i, _)| i)
+            .collect();
+        if !orphans.is_empty() {
+            return Err(ImageError::OrphanedLeaves(orphans));
+        }
+
+        Ok(())
+    }
+
+    /// Returns a [`DirectoryRef`] for the root directory.
+    pub fn as_dir(&self) -> DirectoryRef<'_, T> {
+        DirectoryRef {
+            dir: &self.root,
+            leaves: &self.leaves,
+        }
+    }
+
+    /// Returns a reference to the leaf with the given id.
+    pub fn leaf(&self, id: LeafId) -> &Leaf<T> {
+        &self.leaves[id.0]
+    }
+
+    /// Returns a mutable reference to the leaf with the given id.
+    pub fn leaf_mut(&mut self, id: LeafId) -> &mut Leaf<T> {
+        &mut self.leaves[id.0]
+    }
+}
+
+/// A read-only view of a [`Directory`] paired with the [`FileSystem`]'s
+/// leaves table, so that leaf-resolving methods don't need a separate
+/// `leaves` parameter.
+///
+/// Obtained via [`FileSystem::as_dir`] or [`DirectoryRef::get_directory`].
+#[derive(Debug)]
+pub struct DirectoryRef<'a, T> {
+    dir: &'a Directory<T>,
+    leaves: &'a [Leaf<T>],
+}
+
+// Manual Clone/Copy implementations to avoid requiring T: Clone/Copy,
+// since the struct only holds references.
+impl<T> Clone for DirectoryRef<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for DirectoryRef<'_, T> {}
+
+impl<T> std::ops::Deref for DirectoryRef<'_, T> {
+    type Target = Directory<T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.dir
+    }
+}
+
+impl<'a, T> DirectoryRef<'a, T> {
+    /// Constructs a [`DirectoryRef`] from a directory reference and a leaves table.
+    ///
+    /// This is useful when you have a `&Directory<T>` obtained from tree
+    /// traversal (e.g., pattern matching on [`Inode::Directory`]) and want
+    /// to wrap it with its leaves table for convenient leaf resolution.
+    pub fn from_parts(dir: &'a Directory<T>, leaves: &'a [Leaf<T>]) -> Self {
+        DirectoryRef { dir, leaves }
+    }
+
+    /// Returns the underlying leaves table.
+    pub fn leaves(&self) -> &'a [Leaf<T>] {
+        self.leaves
+    }
+
+    /// Looks up a subdirectory by path, returning a new [`DirectoryRef`].
+    ///
+    /// Like [`Directory::get_directory`] but wraps the result in a
+    /// [`DirectoryRef`] that carries the leaves table.
+    pub fn get_directory_ref(&self, pathname: &OsStr) -> Result<DirectoryRef<'a, T>, ImageError> {
+        self.dir.get_directory(pathname).map(|dir| DirectoryRef {
+            dir,
+            leaves: self.leaves,
+        })
+    }
+
+    /// Looks up a subdirectory by path, returning `None` if not found.
+    ///
+    /// Like [`Directory::get_directory_opt`] but wraps the result in a
+    /// [`DirectoryRef`].
+    pub fn get_directory_ref_opt(
+        &self,
+        pathname: &OsStr,
+    ) -> Result<Option<DirectoryRef<'a, T>>, ImageError> {
+        self.dir.get_directory_opt(pathname).map(|opt| {
+            opt.map(|dir| DirectoryRef {
+                dir,
+                leaves: self.leaves,
+            })
+        })
+    }
+
+    /// Returns a reference to the leaf with the given id.
+    pub fn leaf(&self, id: LeafId) -> &'a Leaf<T> {
+        &self.leaves[id.0]
+    }
+
+    /// Splits a pathname into a [`DirectoryRef`] and the filename within it.
+    ///
+    /// Like [`Directory::split`] but wraps the resulting directory in a
+    /// [`DirectoryRef`].
+    pub fn split_ref<'n>(
+        &self,
+        pathname: &'n OsStr,
+    ) -> Result<(DirectoryRef<'a, T>, &'n OsStr), ImageError> {
+        let (dir, filename) = self.dir.split(pathname)?;
+        Ok((
+            DirectoryRef {
+                dir,
+                leaves: self.leaves,
+            },
+            filename,
+        ))
+    }
+
+    /// Returns the regular file content `T` for the named entry.
+    pub fn get_file(&self, filename: &OsStr) -> Result<&'a T, ImageError> {
+        self.dir.get_file(filename, self.leaves)
+    }
+
+    /// Like [`Self::get_file`] but maps not-found to `None`.
+    pub fn get_file_opt(&self, filename: &OsStr) -> Result<Option<&'a T>, ImageError> {
+        self.dir.get_file_opt(filename, self.leaves)
+    }
+
+    /// Recursively finds the newest modification time in this directory tree.
+    pub fn newest_file(&self) -> i64 {
+        self.dir.newest_file(self.leaves)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::RefCell;
     use std::collections::BTreeMap;
     use std::ffi::{OsStr, OsString};
-    use std::rc::Rc;
 
     // We never store any actual data here
     #[derive(Debug, Default)]
@@ -687,7 +999,7 @@ mod tests {
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: RefCell::new(BTreeMap::new()),
+            xattrs: BTreeMap::new(),
         }
     }
 
@@ -698,24 +1010,28 @@ mod tests {
             st_uid: 1000,
             st_gid: 1000,
             st_mtim_sec: mtime,
-            xattrs: RefCell::new(BTreeMap::new()),
+            xattrs: BTreeMap::new(),
         }
     }
 
-    // Helper to create a simple Leaf (e.g., an empty inline file)
-    fn new_leaf_file(mtime: i64) -> Rc<Leaf<FileContents>> {
-        Rc::new(Leaf {
+    // Helper to create a leaf in the leaves vec and return the LeafId
+    fn push_leaf_file(leaves: &mut Vec<Leaf<FileContents>>, mtime: i64) -> LeafId {
+        let id = LeafId(leaves.len());
+        leaves.push(Leaf {
             stat: stat_with_mtime(mtime),
             content: LeafContent::Regular(FileContents::default()),
-        })
+        });
+        id
     }
 
-    // Helper to create a simple Leaf (symlink)
-    fn new_leaf_symlink(target: &str, mtime: i64) -> Rc<Leaf<FileContents>> {
-        Rc::new(Leaf {
+    // Helper to create a symlink leaf in the leaves vec and return the LeafId
+    fn push_leaf_symlink(leaves: &mut Vec<Leaf<FileContents>>, target: &str, mtime: i64) -> LeafId {
+        let id = LeafId(leaves.len());
+        leaves.push(Leaf {
             stat: stat_with_mtime(mtime),
             content: LeafContent::Symlink(OsString::from(target).into_boxed_os_str()),
-        })
+        });
+        id
     }
 
     // Helper to create an empty Directory Inode with a specific mtime
@@ -744,15 +1060,17 @@ mod tests {
 
     #[test]
     fn test_insert_and_get_leaf() {
+        let mut leaves = Vec::new();
+        let leaf_id = push_leaf_file(&mut leaves, 10);
+
         let mut dir = Directory::<FileContents>::new(default_stat());
-        let leaf = new_leaf_file(10);
-        dir.insert(OsStr::new("file.txt"), Inode::Leaf(Rc::clone(&leaf)));
+        dir.insert(OsStr::new("file.txt"), Inode::leaf(leaf_id));
         assert_eq!(dir.entries.len(), 1);
 
-        let retrieved_leaf_rc = dir.ref_leaf(OsStr::new("file.txt")).unwrap();
-        assert!(Rc::ptr_eq(&retrieved_leaf_rc, &leaf));
+        let retrieved_id = dir.leaf_id(OsStr::new("file.txt")).unwrap();
+        assert_eq!(retrieved_id, leaf_id);
 
-        let regular_file_content = dir.get_file(OsStr::new("file.txt")).unwrap();
+        let regular_file_content = dir.get_file(OsStr::new("file.txt"), &leaves).unwrap();
         assert!(matches!(regular_file_content, FileContents {}));
     }
 
@@ -775,9 +1093,12 @@ mod tests {
 
     #[test]
     fn test_get_directory_errors() {
-        let mut root = Directory::new(default_stat());
+        let mut leaves = Vec::new();
+        let leaf_id = push_leaf_file(&mut leaves, 30);
+
+        let mut root = Directory::<FileContents>::new(default_stat());
         root.insert(OsStr::new("dir1"), new_dir_inode(10));
-        root.insert(OsStr::new("file1"), Inode::Leaf(new_leaf_file(30)));
+        root.insert(OsStr::new("file1"), Inode::leaf(leaf_id));
 
         match root.get_directory(OsStr::new("nonexistent")) {
             Err(ImageError::NotFound(name)) => assert_eq!(name.to_str().unwrap(), "nonexistent"),
@@ -797,30 +1118,30 @@ mod tests {
 
     #[test]
     fn test_get_file_errors() {
-        let mut dir = Directory::new(default_stat());
-        dir.insert(OsStr::new("subdir"), new_dir_inode(10));
-        dir.insert(
-            OsStr::new("link.txt"),
-            Inode::Leaf(new_leaf_symlink("target", 20)),
-        );
+        let mut leaves = Vec::new();
+        let symlink_id = push_leaf_symlink(&mut leaves, "target", 20);
 
-        match dir.get_file(OsStr::new("nonexistent.txt")) {
+        let mut dir = Directory::<FileContents>::new(default_stat());
+        dir.insert(OsStr::new("subdir"), new_dir_inode(10));
+        dir.insert(OsStr::new("link.txt"), Inode::leaf(symlink_id));
+
+        match dir.get_file(OsStr::new("nonexistent.txt"), &leaves) {
             Err(ImageError::NotFound(name)) => {
                 assert_eq!(name.to_str().unwrap(), "nonexistent.txt")
             }
             _ => panic!("Expected NotFound"),
         }
         assert!(
-            dir.get_file_opt(OsStr::new("nonexistent.txt"))
+            dir.get_file_opt(OsStr::new("nonexistent.txt"), &leaves)
                 .unwrap()
                 .is_none()
         );
 
-        match dir.get_file(OsStr::new("subdir")) {
+        match dir.get_file(OsStr::new("subdir"), &leaves) {
             Err(ImageError::IsADirectory(name)) => assert_eq!(name.to_str().unwrap(), "subdir"),
             _ => panic!("Expected IsADirectory"),
         }
-        match dir.get_file(OsStr::new("link.txt")) {
+        match dir.get_file(OsStr::new("link.txt"), &leaves) {
             Err(ImageError::IsNotRegular(name)) => assert_eq!(name.to_str().unwrap(), "link.txt"),
             res => panic!("Expected IsNotRegular, got {res:?}"),
         }
@@ -828,8 +1149,11 @@ mod tests {
 
     #[test]
     fn test_remove() {
-        let mut dir = Directory::new(default_stat());
-        dir.insert(OsStr::new("file1.txt"), Inode::Leaf(new_leaf_file(10)));
+        let mut leaves = Vec::new();
+        let leaf_id = push_leaf_file(&mut leaves, 10);
+
+        let mut dir = Directory::<FileContents>::new(default_stat());
+        dir.insert(OsStr::new("file1.txt"), Inode::leaf(leaf_id));
         dir.insert(OsStr::new("subdir"), new_dir_inode(20));
         assert_eq!(dir.entries.len(), 2);
 
@@ -843,23 +1167,27 @@ mod tests {
 
     #[test]
     fn test_merge() {
-        let mut dir = Directory::new(default_stat());
+        let mut leaves = Vec::new();
+
+        let mut dir = Directory::<FileContents>::new(default_stat());
 
         // Merge Leaf onto empty
-        dir.merge(OsStr::new("item"), Inode::Leaf(new_leaf_file(10)));
+        let leaf_id = push_leaf_file(&mut leaves, 10);
+        dir.merge(OsStr::new("item"), Inode::leaf(leaf_id));
         assert_eq!(
             dir.entries
                 .get(OsStr::new("item"))
                 .unwrap()
-                .stat()
+                .stat(&leaves)
                 .st_mtim_sec,
             10
         );
 
         // Merge Directory onto existing Directory
+        let inner_leaf_id = push_leaf_file(&mut leaves, 85);
         let mut existing_dir_inode = new_dir_inode_with_stat(stat_with_mtime(80));
         if let Inode::Directory(ref mut ed_box) = existing_dir_inode {
-            ed_box.insert(OsStr::new("inner_file"), Inode::Leaf(new_leaf_file(85)));
+            ed_box.insert(OsStr::new("inner_file"), Inode::leaf(inner_leaf_id));
         }
         dir.insert(OsStr::new("merged_dir"), existing_dir_inode);
 
@@ -876,16 +1204,17 @@ mod tests {
         }
 
         // Merge Leaf onto Directory (replaces)
-        dir.merge(OsStr::new("merged_dir"), Inode::Leaf(new_leaf_file(100)));
+        let replace_leaf_id = push_leaf_file(&mut leaves, 100);
+        dir.merge(OsStr::new("merged_dir"), Inode::leaf(replace_leaf_id));
         assert!(matches!(
             dir.entries.get(OsStr::new("merged_dir")),
-            Some(Inode::Leaf(_))
+            Some(Inode::Leaf(..))
         ));
         assert_eq!(
             dir.entries
                 .get(OsStr::new("merged_dir"))
                 .unwrap()
-                .stat()
+                .stat(&leaves)
                 .st_mtim_sec,
             100
         );
@@ -893,8 +1222,11 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let mut dir = Directory::new(default_stat());
-        dir.insert(OsStr::new("file1"), Inode::Leaf(new_leaf_file(10)));
+        let mut leaves = Vec::new();
+        let leaf_id = push_leaf_file(&mut leaves, 10);
+
+        let mut dir = Directory::<FileContents>::new(default_stat());
+        dir.insert(OsStr::new("file1"), Inode::leaf(leaf_id));
         dir.stat.st_mtim_sec = 100;
 
         dir.clear();
@@ -904,36 +1236,42 @@ mod tests {
 
     #[test]
     fn test_newest_file() {
-        let mut root = Directory::new(stat_with_mtime(5));
-        assert_eq!(root.newest_file(), 5);
+        let mut leaves = Vec::new();
 
-        root.insert(OsStr::new("file1"), Inode::Leaf(new_leaf_file(10)));
-        assert_eq!(root.newest_file(), 10);
+        let mut root = Directory::new(stat_with_mtime(5));
+        assert_eq!(root.newest_file(&leaves), 5);
+
+        let leaf_id_10 = push_leaf_file(&mut leaves, 10);
+        root.insert(OsStr::new("file1"), Inode::leaf(leaf_id_10));
+        assert_eq!(root.newest_file(&leaves), 10);
 
         let subdir_stat = stat_with_mtime(15);
         let mut subdir = Box::new(Directory::new(subdir_stat));
-        subdir.insert(OsStr::new("subfile1"), Inode::Leaf(new_leaf_file(12)));
+        let leaf_id_12 = push_leaf_file(&mut leaves, 12);
+        subdir.insert(OsStr::new("subfile1"), Inode::leaf(leaf_id_12));
         root.insert(OsStr::new("subdir"), Inode::Directory(subdir));
-        assert_eq!(root.newest_file(), 15);
+        assert_eq!(root.newest_file(&leaves), 15);
 
         if let Some(Inode::Directory(sd)) = root.entries.get_mut(OsStr::new("subdir")) {
-            sd.insert(OsStr::new("subfile2"), Inode::Leaf(new_leaf_file(20)));
+            let leaf_id_20 = push_leaf_file(&mut leaves, 20);
+            sd.insert(OsStr::new("subfile2"), Inode::leaf(leaf_id_20));
         }
-        assert_eq!(root.newest_file(), 20);
+        assert_eq!(root.newest_file(&leaves), 20);
 
         root.stat.st_mtim_sec = 25;
-        assert_eq!(root.newest_file(), 25);
+        assert_eq!(root.newest_file(&leaves), 25);
     }
 
     #[test]
     fn test_iteration_entries_sorted_inodes() {
-        let mut dir = Directory::new(default_stat());
-        dir.insert(OsStr::new("b_file"), Inode::Leaf(new_leaf_file(10)));
+        let mut leaves = Vec::new();
+        let file_id = push_leaf_file(&mut leaves, 10);
+        let link_id = push_leaf_symlink(&mut leaves, "target", 30);
+
+        let mut dir = Directory::<FileContents>::new(default_stat());
+        dir.insert(OsStr::new("b_file"), Inode::leaf(file_id));
         dir.insert(OsStr::new("a_dir"), new_dir_inode(20));
-        dir.insert(
-            OsStr::new("c_link"),
-            Inode::Leaf(new_leaf_symlink("target", 30)),
-        );
+        dir.insert(OsStr::new("c_link"), Inode::leaf(link_id));
 
         let names_from_entries: Vec<&OsStr> = dir.entries().map(|(name, _)| name).collect();
         assert_eq!(names_from_entries.len(), 3); // BTreeMap iter is sorted
@@ -955,7 +1293,7 @@ mod tests {
         for inode in dir.inodes() {
             match inode {
                 Inode::Directory(_) => inode_types.push("dir"),
-                Inode::Leaf(_) => inode_types.push("leaf"),
+                Inode::Leaf(..) => inode_types.push("leaf"),
             }
         }
         assert_eq!(inode_types.len(), 3);
@@ -973,10 +1311,10 @@ mod tests {
             st_uid: 42,
             st_gid: 43,
             st_mtim_sec: 1234567890,
-            xattrs: RefCell::new(BTreeMap::from([(
+            xattrs: BTreeMap::from([(
                 Box::from(OsStr::new("security.selinux")),
                 Box::from(b"system_u:object_r:usr_t:s0".as_slice()),
-            )])),
+            )]),
         };
         let usr_dir = Directory {
             stat: usr_stat,
@@ -997,7 +1335,6 @@ mod tests {
             fs.root
                 .stat
                 .xattrs
-                .borrow()
                 .contains_key(OsStr::new("security.selinux"))
         );
     }
@@ -1019,7 +1356,7 @@ mod tests {
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: RefCell::new(BTreeMap::from([
+            xattrs: BTreeMap::from([
                 (
                     Box::from(OsStr::new("security.selinux")),
                     Box::from(b"label".as_slice()),
@@ -1032,20 +1369,20 @@ mod tests {
                     Box::from(OsStr::new("user.custom")),
                     Box::from(b"value".as_slice()),
                 ),
-            ])),
+            ]),
         };
-        let fs = FileSystem::<FileContents>::new(root_stat);
+        let mut fs = FileSystem::<FileContents>::new(root_stat);
 
         // Filter to keep only xattrs starting with "user."
         fs.filter_xattrs(|name| name.as_encoded_bytes().starts_with(b"user."));
 
-        let root_xattrs = fs.root.stat.xattrs.borrow();
-        assert_eq!(root_xattrs.len(), 1);
-        assert!(root_xattrs.contains_key(OsStr::new("user.custom")));
+        assert_eq!(fs.root.stat.xattrs.len(), 1);
+        assert!(fs.root.stat.xattrs.contains_key(OsStr::new("user.custom")));
     }
 
     #[test]
     fn test_canonicalize_run() {
+        let mut leaves = Vec::new();
         let mut fs = FileSystem::<FileContents>::new(default_stat());
 
         // Create /usr with specific mtime
@@ -1055,12 +1392,15 @@ mod tests {
 
         // Create /run with content and different mtime
         let mut run_dir = Directory::new(stat_with_mtime(99999));
-        run_dir.insert(OsStr::new("somefile"), Inode::Leaf(new_leaf_file(11111)));
+        let file_id = push_leaf_file(&mut leaves, 11111);
+        run_dir.insert(OsStr::new("somefile"), Inode::leaf(file_id));
         let mut subdir = Directory::new(stat_with_mtime(22222));
-        subdir.insert(OsStr::new("nested"), Inode::Leaf(new_leaf_file(33333)));
+        let nested_id = push_leaf_file(&mut leaves, 33333);
+        subdir.insert(OsStr::new("nested"), Inode::leaf(nested_id));
         run_dir.insert(OsStr::new("subdir"), Inode::Directory(Box::new(subdir)));
         fs.root
             .insert(OsStr::new("run"), Inode::Directory(Box::new(run_dir)));
+        fs.leaves = leaves;
 
         // Verify /run has content before
         assert_eq!(
@@ -1097,17 +1437,18 @@ mod tests {
     #[test]
     fn test_try_map_regular_basic() {
         let mut fs = FileSystem::<u32>::new(stat_with_mtime(1));
-        let leaf = Rc::new(Leaf {
+        fs.leaves.push(Leaf {
             stat: stat_with_mtime(10),
             content: LeafContent::Regular(42u32),
         });
-        fs.root.insert(OsStr::new("file.txt"), Inode::Leaf(leaf));
+        fs.root
+            .insert(OsStr::new("file.txt"), Inode::Leaf(LeafId(0), PhantomData));
 
         let mapped = fs
             .try_map_regular(|v: &u32| Ok::<String, std::fmt::Error>(format!("val={v}")))
             .unwrap();
 
-        let content = mapped.root.get_file(OsStr::new("file.txt")).unwrap();
+        let content = mapped.as_dir().get_file(OsStr::new("file.txt")).unwrap();
         assert_eq!(content, "val=42");
         assert_eq!(mapped.root.stat.st_mtim_sec, 1);
     }
@@ -1115,41 +1456,37 @@ mod tests {
     #[test]
     fn test_try_map_regular_non_regular_passthrough() {
         let mut fs = FileSystem::<u32>::new(default_stat());
-        fs.root.insert(
-            OsStr::new("link"),
-            Inode::Leaf(Rc::new(Leaf {
-                stat: stat_with_mtime(1),
-                content: LeafContent::Symlink(OsString::from("/target").into_boxed_os_str()),
-            })),
-        );
-        fs.root.insert(
-            OsStr::new("fifo"),
-            Inode::Leaf(Rc::new(Leaf {
-                stat: stat_with_mtime(2),
-                content: LeafContent::Fifo,
-            })),
-        );
-        fs.root.insert(
-            OsStr::new("sock"),
-            Inode::Leaf(Rc::new(Leaf {
-                stat: stat_with_mtime(3),
-                content: LeafContent::Socket,
-            })),
-        );
-        fs.root.insert(
-            OsStr::new("blk"),
-            Inode::Leaf(Rc::new(Leaf {
-                stat: stat_with_mtime(4),
-                content: LeafContent::BlockDevice(0x0801),
-            })),
-        );
-        fs.root.insert(
-            OsStr::new("chr"),
-            Inode::Leaf(Rc::new(Leaf {
-                stat: stat_with_mtime(5),
-                content: LeafContent::CharacterDevice(0x0501),
-            })),
-        );
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(1),
+            content: LeafContent::Symlink(OsString::from("/target").into_boxed_os_str()),
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(2),
+            content: LeafContent::Fifo,
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(3),
+            content: LeafContent::Socket,
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(4),
+            content: LeafContent::BlockDevice(0x0801),
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(5),
+            content: LeafContent::CharacterDevice(0x0501),
+        });
+
+        fs.root
+            .insert(OsStr::new("link"), Inode::Leaf(LeafId(0), PhantomData));
+        fs.root
+            .insert(OsStr::new("fifo"), Inode::Leaf(LeafId(1), PhantomData));
+        fs.root
+            .insert(OsStr::new("sock"), Inode::Leaf(LeafId(2), PhantomData));
+        fs.root
+            .insert(OsStr::new("blk"), Inode::Leaf(LeafId(3), PhantomData));
+        fs.root
+            .insert(OsStr::new("chr"), Inode::Leaf(LeafId(4), PhantomData));
 
         let mapped = fs
             .try_map_regular(|_: &u32| Ok::<String, std::fmt::Error>("unused".into()))
@@ -1157,29 +1494,33 @@ mod tests {
 
         // Verify each non-regular variant is preserved
         match mapped.root.lookup(OsStr::new("link")) {
-            Some(Inode::Leaf(l)) => match &l.content {
+            Some(Inode::Leaf(id, _)) => match &mapped.leaf(*id).content {
                 LeafContent::Symlink(t) => assert_eq!(t.as_ref(), OsStr::new("/target")),
                 other => panic!("Expected Symlink, got {other:?}"),
             },
             other => panic!("Expected Leaf, got {other:?}"),
         }
         match mapped.root.lookup(OsStr::new("fifo")) {
-            Some(Inode::Leaf(l)) => assert!(matches!(l.content, LeafContent::Fifo)),
+            Some(Inode::Leaf(id, _)) => {
+                assert!(matches!(mapped.leaf(*id).content, LeafContent::Fifo))
+            }
             other => panic!("Expected Leaf/Fifo, got {other:?}"),
         }
         match mapped.root.lookup(OsStr::new("sock")) {
-            Some(Inode::Leaf(l)) => assert!(matches!(l.content, LeafContent::Socket)),
+            Some(Inode::Leaf(id, _)) => {
+                assert!(matches!(mapped.leaf(*id).content, LeafContent::Socket))
+            }
             other => panic!("Expected Leaf/Socket, got {other:?}"),
         }
         match mapped.root.lookup(OsStr::new("blk")) {
-            Some(Inode::Leaf(l)) => match &l.content {
+            Some(Inode::Leaf(id, _)) => match &mapped.leaf(*id).content {
                 LeafContent::BlockDevice(rdev) => assert_eq!(*rdev, 0x0801),
                 other => panic!("Expected BlockDevice, got {other:?}"),
             },
             other => panic!("Expected Leaf, got {other:?}"),
         }
         match mapped.root.lookup(OsStr::new("chr")) {
-            Some(Inode::Leaf(l)) => match &l.content {
+            Some(Inode::Leaf(id, _)) => match &mapped.leaf(*id).content {
                 LeafContent::CharacterDevice(rdev) => assert_eq!(*rdev, 0x0501),
                 other => panic!("Expected CharacterDevice, got {other:?}"),
             },
@@ -1190,58 +1531,59 @@ mod tests {
     #[test]
     fn test_try_map_regular_hardlink_sharing() {
         let mut fs = FileSystem::<u32>::new(default_stat());
-        let shared_leaf = Rc::new(Leaf {
+        // One leaf, two directory entries (hardlink)
+        fs.leaves.push(Leaf {
             stat: stat_with_mtime(10),
             content: LeafContent::Regular(99u32),
         });
-        // Insert the same Rc under two names (hardlink)
         fs.root
-            .insert(OsStr::new("a"), Inode::Leaf(Rc::clone(&shared_leaf)));
+            .insert(OsStr::new("a"), Inode::Leaf(LeafId(0), PhantomData));
         fs.root
-            .insert(OsStr::new("b"), Inode::Leaf(Rc::clone(&shared_leaf)));
+            .insert(OsStr::new("b"), Inode::Leaf(LeafId(0), PhantomData));
 
         // Track how many times the mapping function is called
-        let call_count = RefCell::new(0u32);
+        let mut call_count = 0u32;
         let mapped = fs
             .try_map_regular(|v: &u32| {
-                *call_count.borrow_mut() += 1;
+                call_count += 1;
                 Ok::<String, std::fmt::Error>(format!("mapped={v}"))
             })
             .unwrap();
 
-        // The mapping function should be called exactly once for the shared leaf
-        assert_eq!(*call_count.borrow(), 1);
+        // The mapping function should be called exactly once for the single leaf
+        assert_eq!(call_count, 1);
 
-        // Both entries should point to the same Rc
-        let rc_a = match mapped.root.lookup(OsStr::new("a")) {
-            Some(Inode::Leaf(l)) => Rc::clone(l),
+        // Both entries should point to the same LeafId
+        let id_a = match mapped.root.lookup(OsStr::new("a")) {
+            Some(Inode::Leaf(id, _)) => *id,
             other => panic!("Expected Leaf, got {other:?}"),
         };
-        let rc_b = match mapped.root.lookup(OsStr::new("b")) {
-            Some(Inode::Leaf(l)) => Rc::clone(l),
+        let id_b = match mapped.root.lookup(OsStr::new("b")) {
+            Some(Inode::Leaf(id, _)) => *id,
             other => panic!("Expected Leaf, got {other:?}"),
         };
-        assert!(Rc::ptr_eq(&rc_a, &rc_b));
-        assert_eq!(mapped.root.get_file(OsStr::new("a")).unwrap(), "mapped=99");
+        assert_eq!(id_a, id_b);
+        assert_eq!(
+            mapped.as_dir().get_file(OsStr::new("a")).unwrap(),
+            "mapped=99"
+        );
     }
 
     #[test]
     fn test_try_map_regular_error_propagation() {
         let mut fs = FileSystem::<u32>::new(default_stat());
-        fs.root.insert(
-            OsStr::new("ok"),
-            Inode::Leaf(Rc::new(Leaf {
-                stat: stat_with_mtime(1),
-                content: LeafContent::Regular(1u32),
-            })),
-        );
-        fs.root.insert(
-            OsStr::new("fail"),
-            Inode::Leaf(Rc::new(Leaf {
-                stat: stat_with_mtime(2),
-                content: LeafContent::Regular(0u32),
-            })),
-        );
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(1),
+            content: LeafContent::Regular(1u32),
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(2),
+            content: LeafContent::Regular(0u32),
+        });
+        fs.root
+            .insert(OsStr::new("ok"), Inode::Leaf(LeafId(0), PhantomData));
+        fs.root
+            .insert(OsStr::new("fail"), Inode::Leaf(LeafId(1), PhantomData));
 
         let result = fs.try_map_regular(|v: &u32| {
             if *v == 0 {
@@ -1257,6 +1599,7 @@ mod tests {
 
     #[test]
     fn test_transform_for_oci() {
+        let mut leaves = Vec::new();
         let mut fs = FileSystem::<FileContents>::new(default_stat());
 
         // Create /usr with specific metadata
@@ -1265,19 +1608,21 @@ mod tests {
             st_uid: 100,
             st_gid: 200,
             st_mtim_sec: 54321,
-            xattrs: RefCell::new(BTreeMap::from([(
+            xattrs: BTreeMap::from([(
                 Box::from(OsStr::new("user.test")),
                 Box::from(b"val".as_slice()),
-            )])),
+            )]),
         };
         fs.root
             .insert(OsStr::new("usr"), new_dir_inode_with_stat(usr_stat));
 
         // Create /run with content
         let mut run_dir = Directory::new(stat_with_mtime(99999));
-        run_dir.insert(OsStr::new("file"), Inode::Leaf(new_leaf_file(11111)));
+        let file_id = push_leaf_file(&mut leaves, 11111);
+        run_dir.insert(OsStr::new("file"), Inode::leaf(file_id));
         fs.root
             .insert(OsStr::new("run"), Inode::Directory(Box::new(run_dir)));
+        fs.leaves = leaves;
 
         // Transform for OCI
         fs.transform_for_oci().unwrap();
@@ -1292,5 +1637,147 @@ mod tests {
         let run = fs.root.get_directory(OsStr::new("run")).unwrap();
         assert!(run.entries.is_empty());
         assert_eq!(run.stat.st_mtim_sec, 54321);
+    }
+
+    #[test]
+    fn test_filesystem_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FileSystem<u32>>();
+        assert_send_sync::<FileSystem<String>>();
+    }
+
+    #[test]
+    fn test_filesystem_hardlink_sharing() {
+        // Two directory entries pointing to the same LeafId
+        let mut fs = FileSystem::<u32>::new(default_stat());
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(10),
+            content: LeafContent::Regular(99u32),
+        });
+        fs.root
+            .insert(OsStr::new("a"), Inode::Leaf(LeafId(0), PhantomData));
+        fs.root
+            .insert(OsStr::new("b"), Inode::Leaf(LeafId(0), PhantomData));
+
+        let id_a = fs.root.leaf_id(OsStr::new("a")).unwrap();
+        let id_b = fs.root.leaf_id(OsStr::new("b")).unwrap();
+        assert_eq!(id_a, id_b);
+    }
+
+    #[test]
+    fn test_try_map_regular_on_flat_fs() {
+        let mut fs = FileSystem::<u32>::new(default_stat());
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(10),
+            content: LeafContent::Regular(42u32),
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(20),
+            content: LeafContent::Symlink(OsString::from("/x").into_boxed_os_str()),
+        });
+        fs.root
+            .insert(OsStr::new("file"), Inode::Leaf(LeafId(0), PhantomData));
+        fs.root
+            .insert(OsStr::new("link"), Inode::Leaf(LeafId(1), PhantomData));
+
+        let mapped = fs
+            .try_map_regular(|v: &u32| Ok::<String, std::fmt::Error>(format!("val={v}")))
+            .unwrap();
+
+        // Check mapped leaf
+        match &mapped.leaf(LeafId(0)).content {
+            LeafContent::Regular(s) => assert_eq!(s, "val=42"),
+            other => panic!("Expected Regular, got {other:?}"),
+        }
+        // Non-regular passthrough
+        match &mapped.leaf(LeafId(1)).content {
+            LeafContent::Symlink(t) => assert_eq!(t.as_ref(), OsStr::new("/x")),
+            other => panic!("Expected Symlink, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_compact() {
+        let mut fs = FileSystem::<u32>::new(default_stat());
+        // Push 3 leaves; only reference 0 and 2
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(10),
+            content: LeafContent::Regular(1u32),
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(20),
+            content: LeafContent::Regular(2u32),
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(30),
+            content: LeafContent::Regular(3u32),
+        });
+        fs.root
+            .insert(OsStr::new("a"), Inode::Leaf(LeafId(0), PhantomData));
+        fs.root
+            .insert(OsStr::new("c"), Inode::Leaf(LeafId(2), PhantomData));
+
+        fs.compact();
+
+        assert_eq!(fs.leaves.len(), 2);
+        // "a" should now be LeafId(0) and "c" should be LeafId(1)
+        let id_a = fs.root.leaf_id(OsStr::new("a")).unwrap();
+        let id_c = fs.root.leaf_id(OsStr::new("c")).unwrap();
+        assert_eq!(id_a, LeafId(0));
+        assert_eq!(id_c, LeafId(1));
+        // Verify content is correct after compaction
+        match &fs.leaf(id_a).content {
+            LeafContent::Regular(v) => assert_eq!(*v, 1),
+            _ => panic!("Wrong content"),
+        }
+        match &fs.leaf(id_c).content {
+            LeafContent::Regular(v) => assert_eq!(*v, 3),
+            _ => panic!("Wrong content"),
+        }
+    }
+
+    #[test]
+    fn test_nlink() {
+        let mut fs = FileSystem::<u32>::new(default_stat());
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(10),
+            content: LeafContent::Regular(42u32),
+        });
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(20),
+            content: LeafContent::Regular(99u32),
+        });
+        // Leaf 0 referenced twice (hardlink), leaf 1 referenced once
+        fs.root
+            .insert(OsStr::new("a"), Inode::Leaf(LeafId(0), PhantomData));
+        fs.root
+            .insert(OsStr::new("b"), Inode::Leaf(LeafId(0), PhantomData));
+        fs.root
+            .insert(OsStr::new("c"), Inode::Leaf(LeafId(1), PhantomData));
+
+        assert_eq!(fs.nlinks()[LeafId(0).0], 2);
+        assert_eq!(fs.nlinks()[LeafId(1).0], 1);
+
+        let nlinks = fs.nlinks();
+        assert_eq!(nlinks, vec![2, 1]);
+    }
+
+    #[test]
+    fn test_for_each_stat_mut() {
+        let mut fs = FileSystem::<u32>::new(stat_with_mtime(100));
+        fs.leaves.push(Leaf {
+            stat: stat_with_mtime(200),
+            content: LeafContent::Regular(1u32),
+        });
+        fs.root
+            .insert(OsStr::new("f"), Inode::Leaf(LeafId(0), PhantomData));
+
+        // Double all mtimes
+        fs.for_each_stat_mut(|stat| {
+            stat.st_mtim_sec *= 2;
+        });
+
+        assert_eq!(fs.root.stat.st_mtim_sec, 200);
+        assert_eq!(fs.leaves[0].stat.st_mtim_sec, 400);
     }
 }

--- a/crates/composefs/src/generic_tree.rs
+++ b/crates/composefs/src/generic_tree.rs
@@ -448,13 +448,15 @@ impl<T> Directory<T> {
     /// If the `filename` existed previously, the content is completely overwritten, including the
     /// case that it was a directory.
     ///
+    /// Returns `true` if the entry is new, `false` if it replaced an existing entry.
+    ///
     /// # Arguments
     ///
     ///  * `filename`: the filename in the current directory.  If you need to support full
     ///    pathnames then you should call `Directory::split()` first.
     ///  * `inode`: the inode to store under the `filename`
-    pub fn insert(&mut self, filename: &OsStr, inode: Inode<T>) {
-        self.entries.insert(Box::from(filename), inode);
+    pub fn insert(&mut self, filename: &OsStr, inode: Inode<T>) -> bool {
+        self.entries.insert(Box::from(filename), inode).is_none()
     }
 
     /// Removes the named file from the directory, if it exists.  If it doesn't exist, this is a

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -3470,16 +3470,17 @@ mod tests {
     /// Make a test in-memory filesystem that only contains one externally referenced object
     fn make_test_fs(obj: &Sha512HashValue, size: u64) -> FileSystem<Sha512HashValue> {
         let mut fs: FileSystem<Sha512HashValue> = FileSystem::new(test_root_stat());
-        let inode = Inode::Leaf(std::rc::Rc::new(Leaf {
-            stat: Stat {
+        let leaf_id = fs.push_leaf(
+            Stat {
                 st_mode: 0o644,
                 st_uid: 0,
                 st_gid: 0,
                 st_mtim_sec: 0,
                 xattrs: Default::default(),
             },
-            content: LeafContent::Regular(RegularFile::External(obj.clone(), size)),
-        }));
+            LeafContent::Regular(RegularFile::External(obj.clone(), size)),
+        );
+        let inode = Inode::leaf(leaf_id);
         fs.root.insert(OsStr::new("data"), inode);
         fs
     }
@@ -3631,16 +3632,17 @@ mod tests {
         size2: u64,
     ) -> FileSystem<Sha512HashValue> {
         let mut fs = make_test_fs(obj1, size1);
-        let inode = Inode::Leaf(std::rc::Rc::new(Leaf {
-            stat: Stat {
+        let leaf_id = fs.push_leaf(
+            Stat {
                 st_mode: 0o644,
                 st_uid: 0,
                 st_gid: 0,
                 st_mtim_sec: 0,
                 xattrs: Default::default(),
             },
-            content: LeafContent::Regular(RegularFile::External(obj2.clone(), size2)),
-        }));
+            LeafContent::Regular(RegularFile::External(obj2.clone(), size2)),
+        );
+        let inode = Inode::leaf(leaf_id);
         fs.root.insert(OsStr::new("extra_data"), inode);
         fs
     }

--- a/crates/composefs/src/test.rs
+++ b/crates/composefs/src/test.rs
@@ -113,12 +113,10 @@ impl<ObjectID: FsVerityHashValue> Default for TestRepo<ObjectID> {
 #[cfg(test)]
 pub(crate) mod proptest_strategies {
     use std::{
-        cell::RefCell,
         collections::BTreeMap,
         ffi::{OsStr, OsString},
         mem,
         os::unix::ffi::OsStringExt,
-        rc::Rc,
     };
 
     use proptest::prelude::*;
@@ -126,6 +124,7 @@ pub(crate) mod proptest_strategies {
     use crate::{
         INLINE_CONTENT_MAX_V0,
         fsverity::FsVerityHashValue,
+        generic_tree::LeafId,
         tree::{self, RegularFile},
     };
 
@@ -173,7 +172,7 @@ pub(crate) mod proptest_strategies {
                 st_uid: uid,
                 st_gid: gid,
                 st_mtim_sec: mtime,
-                xattrs: RefCell::new(xattrs),
+                xattrs,
             })
     }
 
@@ -449,30 +448,24 @@ pub(crate) mod proptest_strategies {
     ) -> tree::FileSystem<ObjectID> {
         let mut fs = tree::FileSystem::new(spec.root.stat);
 
-        let mut all_leaves: Vec<Rc<tree::Leaf<ObjectID>>> = Vec::new();
+        let mut all_leaf_ids: Vec<LeafId> = Vec::new();
         let mut used_names: std::collections::HashSet<OsString> = std::collections::HashSet::new();
 
         // Insert root-level leaves
         for (name, leaf_spec) in spec.root.leaves {
-            let leaf = Rc::new(tree::Leaf {
-                stat: leaf_spec.stat,
-                content: build_leaf_content(leaf_spec.content),
-            });
-            all_leaves.push(Rc::clone(&leaf));
+            let leaf_id = fs.push_leaf(leaf_spec.stat, build_leaf_content(leaf_spec.content));
+            all_leaf_ids.push(leaf_id);
             used_names.insert(name.clone());
-            fs.root.insert(&name, tree::Inode::Leaf(leaf));
+            fs.root.insert(&name, tree::Inode::leaf(leaf_id));
         }
 
         // Insert subdirectories
         for (dir_name, dir_spec) in spec.root.subdirs {
             let mut subdir = tree::Directory::new(dir_spec.stat);
             for (name, leaf_spec) in dir_spec.leaves {
-                let leaf = Rc::new(tree::Leaf {
-                    stat: leaf_spec.stat,
-                    content: build_leaf_content(leaf_spec.content),
-                });
-                all_leaves.push(Rc::clone(&leaf));
-                subdir.insert(&name, tree::Inode::Leaf(leaf));
+                let leaf_id = fs.push_leaf(leaf_spec.stat, build_leaf_content(leaf_spec.content));
+                all_leaf_ids.push(leaf_id);
+                subdir.insert(&name, tree::Inode::leaf(leaf_id));
             }
             used_names.insert(dir_name.clone());
             fs.root
@@ -481,16 +474,14 @@ pub(crate) mod proptest_strategies {
 
         // Insert hardlinks into the root directory
         for hl in &spec.hardlinks {
-            if !all_leaves.is_empty() {
-                let idx = hl.source_index % all_leaves.len();
+            if !all_leaf_ids.is_empty() {
+                let idx = hl.source_index % all_leaf_ids.len();
                 if used_names.insert(hl.link_name.clone()) {
-                    let leaf = Rc::clone(&all_leaves[idx]);
-                    fs.root.insert(&hl.link_name, tree::Inode::Leaf(leaf));
+                    let leaf_id = all_leaf_ids[idx];
+                    fs.root.insert(&hl.link_name, tree::Inode::leaf(leaf_id));
                 }
             }
         }
-        // Drop the temporary refs used for hardlink indexing
-        drop(all_leaves);
 
         fs
     }

--- a/crates/composefs/src/tree.rs
+++ b/crates/composefs/src/tree.rs
@@ -39,12 +39,16 @@ pub type Inode<T> = generic_tree::Inode<RegularFile<T>>;
 /// A complete filesystem tree, specialized for composefs regular files.
 pub type FileSystem<T> = generic_tree::FileSystem<RegularFile<T>>;
 
+/// A read-only view of a directory paired with its leaves table, specialized for composefs regular files.
+pub type DirectoryRef<'a, T> = generic_tree::DirectoryRef<'a, RegularFile<T>>;
+
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, collections::BTreeMap, ffi::OsStr, rc::Rc};
+    use std::{collections::BTreeMap, ffi::OsStr};
 
     use super::*;
     use crate::fsverity::Sha256HashValue;
+    use crate::generic_tree::LeafId;
 
     // Helper to create a Stat with a specific mtime
     fn stat_with_mtime(mtime: i64) -> Stat {
@@ -53,7 +57,7 @@ mod tests {
             st_uid: 1000,
             st_gid: 1000,
             st_mtim_sec: mtime,
-            xattrs: RefCell::new(BTreeMap::new()),
+            xattrs: BTreeMap::new(),
         }
     }
 
@@ -65,14 +69,6 @@ mod tests {
         }))
     }
 
-    // Helper to create a simple Leaf (e.g., an empty inline file)
-    fn new_leaf_file(mtime: i64) -> Rc<Leaf<Sha256HashValue>> {
-        Rc::new(Leaf {
-            stat: stat_with_mtime(mtime),
-            content: LeafContent::Regular(super::RegularFile::Inline(Default::default())),
-        })
-    }
-
     // Helper for default stat in tests
     fn default_stat() -> Stat {
         Stat {
@@ -80,21 +76,27 @@ mod tests {
             st_uid: 0,
             st_gid: 0,
             st_mtim_sec: 0,
-            xattrs: RefCell::new(BTreeMap::new()),
+            xattrs: BTreeMap::new(),
         }
     }
 
     #[test]
     fn test_insert_and_get_leaf() {
+        let mut leaves: Vec<Leaf<Sha256HashValue>> = Vec::new();
+        let leaf_id = LeafId(leaves.len());
+        leaves.push(Leaf {
+            stat: stat_with_mtime(10),
+            content: LeafContent::Regular(super::RegularFile::Inline(Default::default())),
+        });
+
         let mut dir = Directory::<Sha256HashValue>::new(default_stat());
-        let leaf = new_leaf_file(10);
-        dir.insert(OsStr::new("file.txt"), Inode::Leaf(Rc::clone(&leaf)));
+        dir.insert(OsStr::new("file.txt"), Inode::leaf(leaf_id));
         assert_eq!(dir.entries.len(), 1);
 
-        let retrieved_leaf_rc = dir.ref_leaf(OsStr::new("file.txt")).unwrap();
-        assert!(Rc::ptr_eq(&retrieved_leaf_rc, &leaf));
+        let retrieved_id = dir.leaf_id(OsStr::new("file.txt")).unwrap();
+        assert_eq!(retrieved_id, leaf_id);
 
-        let regular_file_content = dir.get_file(OsStr::new("file.txt")).unwrap();
+        let regular_file_content = dir.get_file(OsStr::new("file.txt"), &leaves).unwrap();
         assert!(matches!(
             regular_file_content,
             super::RegularFile::Inline(_)

--- a/crates/composefs/tests/mkfs.rs
+++ b/crates/composefs/tests/mkfs.rs
@@ -1,12 +1,10 @@
 //! Tests for mkfs
 
 use std::{
-    cell::RefCell,
     collections::BTreeMap,
     ffi::OsStr,
     io::Write,
     process::{Command, Stdio},
-    rc::Rc,
 };
 
 use similar_asserts::assert_eq;
@@ -16,7 +14,7 @@ use composefs::{
     dumpfile::write_dumpfile,
     erofs::{debug::debug_img, writer::mkfs_erofs},
     fsverity::{FsVerityHashValue, Sha256HashValue},
-    tree::{Directory, FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
+    tree::{FileSystem, Inode, Leaf, LeafContent, RegularFile, Stat},
 };
 
 fn default_stat() -> Stat {
@@ -25,7 +23,7 @@ fn default_stat() -> Stat {
         st_uid: 0,
         st_gid: 0,
         st_mtim_sec: 0,
-        xattrs: RefCell::new(BTreeMap::new()),
+        xattrs: BTreeMap::new(),
     }
 }
 
@@ -46,23 +44,21 @@ fn test_empty() {
 }
 
 fn add_leaf<ObjectID: FsVerityHashValue>(
-    dir: &mut Directory<ObjectID>,
+    fs: &mut FileSystem<ObjectID>,
     name: impl AsRef<OsStr>,
     content: LeafContent<ObjectID>,
 ) {
-    dir.insert(
-        name.as_ref(),
-        Inode::Leaf(Rc::new(Leaf {
-            content,
-            stat: Stat {
-                st_gid: 0,
-                st_uid: 0,
-                st_mode: 0,
-                st_mtim_sec: 0,
-                xattrs: RefCell::new(BTreeMap::new()),
-            },
-        })),
+    let leaf_id = fs.push_leaf(
+        Stat {
+            st_gid: 0,
+            st_uid: 0,
+            st_mode: 0,
+            st_mtim_sec: 0,
+            xattrs: BTreeMap::new(),
+        },
+        content,
     );
+    fs.root.insert(name.as_ref(), Inode::leaf(leaf_id));
 }
 
 fn simple(fs: &mut FileSystem<Sha256HashValue>) {
@@ -70,22 +66,22 @@ fn simple(fs: &mut FileSystem<Sha256HashValue>) {
         "5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a",
     )
     .unwrap();
-    add_leaf(&mut fs.root, "fifo", LeafContent::Fifo);
+    add_leaf(fs, "fifo", LeafContent::Fifo);
     add_leaf(
-        &mut fs.root,
+        fs,
         "regular-inline",
         LeafContent::Regular(RegularFile::Inline((*b"hihi").into())),
     );
     add_leaf(
-        &mut fs.root,
+        fs,
         "regular-external",
         LeafContent::Regular(RegularFile::External(ext_id, 1234)),
     );
-    add_leaf(&mut fs.root, "chrdev", LeafContent::CharacterDevice(123));
-    add_leaf(&mut fs.root, "blkdev", LeafContent::BlockDevice(123));
-    add_leaf(&mut fs.root, "socket", LeafContent::Socket);
+    add_leaf(fs, "chrdev", LeafContent::CharacterDevice(123));
+    add_leaf(fs, "blkdev", LeafContent::BlockDevice(123));
+    add_leaf(fs, "socket", LeafContent::Socket);
     add_leaf(
-        &mut fs.root,
+        fs,
         "symlink",
         LeafContent::Symlink(OsStr::new("/target").into()),
     );


### PR DESCRIPTION
In trying to update to the newer fuse crate, it wants to do multithreaded stuff, and that just breaks with the `Rc` inside `FileSystem`.

Similarly - I recently changed our local filesystem scanning to be async, and the `Rc` usage made it less ergonomic.

There are 3 cases we care about:

- Borrowed, immutable in memory tree (no interior mut needed!)
- Owned &mut version
- Merging/flattening two trees

I think it's just more natural for us to represent the filesystem with a set of inodes, plus the recursive tree pointing to those.

Assisted-by: OpenCode (Claude Opus 4)