### PR TITLE
ci: A few fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,10 @@ jobs:
     strategy:
       matrix:
         example:
-          - { dir: 'bls', os: 'arch' }
+          # Disabled: Linux 7.0 kernel regression breaks composefs fsverity boot
+          # ("has no fs-verity digest"); see https://github.com/bootc-dev/bootc/issues/2174
+          # - { dir: 'bls', os: 'arch' }
+          # - { dir: 'uki', os: 'arch' }
           - { dir: 'bls', os: 'fedora' }
           - { dir: 'bls', os: 'fedora-compat' }
           # This one is currently failing, needs debugging
@@ -140,7 +143,6 @@ jobs:
           # We believe it's mount API changes causing /sysroot to be mounted
           # at the wrong place.
           # - { dir: 'bls', os: 'ubuntu' }
-          - { dir: 'uki', os: 'arch' }
           - { dir: 'uki', os: 'fedora' }
           - { dir: 'unified', os: 'fedora' }
           - { dir: 'unified-secureboot', os: 'fedora' }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,11 @@ jobs:
         with:
           workspaces: crates/composefs/fuzz
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        # Use cargo-fuzz 0.13.1 without --locked so cargo resolves fresh deps;
+        # the published lockfile pins rustix 0.36 which fails to compile with
+        # nightly ≥ 1.97 (rustc_layout_scalar_valid_range_* now reserved for
+        # the compiler).
+        run: cargo install cargo-fuzz@0.13.1
       - name: Generate corpus
         run: just generate-corpus
       - name: Run fuzz targets

--- a/crates/composefs/src/dumpfile_parse.rs
+++ b/crates/composefs/src/dumpfile_parse.rs
@@ -242,11 +242,11 @@ fn unescape_to_path_canonical(s: &str) -> Result<Cow<'_, Path>> {
             continue;
         }
         match component {
-            b"" => {
+            b""
                 // Only valid for root path (i.e. single trailing empty after "/")
-                if !(i == 1 && path_bytes == b"/") {
-                    anyhow::bail!("Empty path component (// or trailing /)");
-                }
+                if !(i == 1 && path_bytes == b"/") =>
+            {
+                anyhow::bail!("Empty path component (// or trailing /)");
             }
             b"." => anyhow::bail!("Invalid path component '.'"),
             b".." => anyhow::bail!("Invalid path component '..'"),


### PR DESCRIPTION
Linux 7.0 introduced a kernel regression that breaks composefs boot when fsverity enforcement is enabled, failing with "has no fs-verity digest". The Arch CI runner pulls the latest Arch kernel (currently 7.0.3-arch1-2), so the default bls/arch job hits this at switch_root.

See: https://github.com/bootc-dev/bootc/issues/2174

Assisted-by: OpenCode (claude-sonnet-4-6)