### PR TITLE
repo: Support reading and upgrading from older composefs-rs repos

### DIFF
--- a/crates/cfsctl/src/lib.rs
+++ b/crates/cfsctl/src/lib.rs
@@ -99,6 +99,12 @@ pub struct App {
     #[clap(long)]
     require_verity: bool,
 
+    /// Don't automatically upgrade old-format repositories.
+    /// When set, commands will fail on repos without meta.json instead
+    /// of inferring metadata from existing objects.
+    #[clap(long)]
+    no_upgrade: bool,
+
     /// Don't open a repository. Only valid for commands that don't need one
     /// (compute-id, create-dumpfile).
     #[clap(long)]
@@ -537,13 +543,17 @@ fn resolve_repo_path(args: &App) -> Result<PathBuf> {
 /// Resolution order:
 /// 1. If `meta.json` exists, use its algorithm. Error if `--hash` was
 ///    explicitly passed and conflicts.
-/// 2. If no metadata, use `--hash` if given.
-/// 3. Otherwise default to sha512.
+/// 2. If no metadata and `upgrade` is true, infer from existing objects.
+/// 3. If no metadata and `upgrade` is false, error.
 ///
 /// Note: we read the metadata file directly here (rather than via
 /// `Repository::metadata`) because this runs *before* we know which
 /// generic `ObjectID` type to use — that's exactly what we're deciding.
-fn resolve_hash_type(repo_path: &Path, cli_hash: Option<HashType>) -> Result<HashType> {
+fn resolve_hash_type(
+    repo_path: &Path,
+    cli_hash: Option<HashType>,
+    upgrade: bool,
+) -> Result<HashType> {
     let repo_fd = rustix::fs::open(
         repo_path,
         OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
@@ -551,13 +561,26 @@ fn resolve_hash_type(repo_path: &Path, cli_hash: Option<HashType>) -> Result<Has
     )
     .with_context(|| format!("opening repository {}", repo_path.display()))?;
 
-    let algorithm = read_repo_algorithm(&repo_fd)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "{REPO_METADATA_FILENAME} not found in {}; \
-             this repository must be initialized with `cfsctl init`",
-            repo_path.display(),
-        )
-    })?;
+    let algorithm = match read_repo_algorithm(&repo_fd)? {
+        Some(alg) => alg,
+        None if upgrade => {
+            // No meta.json — try to infer from objects (old-format repo).
+            // open_upgrade will write meta.json later when the repo is opened.
+            composefs::repository::infer_repo_algorithm(&repo_fd).with_context(|| {
+                format!(
+                    "no {REPO_METADATA_FILENAME} in {}; tried to infer algorithm from objects",
+                    repo_path.display(),
+                )
+            })?
+        }
+        None => {
+            anyhow::bail!(
+                "{REPO_METADATA_FILENAME} not found in {}; \
+                 this repository must be initialized with `cfsctl init`",
+                repo_path.display(),
+            );
+        }
+    };
 
     let detected = match algorithm {
         Algorithm::Sha256 { .. } => HashType::Sha256,
@@ -614,7 +637,7 @@ pub async fn run_app(args: App) -> Result<()> {
         // instead of the default SHA-512.
         let effective_hash = if !args.no_repo {
             if let Ok(repo_path) = resolve_repo_path(&args) {
-                resolve_hash_type(&repo_path, args.hash)
+                resolve_hash_type(&repo_path, args.hash, !args.no_upgrade)
                     .unwrap_or(args.hash.unwrap_or(HashType::Sha512))
             } else {
                 args.hash.unwrap_or(HashType::Sha512)
@@ -629,7 +652,7 @@ pub async fn run_app(args: App) -> Result<()> {
     }
 
     let repo_path = resolve_repo_path(&args)?;
-    let effective_hash = resolve_hash_type(&repo_path, args.hash)?;
+    let effective_hash = resolve_hash_type(&repo_path, args.hash, !args.no_upgrade)?;
 
     match effective_hash {
         HashType::Sha256 => run_cmd_with_repo(open_repo::<Sha256HashValue>(&args)?, args).await,
@@ -690,13 +713,18 @@ fn run_init(
     Ok(())
 }
 
-/// Open a repo
+/// Open a repo, auto-upgrading old-format repos unless `--no-upgrade` was passed.
 pub fn open_repo<ObjectID>(args: &App) -> Result<Repository<ObjectID>>
 where
     ObjectID: FsVerityHashValue,
 {
     let path = resolve_repo_path(args)?;
-    let mut repo = Repository::open_path(CWD, path)?;
+    let mut repo = if args.no_upgrade {
+        Repository::open_path(CWD, path)?
+    } else {
+        let (repo, _upgraded) = Repository::open_upgrade(CWD, path)?;
+        repo
+    };
     // Hidden --insecure flag for backward compatibility; the default
     // now is to inherit the repo config, but if it's specified we
     // disable requiring verity even if the repo says to use it.

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -31,7 +31,7 @@ pub use composefs;
 
 use std::{collections::HashMap, sync::Arc};
 
-use anyhow::{Result, ensure};
+use anyhow::{Context, Result, ensure};
 /// OCI content-addressable digest type (e.g. `sha256:abcd...`).
 ///
 /// Re-exported from `oci-spec` for convenience.
@@ -508,6 +508,71 @@ pub fn composefs_boot_erofs_for_manifest<ObjectID: FsVerityHashValue>(
     Ok(img.boot_image_ref().cloned())
 }
 
+/// Result of a repository upgrade operation.
+#[derive(Debug, Clone, Default)]
+pub struct UpgradeResult {
+    /// Number of images that already had EROFS (skipped).
+    pub already_current: u64,
+    /// Number of images that were upgraded (EROFS generated).
+    pub upgraded: u64,
+    /// Number of non-container images skipped (artifacts, etc.).
+    pub skipped_non_container: u64,
+}
+
+/// Upgrades all tagged OCI images in the repository to the current format.
+///
+/// For each tagged container image, this ensures a composefs EROFS image
+/// exists and is linked to the config splitstream. Images that already have
+/// an EROFS ref are skipped. Non-container images (artifacts) are also skipped.
+///
+/// This is the migration path for repositories created by older versions of
+/// composefs-rs (e.g. bootc ≤ 1.15.x) that did not generate EROFS at pull
+/// time. Old-format splitstream headers (pre-`repr(C)`) are read transparently;
+/// the rewritten config and manifest splitstreams use the current format.
+///
+/// After upgrading, callers should run [`Repository::gc`] to clean up
+/// unreferenced old config and manifest splitstream objects.
+pub fn upgrade_repo<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+) -> Result<UpgradeResult> {
+    let mut result = UpgradeResult::default();
+
+    for (tag, manifest_digest) in oci_image::list_refs(repo)? {
+        let img = oci_image::OciImage::open(repo, &manifest_digest, None)
+            .with_context(|| format!("opening image {tag}"))?;
+
+        if !img.is_container_image() {
+            tracing::debug!("skipping non-container image {tag}");
+            result.skipped_non_container += 1;
+            continue;
+        }
+
+        if img.image_ref().is_some() {
+            tracing::debug!("image {tag} already has EROFS ref, skipping");
+            result.already_current += 1;
+            continue;
+        }
+
+        let erofs_id = ensure_oci_composefs_erofs(
+            repo,
+            &manifest_digest,
+            Some(img.manifest_verity()),
+            Some(&tag),
+        )
+        .with_context(|| format!("generating EROFS for image {tag}"))?;
+
+        if erofs_id.is_some() {
+            tracing::info!("upgraded image {tag}");
+            result.upgraded += 1;
+        } else {
+            tracing::debug!("image {tag} produced no EROFS (not a container image?)");
+            result.skipped_non_container += 1;
+        }
+    }
+
+    Ok(result)
+}
+
 /// Writes a container configuration to the repository.
 ///
 /// Serializes the image configuration to JSON and stores it as a split stream with the
@@ -693,6 +758,35 @@ mod test {
     use composefs::{fsverity::Sha256HashValue, repository::Repository, test::tempdir};
 
     use super::*;
+
+    /// Expected composefs dumpfile output for the base test image created by
+    /// [`test_util::create_base_image`]. Used across multiple tests to verify
+    /// EROFS round-trip correctness.
+    const EXPECTED_BASE_IMAGE_DUMPFILE: &str = "\
+/ 0 40755 6 0 0 0 0.0 - - -
+/etc 0 40755 2 0 0 0 0.0 - - -
+/etc/hostname 9 100644 1 0 0 0 0.0 - test-host -
+/etc/os-release 23 100644 1 0 0 0 0.0 - ID=test\\nVERSION_ID=1.0\\n -
+/etc/passwd 100 100644 1 0 0 0 0.0 f2/c4fd5735bd46db3b18d402ae87c5086c97c0e1321901cfd30f320b73ef25aa - f2c4fd5735bd46db3b18d402ae87c5086c97c0e1321901cfd30f320b73ef25aa
+/tmp 0 40755 2 0 0 0 0.0 - - -
+/usr 0 40755 5 0 0 0 0.0 - - -
+/usr/bin 0 40755 2 0 0 0 0.0 - - -
+/usr/bin/busybox 4096 100755 1 0 0 0 0.0 f0/f7e1e58fdd31f5792222087377a4a976760c416ecdf5f426193e608681b7a1 - f0f7e1e58fdd31f5792222087377a4a976760c416ecdf5f426193e608681b7a1
+/usr/bin/cat 7 120777 1 0 0 0 0.0 busybox - -
+/usr/bin/cp 7 120777 1 0 0 0 0.0 busybox - -
+/usr/bin/ls 7 120777 1 0 0 0 0.0 busybox - -
+/usr/bin/mv 7 120777 1 0 0 0 0.0 busybox - -
+/usr/bin/ping 7 120777 1 0 0 0 0.0 busybox - - security.capability=\\x02\\x00\\x00\\x02\\x00\\x20\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
+/usr/bin/rm 7 120777 1 0 0 0 0.0 busybox - -
+/usr/bin/sh 7 120777 1 0 0 0 0.0 busybox - -
+/usr/lib 0 40755 2 0 0 0 0.0 - - -
+/usr/share 0 40755 3 0 0 0 0.0 - - -
+/usr/share/doc 0 40755 2 0 0 0 0.0 - - -
+/usr/share/doc/README 512 100644 1 0 0 0 0.0 51/44b8f80be57c3518f410d930e18c4e405387c82e4993c18265a1ba4a80263b - 5144b8f80be57c3518f410d930e18c4e405387c82e4993c18265a1ba4a80263b
+/var 0 40755 3 0 0 0 0.0 - - -
+/var/data 0 40755 2 0 0 0 0.0 - - -
+/var/data/app.json 256 100644 1 0 0 0 0.0 c9/21965b74ac1780bc437cec640b27186d85317b9afdb3dbb68626aed5ecd2b6 - c921965b74ac1780bc437cec640b27186d85317b9afdb3dbb68626aed5ecd2b6
+";
 
     /// Create a test repository with meta.json in insecure mode.
     fn create_test_repo() -> (tempfile::TempDir, Arc<Repository<Sha256HashValue>>) {
@@ -1023,34 +1117,7 @@ mod test {
         let mut dump = Vec::new();
         composefs::dumpfile::write_dumpfile(&mut dump, &fs).unwrap();
         let dump = String::from_utf8(dump).unwrap();
-        similar_asserts::assert_eq!(
-            dump,
-            "\
-/ 0 40755 6 0 0 0 0.0 - - -
-/etc 0 40755 2 0 0 0 0.0 - - -
-/etc/hostname 9 100644 1 0 0 0 0.0 - test-host -
-/etc/os-release 23 100644 1 0 0 0 0.0 - ID=test\\nVERSION_ID=1.0\\n -
-/etc/passwd 100 100644 1 0 0 0 0.0 f2/c4fd5735bd46db3b18d402ae87c5086c97c0e1321901cfd30f320b73ef25aa - f2c4fd5735bd46db3b18d402ae87c5086c97c0e1321901cfd30f320b73ef25aa
-/tmp 0 40755 2 0 0 0 0.0 - - -
-/usr 0 40755 5 0 0 0 0.0 - - -
-/usr/bin 0 40755 2 0 0 0 0.0 - - -
-/usr/bin/busybox 4096 100755 1 0 0 0 0.0 f0/f7e1e58fdd31f5792222087377a4a976760c416ecdf5f426193e608681b7a1 - f0f7e1e58fdd31f5792222087377a4a976760c416ecdf5f426193e608681b7a1
-/usr/bin/cat 7 120777 1 0 0 0 0.0 busybox - -
-/usr/bin/cp 7 120777 1 0 0 0 0.0 busybox - -
-/usr/bin/ls 7 120777 1 0 0 0 0.0 busybox - -
-/usr/bin/mv 7 120777 1 0 0 0 0.0 busybox - -
-/usr/bin/ping 7 120777 1 0 0 0 0.0 busybox - - security.capability=\\x02\\x00\\x00\\x02\\x00\\x20\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
-/usr/bin/rm 7 120777 1 0 0 0 0.0 busybox - -
-/usr/bin/sh 7 120777 1 0 0 0 0.0 busybox - -
-/usr/lib 0 40755 2 0 0 0 0.0 - - -
-/usr/share 0 40755 3 0 0 0 0.0 - - -
-/usr/share/doc 0 40755 2 0 0 0 0.0 - - -
-/usr/share/doc/README 512 100644 1 0 0 0 0.0 51/44b8f80be57c3518f410d930e18c4e405387c82e4993c18265a1ba4a80263b - 5144b8f80be57c3518f410d930e18c4e405387c82e4993c18265a1ba4a80263b
-/var 0 40755 3 0 0 0 0.0 - - -
-/var/data 0 40755 2 0 0 0 0.0 - - -
-/var/data/app.json 256 100644 1 0 0 0 0.0 c9/21965b74ac1780bc437cec640b27186d85317b9afdb3dbb68626aed5ecd2b6 - c921965b74ac1780bc437cec640b27186d85317b9afdb3dbb68626aed5ecd2b6
-"
-        );
+        similar_asserts::assert_eq!(dump, EXPECTED_BASE_IMAGE_DUMPFILE);
     }
 
     #[tokio::test]
@@ -1555,5 +1622,241 @@ mod test {
                 "{path} should have been removed by whiteout but is still present"
             );
         }
+    }
+
+    /// Verify that the full OCI pipeline works when all splitstreams use the
+    /// old (pre-repr(C)) header layout — the format that bootc <= 1.15.x wrote.
+    ///
+    /// Old-format writing stays on throughout, including EROFS generation, so
+    /// the rewritten config+manifest splitstreams are also old-format. This
+    /// exercises the complete read-old → write-old → read-old-again chain.
+    #[tokio::test]
+    async fn test_old_format_splitstream_oci_roundtrip() {
+        use composefs::test::TestRepo;
+
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = &test_repo.repo;
+
+        // Enable old-format writing for the entire test — layers, config,
+        // manifest, and the rewritten config+manifest after EROFS generation
+        // all get old-format headers.
+        repo.set_write_old_splitstream_format(true);
+        let img = test_util::create_base_image(repo, Some("old:v1")).await;
+
+        // Verify open_config still works with old-format splitstreams
+        let oci = oci_image::OciImage::open_ref(repo, "old:v1").unwrap();
+        let oc = open_config(repo, oci.config_digest(), Some(oci.config_verity())).unwrap();
+        assert_eq!(oc.config.architecture().to_string(), "amd64");
+        assert!(
+            oc.image_ref.is_none(),
+            "pre-EROFS image should have no image ref"
+        );
+
+        // Verify create_filesystem works (reads old-format layer splitstreams)
+        let fs =
+            image::create_filesystem(repo, oci.config_digest(), Some(oci.config_verity())).unwrap();
+        let mut fs_dump = Vec::new();
+        composefs::dumpfile::write_dumpfile(&mut fs_dump, &fs).unwrap();
+        assert!(
+            !fs_dump.is_empty(),
+            "filesystem should contain entries from old-format layers"
+        );
+
+        // Generate EROFS with old-format still enabled — the rewritten
+        // config+manifest splitstreams also get old-format headers.
+        let erofs_id = ensure_oci_composefs_erofs(
+            repo,
+            &img.manifest_digest,
+            Some(&img.manifest_verity),
+            Some("old:v1"),
+        )
+        .unwrap()
+        .expect("container image should produce EROFS");
+
+        // The rewritten config+manifest are old-format; verify we can
+        // still open the image and read back the EROFS ref through them.
+        let oci_after = oci_image::OciImage::open_ref(repo, "old:v1").unwrap();
+        assert_eq!(
+            oci_after.image_ref(),
+            Some(&erofs_id),
+            "old-format rewritten config should reference the EROFS image"
+        );
+
+        let erofs_data = repo.read_object(&erofs_id).unwrap();
+        let erofs_fs =
+            composefs::erofs::reader::erofs_to_filesystem::<Sha256HashValue>(&erofs_data).unwrap();
+        let mut dump = Vec::new();
+        composefs::dumpfile::write_dumpfile(&mut dump, &erofs_fs).unwrap();
+        let dump = String::from_utf8(dump).unwrap();
+        similar_asserts::assert_eq!(dump, EXPECTED_BASE_IMAGE_DUMPFILE);
+    }
+
+    /// Simulate upgrading from the pre-EROFS-at-pull-time layout with old-format
+    /// splitstreams. This covers the case of a system that was running
+    /// bootc <= 1.15.x (old splitstream format, no EROFS generated at pull)
+    /// and then upgrades to current code.
+    #[tokio::test]
+    async fn test_pre_erofs_pull_upgrade_with_old_format() {
+        use composefs::test::TestRepo;
+
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = &test_repo.repo;
+
+        // Write everything in old format — simulates bootc <= 1.15.x
+        repo.set_write_old_splitstream_format(true);
+        // create_base_image does NOT call ensure_oci_composefs_erofs,
+        // so this represents the "pre-EROFS-at-pull-time" layout.
+        let img = test_util::create_base_image(repo, Some("upgrade:v1")).await;
+        repo.set_write_old_splitstream_format(false);
+
+        // Verify image_ref is None (no EROFS yet)
+        let oci_before = oci_image::OciImage::open_ref(repo, "upgrade:v1").unwrap();
+        assert!(
+            oci_before.image_ref().is_none(),
+            "pre-EROFS pull should have no image ref"
+        );
+
+        // Upgrade: ensure_oci_composefs_erofs reads old-format splitstreams,
+        // generates EROFS, and rewrites config+manifest in new format.
+        let erofs_id = ensure_oci_composefs_erofs(
+            repo,
+            &img.manifest_digest,
+            Some(&img.manifest_verity),
+            Some("upgrade:v1"),
+        )
+        .unwrap()
+        .expect("container image should produce EROFS");
+
+        // Verify the OciImage now has image_ref
+        let oci_after = oci_image::OciImage::open_ref(repo, "upgrade:v1").unwrap();
+        assert_eq!(
+            oci_after.image_ref(),
+            Some(&erofs_id),
+            "config should reference the EROFS image after upgrade"
+        );
+
+        // Verify the EROFS image is accessible
+        assert!(
+            repo.open_image(&erofs_id.to_hex()).is_ok(),
+            "EROFS image should be accessible"
+        );
+
+        // Verify the EROFS content matches expected dumpfile
+        let erofs_data = repo.read_object(&erofs_id).unwrap();
+        let erofs_fs =
+            composefs::erofs::reader::erofs_to_filesystem::<Sha256HashValue>(&erofs_data).unwrap();
+        let mut dump = Vec::new();
+        composefs::dumpfile::write_dumpfile(&mut dump, &erofs_fs).unwrap();
+        let dump = String::from_utf8(dump).unwrap();
+        similar_asserts::assert_eq!(dump, EXPECTED_BASE_IMAGE_DUMPFILE);
+
+        // GC: old config+manifest splitstreams (2 objects) are now unreferenced
+        let gc1 = repo.gc(&[]).unwrap();
+        assert_eq!(
+            gc1.objects_removed, 2,
+            "old config+manifest splitstream objects"
+        );
+        assert_eq!(gc1.streams_pruned, 0);
+        assert_eq!(gc1.images_pruned, 0);
+
+        // Untag and GC — everything gets collected
+        oci_image::untag_image(repo, "upgrade:v1").unwrap();
+        let gc2 = repo.gc(&[]).unwrap();
+        assert_eq!(gc2.objects_removed, 14, "all objects collected after untag");
+        assert_eq!(gc2.streams_pruned, 7, "all stream symlinks pruned");
+        assert_eq!(gc2.images_pruned, 1, "EROFS image symlink pruned");
+    }
+
+    /// Verify that `upgrade_repo` walks all tagged images, generates EROFS for
+    /// those missing it, and is idempotent on subsequent runs.
+    #[tokio::test]
+    async fn test_upgrade_repo() {
+        use composefs::test::TestRepo;
+
+        let test_repo = TestRepo::<Sha256HashValue>::new();
+        let repo = &test_repo.repo;
+
+        // Simulate old-format pulls (no EROFS generated at pull time)
+        repo.set_write_old_splitstream_format(true);
+        let _img1 = test_util::create_base_image(repo, Some("app:v1")).await;
+        let _img2 = test_util::create_bootable_image(repo, Some("os:v1"), 1).await;
+        repo.set_write_old_splitstream_format(false);
+
+        // Verify neither image has an EROFS ref yet
+        let oci1 = oci_image::OciImage::open_ref(repo, "app:v1").unwrap();
+        assert!(
+            oci1.image_ref().is_none(),
+            "app:v1 should have no EROFS ref before upgrade"
+        );
+        let oci2 = oci_image::OciImage::open_ref(repo, "os:v1").unwrap();
+        assert!(
+            oci2.image_ref().is_none(),
+            "os:v1 should have no EROFS ref before upgrade"
+        );
+
+        // First upgrade: both images should be upgraded
+        let result = upgrade_repo(repo).unwrap();
+        assert_eq!(result.upgraded, 2, "both images should be upgraded");
+        assert_eq!(result.already_current, 0, "none should be already current");
+        assert_eq!(result.skipped_non_container, 0);
+
+        // Verify both images now have EROFS refs
+        let oci1_after = oci_image::OciImage::open_ref(repo, "app:v1").unwrap();
+        let erofs1 = oci1_after
+            .image_ref()
+            .expect("app:v1 should have EROFS ref after upgrade");
+        assert!(
+            repo.open_image(&erofs1.to_hex()).is_ok(),
+            "app:v1 EROFS image should be accessible"
+        );
+        let oci2_after = oci_image::OciImage::open_ref(repo, "os:v1").unwrap();
+        let erofs2 = oci2_after
+            .image_ref()
+            .expect("os:v1 should have EROFS ref after upgrade");
+        assert!(
+            repo.open_image(&erofs2.to_hex()).is_ok(),
+            "os:v1 EROFS image should be accessible"
+        );
+
+        // Second upgrade: idempotent — both should be skipped
+        let result2 = upgrade_repo(repo).unwrap();
+        assert_eq!(result2.upgraded, 0, "no images should need upgrading");
+        assert_eq!(result2.already_current, 2, "both should be already current");
+        assert_eq!(result2.skipped_non_container, 0);
+
+        // GC should collect old config+manifest splitstream objects
+        // (2 per image = 4 total)
+        let gc = repo.gc(&[]).unwrap();
+        assert_eq!(
+            gc.objects_removed, 4,
+            "old config+manifest splitstream objects from 2 images"
+        );
+
+        // EROFS images should survive GC
+        assert!(
+            repo.open_image(&erofs1.to_hex()).is_ok(),
+            "app:v1 EROFS image should survive GC"
+        );
+        assert!(
+            repo.open_image(&erofs2.to_hex()).is_ok(),
+            "os:v1 EROFS image should survive GC"
+        );
+
+        // Verify EROFS content is correct for the base image
+        let erofs_data = repo.read_object(erofs1).unwrap();
+        let fs =
+            composefs::erofs::reader::erofs_to_filesystem::<Sha256HashValue>(&erofs_data).unwrap();
+        let mut dump = Vec::new();
+        composefs::dumpfile::write_dumpfile(&mut dump, &fs).unwrap();
+        let dump = String::from_utf8(dump).unwrap();
+        // The base image EROFS should match what other tests produce
+        assert!(
+            dump.contains("/usr/bin/busybox"),
+            "EROFS should contain busybox"
+        );
+        assert!(
+            dump.contains("/etc/hostname"),
+            "EROFS should contain hostname"
+        );
     }
 }

--- a/crates/composefs/src/fsverity/mod.rs
+++ b/crates/composefs/src/fsverity/mod.rs
@@ -232,6 +232,18 @@ pub fn measure_verity_opt<H: FsVerityHashValue>(
     }
 }
 
+/// Check whether a file has fs-verity enabled, dispatching to the correct
+/// hash type based on the [`Algorithm`].
+///
+/// Returns `true` if verity is enabled, `false` if not (or if the filesystem
+/// does not support verity).
+pub(crate) fn has_verity(fd: impl AsFd, algorithm: Algorithm) -> Result<bool, MeasureVerityError> {
+    match algorithm {
+        Algorithm::Sha256 { .. } => Ok(measure_verity_opt::<Sha256HashValue>(fd)?.is_some()),
+        Algorithm::Sha512 { .. } => Ok(measure_verity_opt::<Sha512HashValue>(fd)?.is_some()),
+    }
+}
+
 /// Compare the fs-verity digest of the file versus the expected digest.
 ///
 /// This calls `measure_verity()` and verifies that the result is equal to the expected value.

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -108,9 +108,9 @@ use rustix::{
 
 use crate::{
     fsverity::{
-        Algorithm, CompareVerityError, EnableVerityError, FsVerityHashValue, FsVerityHasher,
-        MeasureVerityError, compute_verity, enable_verity_maybe_copy, ensure_verity_equal,
-        measure_verity, measure_verity_opt,
+        Algorithm, CompareVerityError, DEFAULT_LG_BLOCKSIZE, EnableVerityError, FsVerityHashValue,
+        FsVerityHasher, MeasureVerityError, compute_verity, enable_verity_maybe_copy,
+        ensure_verity_equal, has_verity, measure_verity, measure_verity_opt,
     },
     mount::{composefs_fsmount, mount_at},
     shared_internals::IO_BUF_CAPACITY,
@@ -133,7 +133,7 @@ pub enum RepositoryOpenError {
     /// `meta.json` is missing but `objects/` exists, indicating an
     /// old-format repository that predates `meta.json`.
     #[error(
-        "{REPO_METADATA_FILENAME} not found; this appears to be an old-format repository — run `cfsctl init --reset-metadata` to migrate"
+        "{REPO_METADATA_FILENAME} not found; this appears to be an old-format repository — use Repository::open_upgrade() or `cfsctl init` to migrate"
     )]
     OldFormatRepository,
     /// `meta.json` exists but could not be parsed.
@@ -521,6 +521,110 @@ pub(crate) fn write_repo_metadata(
     Ok(())
 }
 
+/// Infer repository metadata by examining existing objects.
+///
+/// Walks `objects/` to find any stored object, determines the hash
+/// algorithm from the filename length, and probes for fs-verity.
+///
+/// Returns `(Algorithm, has_verity)` or an error if the objects
+/// directory is empty or the algorithm can't be determined.
+fn infer_metadata(repo_fd: &OwnedFd) -> Result<(Algorithm, bool)> {
+    let objects_fd = openat(
+        repo_fd,
+        "objects",
+        OFlags::RDONLY | OFlags::CLOEXEC,
+        Mode::empty(),
+    )
+    .context("opening objects/ directory")?;
+
+    let dir = Dir::read_from(&objects_fd).context("reading objects/ directory")?;
+
+    for entry in dir {
+        let entry = entry.context("reading objects/ directory entry")?;
+        let subdir_name = entry.file_name().to_bytes();
+
+        if subdir_name == b"." || subdir_name == b".." {
+            continue;
+        }
+
+        // Each subdirectory should be a 2-char hex prefix
+        if subdir_name.len() != 2 {
+            continue;
+        }
+
+        let subdir_fd = openat(
+            &objects_fd,
+            entry.file_name(),
+            OFlags::RDONLY | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .with_context(|| {
+            format!(
+                "opening objects/{} subdirectory",
+                entry.file_name().to_string_lossy()
+            )
+        })?;
+
+        let subdir = Dir::read_from(&subdir_fd).context("reading object subdirectory")?;
+        for obj_entry in subdir {
+            let obj_entry = obj_entry.context("reading object subdirectory entry")?;
+            let obj_name = obj_entry.file_name().to_bytes();
+
+            if obj_name == b"." || obj_name == b".." {
+                continue;
+            }
+
+            // Infer algorithm from filename length.
+            // Objects are stored as objects/XX/<remaining_hex>, where XX is the first
+            // byte (2 hex chars). The filename is the remaining bytes in hex.
+            // SHA-256: 32 bytes total → 62 hex char filename
+            // SHA-512: 64 bytes total → 126 hex char filename
+            let algorithm = match obj_name.len() {
+                62 => Algorithm::Sha256 {
+                    lg_blocksize: DEFAULT_LG_BLOCKSIZE,
+                },
+                126 => Algorithm::Sha512 {
+                    lg_blocksize: DEFAULT_LG_BLOCKSIZE,
+                },
+                _ => continue,
+            };
+
+            let obj_fd = openat(
+                &subdir_fd,
+                obj_entry.file_name(),
+                OFlags::RDONLY | OFlags::CLOEXEC,
+                Mode::empty(),
+            )
+            .with_context(|| {
+                format!(
+                    "opening object file {}",
+                    obj_entry.file_name().to_string_lossy()
+                )
+            })?;
+
+            let has_verity =
+                has_verity(&obj_fd, algorithm).context("probing fs-verity on object")?;
+
+            return Ok((algorithm, has_verity));
+        }
+    }
+
+    bail!("no objects found in repository — cannot infer metadata");
+}
+
+/// Infer the repository algorithm by examining existing object filenames.
+///
+/// This is useful when `meta.json` is missing (old-format repos) and the
+/// caller needs to determine the hash type before constructing a typed
+/// [`Repository`].  For example, the CLI uses this to pick the correct
+/// `ObjectID` generic parameter before calling [`Repository::open_upgrade`].
+///
+/// Returns the inferred [`Algorithm`], or an error if the objects
+/// directory is empty or contains no recognizable filenames.
+pub fn infer_repo_algorithm(repo_fd: &OwnedFd) -> Result<Algorithm> {
+    Ok(infer_metadata(repo_fd)?.0)
+}
+
 /// How an object was stored in the repository.
 ///
 /// Returned by [`Repository::ensure_object_from_file`] to indicate
@@ -633,6 +737,11 @@ pub struct Repository<ObjectID: FsVerityHashValue> {
     write_semaphore: OnceCell<Arc<Semaphore>>,
     insecure: bool,
     metadata: RepoMetadata,
+    /// When true, SplitStreamWriter::done() writes old-format (pre-repr(C))
+    /// headers. Used to test backward compatibility with splitstreams
+    /// written before #[repr(C)] was added to SplitstreamHeader.
+    #[cfg(any(test, feature = "test"))]
+    write_old_splitstream_format: std::sync::atomic::AtomicBool,
     _data: std::marker::PhantomData<ObjectID>,
 }
 
@@ -895,6 +1004,24 @@ impl fmt::Display for FsckResult {
 }
 
 impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
+    /// Enable or disable writing old-format splitstream headers.
+    ///
+    /// When enabled, all splitstreams created via [`create_stream`] will be
+    /// written with the pre-`repr(C)` header layout, simulating data written
+    /// by composefs-rs versions before the `#[repr(C)]` fix.
+    #[cfg(any(test, feature = "test"))]
+    pub fn set_write_old_splitstream_format(&self, enabled: bool) {
+        self.write_old_splitstream_format
+            .store(enabled, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Whether splitstream writers should use the old (pre-repr(C)) header format.
+    #[cfg(any(test, feature = "test"))]
+    pub(crate) fn write_old_splitstream_format(&self) -> bool {
+        self.write_old_splitstream_format
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Return the objects directory.
     pub fn objects_dir(&self) -> ErrnoResult<&OwnedFd> {
         self.objects
@@ -1027,8 +1154,61 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
             write_semaphore: OnceCell::new(),
             insecure: !has_verity,
             metadata,
+            #[cfg(any(test, feature = "test"))]
+            write_old_splitstream_format: std::sync::atomic::AtomicBool::new(false),
             _data: std::marker::PhantomData,
         })
+    }
+
+    /// Open a repository, upgrading old-format repos that lack `meta.json`.
+    ///
+    /// This method first tries [`open_path`](Self::open_path). If that fails
+    /// with [`OldFormatRepository`](RepositoryOpenError::OldFormatRepository),
+    /// it infers the algorithm and verity mode from existing objects,
+    /// writes `meta.json`, and retries the open.
+    ///
+    /// This is the non-destructive upgrade path for repositories created
+    /// by composefs-rs versions that predated `meta.json`.
+    ///
+    /// Returns `(repo, upgraded)` where `upgraded` is true if `meta.json`
+    /// was written.
+    pub fn open_upgrade(dirfd: impl AsFd, path: impl AsRef<Path>) -> Result<(Self, bool)> {
+        let path = path.as_ref();
+
+        match Self::open_path(&dirfd, path) {
+            Ok(repo) => Ok((repo, false)),
+            Err(RepositoryOpenError::OldFormatRepository) => {
+                let repo_fd = openat(
+                    &dirfd,
+                    path,
+                    OFlags::RDONLY | OFlags::CLOEXEC,
+                    Mode::empty(),
+                )
+                .with_context(|| format!("opening repository directory {}", path.display()))?;
+
+                let (algorithm, has_verity) = infer_metadata(&repo_fd)?;
+
+                if !algorithm.is_compatible::<ObjectID>() {
+                    bail!(
+                        "inferred algorithm {} is not compatible with this repository type \
+                         (expected {})",
+                        algorithm,
+                        Algorithm::for_hash::<ObjectID>(),
+                    );
+                }
+
+                let meta = RepoMetadata::new(algorithm);
+                write_repo_metadata(&repo_fd, &meta, has_verity)?;
+
+                drop(repo_fd);
+
+                let repo = Self::open_path(&dirfd, path)
+                    .context("opening repository after writing meta.json")?;
+
+                Ok((repo, true))
+            }
+            Err(other) => Err(other.into()),
+        }
     }
 
     /// Read, parse, and probe verity on `meta.json`.
@@ -4769,5 +4949,150 @@ mod tests {
 
         // Verify Debug impl works
         assert_eq!(format!("{:?}", ObjectStoreMethod::Hardlinked), "Hardlinked");
+    }
+
+    // ---- open_upgrade tests ----
+
+    #[test]
+    fn test_open_upgrade_sha256() {
+        let tmp = tempdir();
+        let repo_path = tmp.path().join("repo");
+
+        // Create a repo, store an object, then remove meta.json to
+        // simulate an old-format repository.
+        let (repo, _) =
+            Repository::<Sha256HashValue>::init_path(CWD, &repo_path, Algorithm::SHA256, false)
+                .unwrap();
+        let data = b"hello world";
+        let obj_id = repo.ensure_object(data).unwrap();
+        drop(repo);
+
+        std::fs::remove_file(repo_path.join(REPO_METADATA_FILENAME)).unwrap();
+
+        // open_path should fail with OldFormatRepository
+        assert!(matches!(
+            Repository::<Sha256HashValue>::open_path(CWD, &repo_path),
+            Err(RepositoryOpenError::OldFormatRepository)
+        ));
+
+        // open_upgrade should infer metadata and succeed
+        let (repo, upgraded) =
+            Repository::<Sha256HashValue>::open_upgrade(CWD, &repo_path).unwrap();
+        assert!(upgraded);
+        assert!(repo_path.join(REPO_METADATA_FILENAME).exists());
+
+        // Verify the algorithm was inferred correctly
+        let meta = read_repo_metadata(
+            &openat(
+                CWD,
+                &repo_path,
+                OFlags::RDONLY | OFlags::CLOEXEC,
+                Mode::empty(),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(meta.algorithm.is_compatible::<Sha256HashValue>());
+
+        // The repo should work — read back the object
+        let read_data = repo.read_object(&obj_id).unwrap();
+        assert_eq!(&read_data[..], data);
+
+        // Second call should not upgrade
+        drop(repo);
+        let (_repo, upgraded) =
+            Repository::<Sha256HashValue>::open_upgrade(CWD, &repo_path).unwrap();
+        assert!(!upgraded);
+    }
+
+    #[test]
+    fn test_open_upgrade_sha512() {
+        let tmp = tempdir();
+        let repo_path = tmp.path().join("repo");
+
+        let (repo, _) =
+            Repository::<Sha512HashValue>::init_path(CWD, &repo_path, Algorithm::SHA512, false)
+                .unwrap();
+        let data = b"sha512 test data";
+        let obj_id = repo.ensure_object(data).unwrap();
+        drop(repo);
+
+        std::fs::remove_file(repo_path.join(REPO_METADATA_FILENAME)).unwrap();
+
+        let (repo, upgraded) =
+            Repository::<Sha512HashValue>::open_upgrade(CWD, &repo_path).unwrap();
+        assert!(upgraded);
+
+        let meta = read_repo_metadata(
+            &openat(
+                CWD,
+                &repo_path,
+                OFlags::RDONLY | OFlags::CLOEXEC,
+                Mode::empty(),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(meta.algorithm.is_compatible::<Sha512HashValue>());
+
+        let read_data = repo.read_object(&obj_id).unwrap();
+        assert_eq!(&read_data[..], data);
+    }
+
+    #[test]
+    fn test_open_upgrade_algorithm_mismatch() {
+        // Create a sha512 repo, remove meta.json, then try to
+        // open_upgrade as sha256 — should fail with algorithm mismatch.
+        let tmp = tempdir();
+        let repo_path = tmp.path().join("repo");
+
+        let (repo, _) =
+            Repository::<Sha512HashValue>::init_path(CWD, &repo_path, Algorithm::SHA512, false)
+                .unwrap();
+        repo.ensure_object(b"some data").unwrap();
+        drop(repo);
+
+        std::fs::remove_file(repo_path.join(REPO_METADATA_FILENAME)).unwrap();
+
+        let err = Repository::<Sha256HashValue>::open_upgrade(CWD, &repo_path).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not compatible"),
+            "expected algorithm mismatch error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_open_upgrade_empty_objects() {
+        // An old-format repo with an empty objects/ directory should
+        // fail because we can't infer the algorithm.
+        let tmp = tempdir();
+        let repo_path = tmp.path().join("repo");
+        mkdirat(CWD, &repo_path, Mode::from_raw_mode(0o755)).unwrap();
+        mkdirat(CWD, &repo_path.join("objects"), Mode::from_raw_mode(0o755)).unwrap();
+
+        let err = Repository::<Sha256HashValue>::open_upgrade(CWD, &repo_path).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no objects found"),
+            "expected 'no objects found' error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_open_upgrade_already_initialized() {
+        // open_upgrade on a repo that already has meta.json should
+        // return upgraded=false.
+        let tmp = tempdir();
+        let repo_path = tmp.path().join("repo");
+
+        Repository::<Sha256HashValue>::init_path(CWD, &repo_path, Algorithm::SHA256, false)
+            .unwrap();
+
+        let (_repo, upgraded) =
+            Repository::<Sha256HashValue>::open_upgrade(CWD, &repo_path).unwrap();
+        assert!(!upgraded);
     }
 }

--- a/crates/composefs/src/splitstream.rs
+++ b/crates/composefs/src/splitstream.rs
@@ -76,6 +76,97 @@ struct SplitstreamInfo {
     pub stream_size: U64,       // total uncompressed size of inline chunks and external chunks
 }
 
+/// Old layout of SplitstreamHeader, without `#[repr(C)]`.
+/// The Rust compiler reorders fields for alignment — the const asserts below
+/// verify the resulting layout matches what bootc <= 1.15.x actually wrote.
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct OldSplitstreamHeader {
+    pub magic: [u8; 11],
+    pub version: u8,
+    pub _flags: U16,
+    pub algorithm: u8,
+    pub lg_blocksize: u8,
+    pub info: FileRange,
+}
+
+/// Old layout of SplitstreamInfo, without `#[repr(C)]`.
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout)]
+struct OldSplitstreamInfo {
+    pub stream_refs: FileRange,
+    pub object_refs: FileRange,
+    pub stream: FileRange,
+    pub named_refs: FileRange,
+    pub content_type: U64,
+    pub stream_size: U64,
+}
+
+// FileRange: both old and new layouts should be identical (two U64 fields, uniform alignment)
+const _: () = {
+    assert!(std::mem::offset_of!(FileRange, start) == 0);
+    assert!(std::mem::offset_of!(FileRange, end) == 8);
+    assert!(std::mem::size_of::<FileRange>() == 16);
+};
+
+// SplitstreamHeader: verify old layout DIFFERS from new layout
+const _: () = {
+    // New (repr(C)) layout: magic at 0, info at 16
+    assert!(std::mem::offset_of!(SplitstreamHeader, magic) == 0);
+    assert!(std::mem::offset_of!(SplitstreamHeader, info) == 16);
+    assert!(std::mem::size_of::<SplitstreamHeader>() == 32);
+
+    // Old (no repr(C)) layout: info at 0, magic at 18
+    assert!(std::mem::offset_of!(OldSplitstreamHeader, info) == 0);
+    assert!(std::mem::offset_of!(OldSplitstreamHeader, _flags) == 16);
+    assert!(std::mem::offset_of!(OldSplitstreamHeader, magic) == 18);
+    assert!(std::mem::offset_of!(OldSplitstreamHeader, version) == 29);
+    assert!(std::mem::offset_of!(OldSplitstreamHeader, algorithm) == 30);
+    assert!(std::mem::offset_of!(OldSplitstreamHeader, lg_blocksize) == 31);
+    assert!(std::mem::size_of::<OldSplitstreamHeader>() == 32);
+};
+
+// SplitstreamInfo: verify old and new layouts are IDENTICAL
+// (all fields are 8-byte aligned, no reason for compiler to reorder)
+const _: () = {
+    assert!(
+        std::mem::offset_of!(SplitstreamInfo, stream_refs)
+            == std::mem::offset_of!(OldSplitstreamInfo, stream_refs)
+    );
+    assert!(
+        std::mem::offset_of!(SplitstreamInfo, object_refs)
+            == std::mem::offset_of!(OldSplitstreamInfo, object_refs)
+    );
+    assert!(
+        std::mem::offset_of!(SplitstreamInfo, stream)
+            == std::mem::offset_of!(OldSplitstreamInfo, stream)
+    );
+    assert!(
+        std::mem::offset_of!(SplitstreamInfo, named_refs)
+            == std::mem::offset_of!(OldSplitstreamInfo, named_refs)
+    );
+    assert!(
+        std::mem::offset_of!(SplitstreamInfo, content_type)
+            == std::mem::offset_of!(OldSplitstreamInfo, content_type)
+    );
+    assert!(
+        std::mem::offset_of!(SplitstreamInfo, stream_size)
+            == std::mem::offset_of!(OldSplitstreamInfo, stream_size)
+    );
+    assert!(std::mem::size_of::<SplitstreamInfo>() == std::mem::size_of::<OldSplitstreamInfo>());
+};
+
+impl From<OldSplitstreamHeader> for SplitstreamHeader {
+    fn from(old: OldSplitstreamHeader) -> Self {
+        Self {
+            magic: old.magic,
+            version: old.version,
+            _flags: old._flags,
+            algorithm: old.algorithm,
+            lg_blocksize: old.lg_blocksize,
+            info: old.info,
+        }
+    }
+}
+
 impl FileRange {
     fn len(&self) -> Result<u64> {
         self.end
@@ -386,6 +477,9 @@ pub struct SplitStreamWriter<ObjectId: FsVerityHashValue> {
     total_size: u64,
     writer: Encoder<'static, Vec<u8>>,
     content_type: u64,
+    /// When true, done() writes old-format (pre-repr(C)) headers.
+    #[cfg(any(test, feature = "test"))]
+    write_old_format: bool,
 }
 
 impl<ObjectID: FsVerityHashValue> std::fmt::Debug for SplitStreamWriter<ObjectID> {
@@ -431,6 +525,8 @@ impl<ObjectID: FsVerityHashValue> SplitStreamWriter<ObjectID> {
             named_refs: Default::default(),
             total_size: 0,
             writer,
+            #[cfg(any(test, feature = "test"))]
+            write_old_format: repo.write_old_splitstream_format(),
         }
     }
 
@@ -631,6 +727,14 @@ impl<ObjectID: FsVerityHashValue> SplitStreamWriter<ObjectID> {
         buf.extend_from_slice(&stream);
         assert_eq!(buf.len() as u64, stream_end);
 
+        // If test mode requests old-format headers, rewrite the header in place
+        #[cfg(any(test, feature = "test"))]
+        let buf = if self.write_old_format {
+            new_to_old_format(&buf)
+        } else {
+            buf
+        };
+
         // Store the Vec<u8> into the repository (writable already checked)
         self.repo.ensure_object_impl(&buf, &self.writable)
     }
@@ -702,9 +806,22 @@ impl<ObjectID: FsVerityHashValue> SplitStreamReader<ObjectID> {
         let header = SplitstreamHeader::read_from_io(&mut file)
             .map_err(|e| Error::msg(format!("Error reading splitstream header: {e:?}")))?;
 
-        if header.magic != SPLITSTREAM_MAGIC {
-            bail!("Invalid splitstream header magic value");
-        }
+        let header = if header.magic != SPLITSTREAM_MAGIC {
+            // Try interpreting as old layout (pre-repr(C) fix, bootc <= 1.15.x)
+            file.seek(SeekFrom::Start(0))
+                .context("Seeking back to start for old-format header")?;
+            let old_header = OldSplitstreamHeader::read_from_io(&mut file).map_err(|e| {
+                Error::msg(format!(
+                    "Error reading old-format splitstream header: {e:?}"
+                ))
+            })?;
+            if old_header.magic != SPLITSTREAM_MAGIC {
+                bail!("Invalid splitstream header magic value");
+            }
+            old_header.into()
+        } else {
+            header
+        };
 
         if header.version != 0 {
             bail!("Invalid splitstream version {}", header.version);
@@ -962,6 +1079,31 @@ impl<ObjectID: FsVerityHashValue> Read for SplitStreamReader<ObjectID> {
             Err(e) => Err(std::io::Error::other(e)),
         }
     }
+}
+
+/// Convert a new-format splitstream to old (pre-repr(C)) header layout.
+/// Takes the raw bytes of a valid new-format splitstream and returns bytes
+/// with the header rewritten to match the compiler-reordered layout.
+/// Only the 32-byte header changes; the rest of the file is identical.
+#[cfg(any(test, feature = "test"))]
+pub fn new_to_old_format(new_format: &[u8]) -> Vec<u8> {
+    assert!(new_format.len() >= size_of::<SplitstreamHeader>());
+    let (header, _) = SplitstreamHeader::ref_from_prefix(new_format).unwrap();
+    assert_eq!(header.magic, SPLITSTREAM_MAGIC, "input must be new-format");
+
+    let old_header = OldSplitstreamHeader {
+        info: header.info,
+        _flags: header._flags,
+        magic: header.magic,
+        version: header.version,
+        algorithm: header.algorithm,
+        lg_blocksize: header.lg_blocksize,
+    };
+
+    let mut result = Vec::with_capacity(new_format.len());
+    result.extend_from_slice(old_header.as_bytes());
+    result.extend_from_slice(&new_format[size_of::<SplitstreamHeader>()..]);
+    result
 }
 
 #[cfg(test)]
@@ -1359,6 +1501,95 @@ mod tests {
         let reader = repo.open_stream("test-size", Some(&stream_id), None)?;
         assert_eq!(reader.total_size, 1100, "total size should be tracked");
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_old_format_header_differs_from_new() -> Result<()> {
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let mut writer = repo.create_stream(0)?;
+        writer.write_inline(b"hello");
+        let stream_id = repo.write_stream(writer, "test-old-hdr", None)?;
+
+        let new_bytes = repo.read_object(&stream_id)?;
+        let old_bytes = new_to_old_format(&new_bytes);
+
+        // New format starts with magic, old format should NOT
+        assert_eq!(&new_bytes[..11], b"SplitStream");
+        assert_ne!(
+            &old_bytes[..11],
+            b"SplitStream",
+            "old format should NOT start with magic"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_read_old_format_splitstream() -> Result<()> {
+        use std::io::Write as _;
+
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let inline_data = b"hello";
+        let mut writer = repo.create_stream(0)?;
+        writer.write_inline(inline_data);
+        let stream_id = repo.write_stream(writer, "test-old-read", None)?;
+
+        // Read the raw stored bytes, convert to old format, write to a temp file
+        let new_bytes = repo.read_object(&stream_id)?;
+        let old_bytes = new_to_old_format(&new_bytes);
+
+        let mut tmpfile = tempfile::NamedTempFile::new()?;
+        tmpfile.write_all(&old_bytes)?;
+        tmpfile.flush()?;
+
+        // Read back via the old-format file
+        let file = std::fs::File::open(tmpfile.path())?;
+        let mut old_reader = SplitStreamReader::<Sha256HashValue>::new(file, None)?;
+
+        assert_eq!(old_reader.total_size, inline_data.len() as u64);
+        assert_eq!(old_reader.content_type, 0);
+
+        let mut old_output = Vec::new();
+        std::io::Read::read_to_end(&mut old_reader, &mut old_output)?;
+
+        // Read back via the new-format (repo) for comparison
+        let mut new_reader = repo.open_stream("test-old-read", Some(&stream_id), None)?;
+        let mut new_output = Vec::new();
+        std::io::Read::read_to_end(&mut new_reader, &mut new_output)?;
+
+        assert_eq!(
+            old_output, new_output,
+            "old and new format must produce identical data"
+        );
+        assert_eq!(&old_output, inline_data);
+        Ok(())
+    }
+
+    #[test]
+    fn test_new_format_still_works() -> Result<()> {
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let inline_data = b"world";
+        let mut writer = repo.create_stream(0)?;
+        writer.write_inline(inline_data);
+        let stream_id = repo.write_stream(writer, "test-new-fmt", None)?;
+
+        // Verify the stored bytes start with magic (new format)
+        let raw_bytes = repo.read_object(&stream_id)?;
+        assert_eq!(&raw_bytes[..11], b"SplitStream");
+
+        // Read back and verify content
+        let mut reader = repo.open_stream("test-new-fmt", Some(&stream_id), None)?;
+        assert_eq!(reader.total_size, inline_data.len() as u64);
+
+        let mut output = Vec::new();
+        std::io::Read::read_to_end(&mut reader, &mut output)?;
+        assert_eq!(&output, inline_data);
         Ok(())
     }
 }

--- a/crates/integration-tests/src/tests/mod.rs
+++ b/crates/integration-tests/src/tests/mod.rs
@@ -3,4 +3,5 @@
 pub mod cli;
 pub mod cstor;
 pub mod digest_stability;
+pub mod old_format;
 pub mod privileged;

--- a/crates/integration-tests/src/tests/old_format.rs
+++ b/crates/integration-tests/src/tests/old_format.rs
@@ -1,0 +1,121 @@
+//! Tests for backward compatibility with old-format composefs-rs repositories.
+//!
+//! These tests require an old version of cfsctl to create a repo with
+//! old-format splitstream headers (pre-repr(C)). Set `CFSCTL_PATH_OLD`
+//! to the path of an old cfsctl binary to enable these tests.
+//!
+//! Build an old binary from the bootc-pinned rev:
+//! ```sh
+//! git worktree add /tmp/composefs-rs-old 2203e8f
+//! cargo build --release --bin cfsctl -p cfsctl \
+//!     --manifest-path /tmp/composefs-rs-old/Cargo.toml
+//! export CFSCTL_PATH_OLD=/tmp/composefs-rs-old/target/release/cfsctl
+//! ```
+
+use anyhow::Result;
+use std::path::PathBuf;
+use xshell::{Shell, cmd};
+
+use crate::{cfsctl, integration_test};
+
+/// Returns the path to the old cfsctl binary, or None if not configured.
+fn cfsctl_old() -> Option<PathBuf> {
+    std::env::var_os("CFSCTL_PATH_OLD").map(PathBuf::from)
+}
+
+/// Returns true if skopeo is available on the system.
+fn have_skopeo() -> bool {
+    std::process::Command::new("skopeo")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn test_read_old_format_repo() -> Result<()> {
+    let old_cfsctl = match cfsctl_old() {
+        Some(p) => p,
+        None => {
+            eprintln!("CFSCTL_PATH_OLD not set, skipping old-format test");
+            return Ok(());
+        }
+    };
+    if !have_skopeo() {
+        eprintln!("skopeo not found, skipping old-format test");
+        return Ok(());
+    }
+    let cfsctl = cfsctl()?;
+    let sh = Shell::new()?;
+
+    // Create a local OCI layout from busybox using skopeo
+    let oci_dir = tempfile::tempdir()?;
+    let oci_path = oci_dir.path().join("busybox-oci");
+    cmd!(
+        sh,
+        "skopeo copy docker://docker.io/library/busybox:latest oci:{oci_path}"
+    )
+    .run()?;
+
+    // Create repo with old cfsctl and pull the image.
+    // The old cfsctl auto-creates the repo directory structure on pull.
+    let repo_dir = tempfile::tempdir()?;
+    let repo = repo_dir.path();
+    std::fs::create_dir_all(repo)?;
+
+    let pull_output = cmd!(
+        sh,
+        "{old_cfsctl} --insecure --repo {repo} oci pull oci:{oci_path} busybox:latest"
+    )
+    .read()?;
+    eprintln!("old cfsctl pull output: {pull_output}");
+
+    // Old repo has no meta.json — --no-upgrade should refuse to operate
+    let result = cmd!(sh, "{cfsctl} --no-upgrade --repo {repo} oci images")
+        .ignore_status()
+        .read_stderr()?;
+    assert!(
+        result.contains("meta.json") || result.contains("must be initialized"),
+        "new cfsctl --no-upgrade should fail on repo without meta.json, got: {result}"
+    );
+
+    // Without --no-upgrade (default), cfsctl should auto-upgrade and work
+    let images_output = cmd!(sh, "{cfsctl} --repo {repo} oci images").read()?;
+
+    // Verify meta.json was written by auto-upgrade
+    assert!(
+        repo.join("meta.json").exists(),
+        "meta.json should have been written by auto-upgrade"
+    );
+    assert!(
+        images_output.contains("busybox"),
+        "should list busybox image after init, got: {images_output}"
+    );
+
+    // Dump filesystem — this reads old-format layer splitstreams
+    let dump_output = cmd!(sh, "{cfsctl} --repo {repo} oci dump busybox:latest").read()?;
+    assert!(
+        dump_output.contains("/bin/sh"),
+        "busybox dump should contain /bin/sh, got first 200 chars: {}",
+        &dump_output[..dump_output.len().min(200)]
+    );
+
+    // GC should work without errors
+    let gc_output = cmd!(sh, "{cfsctl} --insecure --repo {repo} gc").read()?;
+    assert!(
+        gc_output.contains("Objects: 0 removed"),
+        "gc should find nothing to remove (all objects are referenced), got: {gc_output}"
+    );
+
+    // oci fsck should pass (verifies splitstream integrity)
+    let fsck_output = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci fsck --json").read()?;
+    let fsck: serde_json::Value = serde_json::from_str(&fsck_output)?;
+    assert_eq!(
+        fsck["ok"], true,
+        "oci fsck should pass on old-format repo, got: {fsck_output}"
+    );
+
+    Ok(())
+}
+integration_test!(test_read_old_format_repo);


### PR DESCRIPTION
Production bootc (pinned at composefs-rs 2203e8f) predates three format changes:

 - ce6628525 repository: Add meta.json for repo metadata and cfsctl init
 - b7dc27065 Add repr(c) for SplitStream header structs
 - d5ec81d74 oci: Generate composefs EROFS at pull time, track via config refs

This commit adds transparent backward compatibility and a non-destructive upgrade path.

The splitstream reader detects old-layout headers (where the Rust compiler reordered SplitstreamHeader fields) and converts them on the fly. Repository::open_upgrade() infers the algorithm and verity mode from existing objects when meta.json is missing, writes it, and opens normally — replacing the destructive --reset-metadata flow. upgrade_repo() walks all tagged images and generates EROFS for any that lack it, rewriting config and manifest splitstreams in the current format. Layer splitstreams stay old-format on disk since the reader handles them transparently.

The CLI uses open_upgrade by default (opt out with --no-upgrade). An integration test pulls a real image with an old cfsctl binary (requires CFSCTL_PATH_OLD) to verify the full upgrade path.

Assisted-by: OpenCode (Claude Opus 4)