### PR TITLE
Add support for mounting upper layers with images

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -63,6 +63,7 @@ use composefs::{
     erofs::reader::erofs_to_filesystem,
     fsverity::{Algorithm, FsVerityHashValue, Sha256HashValue, Sha512HashValue},
     generic_tree::{FileSystem, Inode},
+    mount::MountOptions,
     repository::{
         REPO_METADATA_FILENAME, Repository, RepositoryConfig, read_repo_algorithm, system_path,
         user_path,
@@ -437,6 +438,15 @@ enum OciCommand {
         /// Mount the bootable variant instead of the regular EROFS image
         #[arg(long)]
         bootable: bool,
+        /// Writable upper layer directory for overlayfs
+        #[arg(long, requires = "workdir")]
+        upperdir: Option<PathBuf>,
+        /// Work directory for overlayfs (required with --upperdir)
+        #[arg(long, requires = "upperdir")]
+        workdir: Option<PathBuf>,
+        /// Mount read-write (requires --upperdir)
+        #[arg(long, requires = "upperdir")]
+        read_write: bool,
     },
     /// Compute the composefs image ID of a stored OCI image's rootfs
     ///
@@ -564,6 +574,15 @@ enum Command {
         name: String,
         /// the mountpoint
         mountpoint: String,
+        /// Writable upper layer directory for overlayfs
+        #[arg(long, requires = "workdir")]
+        upperdir: Option<PathBuf>,
+        /// Work directory for overlayfs (required with --upperdir)
+        #[arg(long, requires = "upperdir")]
+        workdir: Option<PathBuf>,
+        /// Mount read-write (requires --upperdir)
+        #[arg(long, requires = "upperdir")]
+        read_write: bool,
     },
     /// Read rootfs located at a path, add all files to the repo, then create the composefs image of the rootfs,
     /// commit it to the repo, and print its image object ID
@@ -664,6 +683,31 @@ where
     );
 
     run_app(args).await
+}
+
+fn get_mount_options(
+    upperdir: Option<&Path>,
+    workdir: Option<&Path>,
+    read_write: bool,
+) -> Result<MountOptions> {
+    let mut options = MountOptions::default();
+    if let (Some(u), Some(w)) = (upperdir, workdir) {
+        let upper_fd = rustix::fs::open(
+            u,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .with_context(|| format!("Opening upperdir '{}'", u.display()))?;
+        let work_fd = rustix::fs::open(
+            w,
+            OFlags::PATH | OFlags::DIRECTORY | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .with_context(|| format!("Opening workdir '{}'", w.display()))?;
+        options.set_overlay(upper_fd, work_fd);
+    }
+    options.set_read_write(read_write);
+    Ok(options)
 }
 
 #[cfg(feature = "oci")]
@@ -1217,7 +1261,12 @@ where
                 ref image,
                 ref mountpoint,
                 bootable,
+                ref upperdir,
+                ref workdir,
+                read_write,
             } => {
+                let mount_options =
+                    get_mount_options(upperdir.as_deref(), workdir.as_deref(), read_write)?;
                 let img = if image.starts_with("sha256:") {
                     let digest: composefs_oci::OciDigest =
                         image.parse().context("Parsing manifest digest")?;
@@ -1240,7 +1289,7 @@ where
                         ),
                     }
                 };
-                repo.mount_at(&erofs_id.to_hex(), mountpoint.as_str())?;
+                repo.mount_at(&erofs_id.to_hex(), mountpoint.as_str(), &mount_options)?;
             }
             OciCommand::ComputeId { config_opts } => {
                 let mut fs = load_filesystem_from_oci_image(&repo, config_opts)?;
@@ -1461,8 +1510,16 @@ where
             // Handled in run_app before opening the repo
             unreachable!("compute-id and create-dumpfile are dispatched without a repo");
         }
-        Command::Mount { name, mountpoint } => {
-            repo.mount_at(&name, &mountpoint)?;
+        Command::Mount {
+            name,
+            mountpoint,
+            ref upperdir,
+            ref workdir,
+            read_write,
+        } => {
+            let mount_options =
+                get_mount_options(upperdir.as_deref(), workdir.as_deref(), read_write)?;
+            repo.mount_at(&name, &mountpoint, &mount_options)?;
         }
         Command::ImageObjects { name } => {
             let objects = repo.objects_for_image(&name)?;

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -407,6 +407,125 @@ async fn run_image_objects<ObjectID: FsVerityHashValue>(
     Ok(ImageObjectsReply { object_ids })
 }
 
+/// Options for a `Mount` call. All fields are optional for forward
+/// compatibility — new mount options can be added without breaking the
+/// wire format.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize, zlink::introspect::Type)]
+pub struct MountParams {
+    /// Whether to set up an overlayfs upper layer.
+    /// When true, the fd array must contain two fds: upperdir and workdir.
+    pub overlay: Option<bool>,
+    /// Whether to mount read-write (only meaningful with overlay).
+    pub read_write: Option<bool>,
+}
+
+impl MountParams {
+    /// Build [`MountOptions`] from these params, consuming the expected fds.
+    fn to_mount_options(
+        &self,
+        fds: Vec<std::os::fd::OwnedFd>,
+    ) -> std::result::Result<composefs::mount::MountOptions, RepositoryError> {
+        let overlay = self.overlay.unwrap_or(false);
+
+        let mut expected_fds = 0;
+        if overlay {
+            expected_fds += 2;
+        }
+
+        if fds.len() != expected_fds {
+            return Err(RepositoryError::InvalidSpec {
+                message: format!(
+                    "Mount expects {expected_fds} fds for the requested options, got {}",
+                    fds.len()
+                ),
+            });
+        }
+
+        let mut options = composefs::mount::MountOptions::default();
+        let mut fd_iter = fds.into_iter();
+        if overlay {
+            let upperdir = fd_iter.next().unwrap();
+            let workdir = fd_iter.next().unwrap();
+            options.set_overlay(upperdir, workdir);
+        }
+        options.set_read_write(self.read_write.unwrap_or(false));
+
+        Ok(options)
+    }
+}
+
+/// Reply for a `Mount` call — just an fd_index referencing the mount fd.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, zlink::introspect::Type)]
+pub struct MountReply {
+    /// Index into the fd vector of the detached mount file descriptor.
+    pub fd_index: u32,
+}
+
+fn run_mount<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: &str,
+    params: &MountParams,
+    fds: Vec<std::os::fd::OwnedFd>,
+) -> std::result::Result<(MountReply, Vec<std::os::fd::OwnedFd>), RepositoryError> {
+    let options = params.to_mount_options(fds)?;
+
+    let mount_fd =
+        repo.mount_with_options(name, &options)
+            .map_err(|e| RepositoryError::InternalError {
+                message: format!("{e:#}"),
+            })?;
+
+    Ok((MountReply { fd_index: 0 }, vec![mount_fd]))
+}
+
+#[cfg(feature = "oci")]
+fn run_oci_mount<ObjectID: composefs::fsverity::FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    image: &str,
+    bootable: bool,
+    params: &MountParams,
+    fds: Vec<std::os::fd::OwnedFd>,
+) -> std::result::Result<(MountReply, Vec<std::os::fd::OwnedFd>), oci::OciError> {
+    let img = if image.starts_with("sha256:") {
+        let digest: composefs_oci::OciDigest =
+            image.parse().map_err(|e| oci::OciError::InternalError {
+                message: format!("Invalid manifest digest: {e}"),
+            })?;
+        composefs_oci::OciImage::open(repo, &digest, None)
+    } else {
+        composefs_oci::OciImage::open_ref(repo, image)
+    }
+    .map_err(|e| oci::OciError::NoSuchImage {
+        image: format!("{image}: {e:#}"),
+    })?;
+
+    let erofs_id = if bootable {
+        img.boot_image_ref()
+    } else {
+        img.image_ref()
+    }
+    .ok_or_else(|| oci::OciError::InternalError {
+        message: if bootable {
+            "No boot EROFS image linked".into()
+        } else {
+            "No composefs EROFS image linked".into()
+        },
+    })?;
+
+    let options = params
+        .to_mount_options(fds)
+        .map_err(|e| oci::OciError::InternalError {
+            message: format!("{e:?}"),
+        })?;
+    let mount_fd = repo
+        .mount_with_options(&erofs_id.to_hex(), &options)
+        .map_err(|e| oci::OciError::InternalError {
+            message: format!("{e:#}"),
+        })?;
+
+    Ok((MountReply { fd_index: 0 }, vec![mount_fd]))
+}
+
 /// Initialize (or verify) a repository at `path` with the given algorithm.
 ///
 /// Creates parent directories if needed, then delegates to
@@ -624,9 +743,9 @@ mod service_impl {
     #![allow(missing_docs)]
 
     use super::{
-        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, OpenRepo,
-        OpenRepositoryReply, RepositoryError, run_fsck, run_gc, run_image_objects,
-        run_init_repository,
+        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, MountParams,
+        MountReply, OpenRepo, OpenRepositoryReply, RepositoryError, run_fsck, run_gc,
+        run_image_objects, run_init_repository, run_mount,
     };
     use composefs::fsverity::{Algorithm, Sha256HashValue, Sha512HashValue};
 
@@ -732,6 +851,37 @@ mod service_impl {
                 OpenRepo::Sha512(ref r) => run_image_objects::<Sha512HashValue>(r, name).await,
             }
         }
+
+        /// Create a detached mount of an image and return the mount fd.
+        ///
+        /// If overlay upper/work directories are needed, pass them as two fds
+        /// (upperdir, workdir) via SCM_RIGHTS. The returned fd is a detached
+        /// mount that the caller can attach with `move_mount()`.
+        #[zlink(return_fds)]
+        async fn mount(
+            &self,
+            handle: u64,
+            name: String,
+            options: MountParams,
+            #[zlink(fds)] fds: Vec<std::os::fd::OwnedFd>,
+        ) -> (
+            std::result::Result<MountReply, RepositoryError>,
+            Vec<std::os::fd::OwnedFd>,
+        ) {
+            let result = match self.lookup_repo(handle) {
+                Ok(OpenRepo::Sha256(ref r)) => {
+                    run_mount::<Sha256HashValue>(r, &name, &options, fds)
+                }
+                Ok(OpenRepo::Sha512(ref r)) => {
+                    run_mount::<Sha512HashValue>(r, &name, &options, fds)
+                }
+                Err(e) => Err(e),
+            };
+            match result {
+                Ok((reply, fds)) => (Ok(reply), fds),
+                Err(e) => (Err(e), vec![]),
+            }
+        }
     }
 }
 
@@ -748,9 +898,10 @@ mod service_impl {
         parse_local_fetch, pull_stream,
     };
     use super::{
-        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, OpenRepo,
-        OpenRepositoryReply, RepositoryError, run_compute_id, run_fsck, run_gc, run_image_objects,
-        run_init_repository, run_inspect, run_list_images, run_oci_fsck, run_tag, run_untag,
+        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, MountParams,
+        MountReply, OpenRepo, OpenRepositoryReply, RepositoryError, run_compute_id, run_fsck,
+        run_gc, run_image_objects, run_init_repository, run_inspect, run_list_images, run_mount,
+        run_oci_fsck, run_oci_mount, run_tag, run_untag,
     };
     use composefs::fsverity::{Algorithm, Sha256HashValue, Sha512HashValue};
 
@@ -856,6 +1007,37 @@ mod service_impl {
             match self.lookup_repo(handle)? {
                 OpenRepo::Sha256(ref r) => run_image_objects::<Sha256HashValue>(r, name).await,
                 OpenRepo::Sha512(ref r) => run_image_objects::<Sha512HashValue>(r, name).await,
+            }
+        }
+
+        /// Create a detached mount of an image and return the mount fd.
+        ///
+        /// If overlay upper/work directories are needed, pass them as two fds
+        /// (upperdir, workdir) via SCM_RIGHTS. The returned fd is a detached
+        /// mount that the caller can attach with `move_mount()`.
+        #[zlink(return_fds)]
+        async fn mount(
+            &self,
+            handle: u64,
+            name: String,
+            options: MountParams,
+            #[zlink(fds)] fds: Vec<std::os::fd::OwnedFd>,
+        ) -> (
+            std::result::Result<MountReply, RepositoryError>,
+            Vec<std::os::fd::OwnedFd>,
+        ) {
+            let result = match self.lookup_repo(handle) {
+                Ok(OpenRepo::Sha256(ref r)) => {
+                    run_mount::<Sha256HashValue>(r, &name, &options, fds)
+                }
+                Ok(OpenRepo::Sha512(ref r)) => {
+                    run_mount::<Sha512HashValue>(r, &name, &options, fds)
+                }
+                Err(e) => Err(e),
+            };
+            match result {
+                Ok((reply, fds)) => (Ok(reply), fds),
+                Err(e) => (Err(e), vec![]),
             }
         }
 
@@ -996,6 +1178,39 @@ mod service_impl {
                         Err(OciError::InvalidHandle { handle })
                     }))
                 }
+            }
+        }
+
+        /// Mount an OCI image and return the detached mount fd.
+        ///
+        /// Resolves the image by ref name or `sha256:` digest, finds its
+        /// EROFS image (or boot variant if `bootable` is true), and creates
+        /// a composefs mount. If `options.overlay` is true, the fd array
+        /// must contain upperdir and workdir fds.
+        #[zlink(interface = "org.composefs.Oci", return_fds)]
+        async fn oci_mount(
+            &self,
+            handle: u64,
+            image: String,
+            bootable: bool,
+            options: MountParams,
+            #[zlink(fds)] fds: Vec<std::os::fd::OwnedFd>,
+        ) -> (
+            std::result::Result<MountReply, OciError>,
+            Vec<std::os::fd::OwnedFd>,
+        ) {
+            let result = match self.lookup_oci(handle) {
+                Ok(OpenRepo::Sha256(ref r)) => {
+                    run_oci_mount::<Sha256HashValue>(r, &image, bootable, &options, fds)
+                }
+                Ok(OpenRepo::Sha512(ref r)) => {
+                    run_oci_mount::<Sha512HashValue>(r, &image, bootable, &options, fds)
+                }
+                Err(e) => Err(e),
+            };
+            match result {
+                Ok((reply, fds)) => (Ok(reply), fds),
+                Err(e) => (Err(e), vec![]),
             }
         }
     }

--- a/crates/composefs-integration-tests/src/tests/privileged.rs
+++ b/crates/composefs-integration-tests/src/tests/privileged.rs
@@ -17,7 +17,7 @@ use xshell::{Shell, cmd};
 use composefs_oci::composefs::fsverity::{FsVerityHashValue, Sha256HashValue, Sha512HashValue};
 use composefs_oci::composefs::repository::{Repository, RepositoryConfig};
 
-use crate::{cfsctl, integration_test};
+use crate::{cfsctl, create_test_rootfs, integration_test};
 
 /// Ensure we're running in a privileged environment, or re-exec this test inside a VM.
 ///
@@ -380,6 +380,137 @@ fn privileged_oci_pull_mount() -> Result<()> {
     Ok(())
 }
 integration_test!(privileged_oci_pull_mount);
+
+/// Test `cfsctl mount` with `--upperdir`/`--workdir`/`--read-write` flags.
+///
+/// Exercises three scenarios:
+/// 1. Upperdir present but no `--read-write` → mount stays read-only.
+/// 2. Upperdir + `--read-write` → writes land in the upper directory.
+/// 3. Plain mount (no upperdir) → baseline sanity check.
+fn privileged_mount_upper_layer() -> Result<()> {
+    if require_privileged("privileged_mount_upper_layer")?.is_some() {
+        return Ok(());
+    }
+
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let verity_dir = VerityTempDir::new()?;
+    let repo_path = verity_dir.path().join("repo");
+    let repo_arg = repo_path.to_str().unwrap();
+
+    cmd!(sh, "{cfsctl} --insecure --repo {repo_arg} init").run()?;
+
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+    let rootfs = rootfs.to_str().unwrap();
+
+    // Use a named ref so we can mount via "refs/upper-test" — the bare output
+    // of create-image is "algo:hex" but mount expects just the hex or a ref path.
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo_arg} create-image {rootfs} upper-test"
+    )
+    .run()?;
+    let image_name = "refs/upper-test";
+
+    // --- Scenario 1: upperdir without --read-write keeps the mount read-only ---
+    {
+        let upper1 = tempfile::tempdir()?;
+        let work1 = tempfile::tempdir()?;
+        let mp1 = tempfile::tempdir()?;
+        let upper1_path = upper1.path().to_str().unwrap();
+        let work1_path = work1.path().to_str().unwrap();
+        let mp1_path = mp1.path().to_str().unwrap();
+
+        cmd!(
+            sh,
+            "{cfsctl} --insecure --repo {repo_arg} mount {image_name} {mp1_path}
+             --upperdir {upper1_path} --workdir {work1_path}"
+        )
+        .run()?;
+
+        // The rootfs fixture has etc/hostname — verify the mount is populated.
+        let hostname = std::fs::read_to_string(mp1.path().join("etc/hostname"))?;
+        ensure!(
+            hostname == "integration-test\n",
+            "hostname mismatch in scenario 1: {hostname:?}"
+        );
+
+        // Without --read-write the mount must be read-only.
+        let write_result = std::fs::write(mp1.path().join("should_fail"), b"data");
+        ensure!(
+            write_result.is_err(),
+            "write to read-only overlayfs mount should fail"
+        );
+
+        cmd!(sh, "umount {mp1_path}").run()?;
+    }
+
+    // --- Scenario 2: upperdir + --read-write allows writes that persist in upperdir ---
+    {
+        let upper2 = tempfile::tempdir()?;
+        let work2 = tempfile::tempdir()?;
+        let mp2 = tempfile::tempdir()?;
+        let upper2_path = upper2.path().to_str().unwrap();
+        let work2_path = work2.path().to_str().unwrap();
+        let mp2_path = mp2.path().to_str().unwrap();
+
+        cmd!(
+            sh,
+            "{cfsctl} --insecure --repo {repo_arg} mount {image_name} {mp2_path}
+             --upperdir {upper2_path} --workdir {work2_path} --read-write"
+        )
+        .run()?;
+
+        // Write a new file through the mount.
+        let new_file = mp2.path().join("upper_test_file");
+        std::fs::write(&new_file, b"hello from upper")?;
+
+        // Read it back through the mount.
+        let content = std::fs::read(&new_file)?;
+        ensure!(
+            content == b"hello from upper",
+            "newly written file content mismatch"
+        );
+
+        cmd!(sh, "umount {mp2_path}").run()?;
+
+        // After unmount the file must be visible in the upperdir itself.
+        let upper_file = upper2.path().join("upper_test_file");
+        ensure!(
+            upper_file.exists(),
+            "written file should persist in upperdir after unmount"
+        );
+        let upper_content = std::fs::read(&upper_file)?;
+        ensure!(
+            upper_content == b"hello from upper",
+            "upperdir file content mismatch after unmount"
+        );
+    }
+
+    // --- Scenario 3: plain mount (no upperdir) still works as a baseline ---
+    {
+        let mp3 = tempfile::tempdir()?;
+        let mp3_path = mp3.path().to_str().unwrap();
+
+        cmd!(
+            sh,
+            "{cfsctl} --insecure --repo {repo_arg} mount {image_name} {mp3_path}"
+        )
+        .run()?;
+
+        // Check a known file rather than read_dir to avoid keeping a dirfd open.
+        ensure!(
+            mp3.path().join("etc/hostname").exists(),
+            "plain mount should expose etc/hostname from rootfs"
+        );
+
+        cmd!(sh, "umount {mp3_path}").run()?;
+    }
+
+    Ok(())
+}
+integration_test!(privileged_mount_upper_layer);
 
 /// Verify that `init` on a verity-capable filesystem enables verity on
 /// meta.json, and that `--require-verity` succeeds on such a repo.

--- a/crates/composefs/src/mount.rs
+++ b/crates/composefs/src/mount.rs
@@ -18,7 +18,9 @@ use rustix::{
 };
 
 use crate::{
-    mountcompat::{make_erofs_mountable, overlayfs_set_lower_and_data_fds, prepare_mount},
+    mountcompat::{
+        make_erofs_mountable, overlayfs_set_fd, overlayfs_set_lower_and_data_fds, prepare_mount,
+    },
     util::proc_self_fd,
 };
 
@@ -124,6 +126,29 @@ pub fn erofs_mount(image: OwnedFd) -> Result<OwnedFd> {
     )?)
 }
 
+/// Options controlling how a composefs image is mounted.
+#[derive(Debug, Default)]
+#[non_exhaustive]
+pub struct MountOptions {
+    /// Overlay upper layer and work directory: (upperdir, workdir).
+    upperdirs: Option<(OwnedFd, OwnedFd)>,
+    read_write: bool,
+}
+
+impl MountOptions {
+    /// Add an overlayfs upper layer and work directory to the mount.
+    pub fn set_overlay(&mut self, upperdir: OwnedFd, workdir: OwnedFd) -> &mut Self {
+        self.upperdirs = Some((upperdir, workdir));
+        self
+    }
+
+    /// Make the mount read-write (only meaningful with an overlay).
+    pub fn set_read_write(&mut self, read_write: bool) -> &mut Self {
+        self.read_write = read_write;
+        self
+    }
+}
+
 /// Creates a composefs mount using overlayfs with an erofs image and base directory.
 ///
 /// This mounts a composefs image by creating an overlayfs that layers the erofs image
@@ -136,6 +161,7 @@ pub fn erofs_mount(image: OwnedFd) -> Result<OwnedFd> {
 /// * `name` - Name for the mount source (appears as "composefs:{name}")
 /// * `basedir` - File descriptor for the base directory containing the actual file data
 /// * `enable_verity` - Whether to require fs-verity verification for all files
+/// * `options` - Mount options controlling overlay and read-write behaviour
 ///
 /// # Returns
 ///
@@ -146,6 +172,7 @@ pub fn composefs_fsmount(
     name: &str,
     basedir: impl AsFd,
     enable_verity: bool,
+    options: &MountOptions,
 ) -> Result<OwnedFd> {
     let erofs_mnt = prepare_mount(erofs_mount(image)?)?;
 
@@ -156,12 +183,21 @@ pub fn composefs_fsmount(
     if enable_verity {
         fsconfig_set_string(overlayfs.as_fd(), "verity", "require")?;
     }
+    if let Some((upperdir, workdir)) = &options.upperdirs {
+        overlayfs_set_fd(overlayfs.as_fd(), "upperdir", upperdir.as_fd())?;
+        overlayfs_set_fd(overlayfs.as_fd(), "workdir", workdir.as_fd())?;
+    }
     overlayfs_set_lower_and_data_fds(&overlayfs, &erofs_mnt, Some(&basedir))?;
     fsconfig_create(overlayfs.as_fd())?;
 
+    let mount_attr = if options.read_write {
+        MountAttrFlags::empty()
+    } else {
+        MountAttrFlags::MOUNT_ATTR_RDONLY
+    };
     Ok(fsmount(
         overlayfs.as_fd(),
         FsMountFlags::FSMOUNT_CLOEXEC,
-        MountAttrFlags::empty(),
+        mount_attr,
     )?)
 }

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -113,7 +113,7 @@ use crate::{
         FsVerityHasher, MeasureVerityError, compute_verity, enable_verity_maybe_copy,
         ensure_verity_equal, has_verity, measure_verity, measure_verity_opt,
     },
-    mount::{composefs_fsmount, mount_at},
+    mount::{MountOptions, composefs_fsmount, mount_at},
     shared_internals::IO_BUF_CAPACITY,
     splitstream::{SplitStreamReader, SplitStreamWriter},
     util::{ErrnoFilter, proc_self_fd, reopen_tmpfile_ro, replace_symlinkat},
@@ -2517,7 +2517,7 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     /// Create a detached mount of an image. This file descriptor can then
     /// be attached via e.g. `move_mount`.
     #[context("Mounting image '{name}'")]
-    pub fn mount(&self, name: &str) -> Result<OwnedFd> {
+    pub fn mount_with_options(&self, name: &str, options: &MountOptions) -> Result<OwnedFd> {
         let (image, enable_verity) = self.open_image(name)?;
 
         composefs_fsmount(
@@ -2526,15 +2526,28 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
             self.objects_dir()
                 .context("Getting objects directory for mount")?,
             enable_verity,
+            options,
         )
         .context("Creating filesystem mount")
     }
 
+    /// Create a detached read-only mount of an image.
+    /// This file descriptor can then be attached via e.g. `move_mount`.
+    #[context("Mounting image '{name}'")]
+    pub fn mount(&self, name: &str) -> Result<OwnedFd> {
+        self.mount_with_options(name, &MountOptions::default())
+    }
+
     /// Mount the image with the provided digest at the target path.
     #[context("Mounting image '{name}' at path")]
-    pub fn mount_at(&self, name: &str, mountpoint: impl AsRef<Path>) -> Result<()> {
+    pub fn mount_at(
+        &self,
+        name: &str,
+        mountpoint: impl AsRef<Path>,
+        options: &MountOptions,
+    ) -> Result<()> {
         mount_at(
-            self.mount(name)?,
+            self.mount_with_options(name, options)?,
             CWD,
             &canonicalize(mountpoint).context("Canonicalizing mountpoint path")?,
         )


### PR DESCRIPTION
This is useful from the cli if you want to add a writable layer to a composefs mount. This is better than doing it in a separate overlayfs layer as that would increase the overlayfs stacking depth, etc.