### PR TITLE
cfsctl: Add varlink RPC API and unify structured output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,13 @@ composefs-ioctls = { version = "0.4.0", path = "crates/composefs-ioctls", defaul
 composefs-oci = { version = "0.4.0", path = "crates/composefs-oci", default-features = false }
 composefs-boot = { version = "0.4.0", path = "crates/composefs-boot", default-features = false }
 composefs-http = { version = "0.4.0", path = "crates/composefs-http", default-features = false }
-cap-std-ext = "5.0"
+cap-std-ext = "5.1.2"
 ocidir = "0.7.2"
 
 # JSON-RPC with FD passing for userns helper
 jsonrpc-fdpass = { version = "0.1.0", default-features = false }
+zlink = { version = "0.5", default-features = false, features = ["tokio", "introspection", "proxy", "server", "service", "tracing"] }
+zlink-core = { version = "0.5", default-features = false, features = ["introspection", "std", "tracing"] }
 
 [profile.dev.package.sha2]
 # this is *really* slow otherwise

--- a/crates/composefs-ctl/Cargo.toml
+++ b/crates/composefs-ctl/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [features]
 default = ['pre-6.15', 'oci', 'containers-storage']
 http = ['composefs-http']
-oci = ['composefs-oci']
+oci = ['composefs-oci', 'composefs-oci/varlink']
 containers-storage = ['composefs-oci/containers-storage', 'cstorage']
 rhel9 = ['composefs/rhel9']
 'pre-6.15' = ['composefs/pre-6.15']
@@ -29,7 +29,7 @@ anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
 clap = { version = "4.5.0", default-features = false, features = ["std", "help", "usage", "derive", "wrap_help"] }
 comfy-table = { version = "7.1", default-features = false }
-composefs = { workspace = true }
+composefs = { workspace = true, features = ["varlink"] }
 composefs-boot = { workspace = true }
 composefs-oci = { workspace = true, optional = true, features = ["boot"] }
 composefs-http = { workspace = true, optional = true }
@@ -37,10 +37,13 @@ cstorage = { package = "composefs-storage", path = "../composefs-storage", versi
 env_logger = { version = "0.11.0", default-features = false }
 hex = { version = "0.4.0", default-features = false }
 indicatif = { version = "0.17.0", default-features = false }
+libsystemd = { version = "0.7" }
+log = { version = "0.4", default-features = false }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "process"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
-tokio = { version = "1.24.2", default-features = false, features = ["io-std", "io-util"] }
+tokio = { version = "1.24.2", default-features = false, features = ["io-std", "io-util", "net", "rt", "sync"] }
+zlink = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -22,6 +22,9 @@ pub use composefs_http;
 #[cfg(feature = "oci")]
 pub use composefs_oci;
 
+/// Varlink RPC service exposing repository operations over a Unix socket.
+pub mod varlink;
+
 #[cfg(any(feature = "oci", feature = "http"))]
 use std::collections::HashMap;
 use std::io::Read;
@@ -42,7 +45,6 @@ use comfy_table::{Table, presets::UTF8_FULL};
 #[cfg(any(feature = "oci", feature = "http"))]
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rustix::fs::{CWD, Mode, OFlags};
-use serde::Serialize;
 
 #[cfg(any(feature = "oci", feature = "http"))]
 use composefs::progress::{
@@ -151,23 +153,6 @@ impl ProgressReporter for IndicatifReporter {
     }
 }
 
-/// JSON output wrapper for `cfsctl fsck --json`.
-#[derive(Serialize)]
-struct FsckJsonOutput {
-    ok: bool,
-    #[serde(flatten)]
-    result: composefs::repository::FsckResult,
-}
-
-/// JSON output wrapper for `cfsctl oci fsck --json`.
-#[cfg(feature = "oci")]
-#[derive(Serialize)]
-struct OciFsckJsonOutput {
-    ok: bool,
-    #[serde(flatten)]
-    result: composefs_oci::OciFsckResult,
-}
-
 /// cfsctl
 #[derive(Debug, Parser)]
 #[clap(name = "cfsctl", version)]
@@ -241,7 +226,7 @@ pub enum HashType {
 /// start with `@`.
 #[cfg(feature = "oci")]
 #[derive(Debug, Clone)]
-enum OciReference {
+pub(crate) enum OciReference {
     /// A content-addressable digest such as `sha256:abcdef…`.
     Digest(composefs_oci::OciDigest),
     /// A named ref resolved through the repository's ref tree, typically
@@ -328,11 +313,6 @@ enum OciCommand {
         digest: composefs_oci::OciDigest,
         /// Optional human-readable name for the layer
         name: Option<String>,
-    },
-    /// List the contents of a stored tar layer
-    LsLayer {
-        /// Layer content digest, e.g. sha256:a1b2c3...
-        name: composefs_oci::OciDigest,
     },
     /// Dump the rootfs of a stored OCI image as a composefs dumpfile to stdout
     ///
@@ -463,6 +443,16 @@ enum OciCommand {
         #[clap(long)]
         json: bool,
     },
+    /// Serve the varlink RPC API on a Unix socket or systemd socket.
+    ///
+    /// Equivalent to `cfsctl varlink`: a single service answers both the
+    /// `org.composefs.Repository` and `org.composefs.Oci` interfaces on one
+    /// socket. Kept for discoverability under the `oci` subcommand.
+    Varlink {
+        /// Unix socket path to listen on (omit when using systemd socket activation).
+        #[clap(long)]
+        address: Option<PathBuf>,
+    },
 }
 
 /// Common options for reading a filesystem from a path
@@ -585,9 +575,23 @@ enum Command {
         /// Output results as JSON (always exits 0 unless the check itself fails)
         #[clap(long)]
         json: bool,
+        /// Skip per-object fs-verity verification; check only metadata and
+        /// symlink structure (much faster on large repositories)
+        #[clap(long)]
+        metadata_only: bool,
     },
     #[cfg(feature = "http")]
     Fetch { url: String, name: String },
+    /// Serve the varlink RPC API on a Unix socket or systemd socket.
+    ///
+    /// A single service answers both the `org.composefs.Repository` and (when
+    /// the `oci` feature is enabled) `org.composefs.Oci` interfaces on one
+    /// socket.
+    Varlink {
+        /// Unix socket path to listen on (omit when using systemd socket activation).
+        #[clap(long)]
+        address: Option<PathBuf>,
+    },
 }
 
 /// Acts as a proxy for the `cfsctl` CLI by executing the CLI logic programmatically
@@ -608,7 +612,7 @@ where
 }
 
 #[cfg(feature = "oci")]
-fn verity_opt<ObjectID>(opt: &Option<String>) -> Result<Option<ObjectID>>
+pub(crate) fn verity_opt<ObjectID>(opt: &Option<String>) -> Result<Option<ObjectID>>
 where
     ObjectID: FsVerityHashValue,
 {
@@ -618,21 +622,32 @@ where
     })
 }
 
+/// Resolve the default repository path based on the effective uid.
+///
+/// Root operates on the system repository; everyone else on their per-user
+/// repository. Used both when no `--repo`/`--user`/`--system` is given and by
+/// the socket-activated path (which has no CLI args to consult).
+pub(crate) fn default_repo_path() -> Result<PathBuf> {
+    if rustix::process::getuid().is_root() {
+        Ok(system_path())
+    } else {
+        user_path()
+    }
+}
+
 /// Resolve the repository path from CLI args without opening it.
 ///
 /// Uses [`user_path`] and [`system_path`] to avoid duplicating
 /// path constants.
-fn resolve_repo_path(args: &App) -> Result<PathBuf> {
+pub(crate) fn resolve_repo_path(args: &App) -> Result<PathBuf> {
     if let Some(path) = &args.repo {
         Ok(path.clone())
     } else if args.system {
         Ok(system_path())
     } else if args.user {
         user_path()
-    } else if rustix::process::getuid().is_root() {
-        Ok(system_path())
     } else {
-        user_path()
+        default_repo_path()
     }
 }
 
@@ -647,7 +662,7 @@ fn resolve_repo_path(args: &App) -> Result<PathBuf> {
 /// Note: we read the metadata file directly here (rather than via
 /// `Repository::metadata`) because this runs *before* we know which
 /// generic `ObjectID` type to use — that's exactly what we're deciding.
-fn resolve_hash_type(
+pub(crate) fn resolve_hash_type(
     repo_path: &Path,
     cli_hash: Option<HashType>,
     upgrade: bool,
@@ -702,6 +717,38 @@ fn resolve_hash_type(
     Ok(detected)
 }
 
+/// If the process was started *bare* via systemd socket activation, serve the
+/// varlink API on the activated socket and return `Ok(true)`. Otherwise return
+/// `Ok(false)` so the caller falls through to normal CLI parsing.
+///
+/// This runs *before* clap to support a truly argument-less invocation —
+/// notably `varlinkctl exec:cfsctl`, which hands us the connected socket on fd
+/// 3 but passes no subcommand for clap to parse. A client selects a repository
+/// at runtime via the `OpenRepository` method.
+///
+/// The shortcut is taken *only* when there are no command-line arguments
+/// (`argv` is just the program name). When any argument is present — e.g. a
+/// systemd unit running `cfsctl varlink` — we fall through to clap; the
+/// `varlink`/`oci varlink` subcommand's [`serve`](crate::varlink::serve)
+/// detects and serves on the activation fd itself. We must NOT call
+/// [`try_activated_listener`](crate::varlink::try_activated_listener) on that
+/// path: it consumes `LISTEN_FDS`/`LISTEN_PID` (via `receive_descriptors`),
+/// which would prevent `serve` from finding the fd later.
+pub async fn run_if_socket_activated() -> Result<bool> {
+    // Only take the pre-clap shortcut for a bare invocation (`argv[0]` only).
+    // Check argv before touching the activation env so the latter is consumed
+    // only when we actually intend to serve from this shortcut.
+    if std::env::args_os().len() != 1 {
+        return Ok(false);
+    }
+    let Some(listener) = crate::varlink::try_activated_listener()? else {
+        return Ok(false);
+    };
+    let service = crate::varlink::CfsctlService::activated();
+    crate::varlink::serve_activated(service, listener).await?;
+    Ok(true)
+}
+
 /// Top-level dispatch: handle init specially, otherwise open repo and run.
 pub async fn run_app(args: App) -> Result<()> {
     // Init is handled before opening a repo since it creates one
@@ -719,6 +766,25 @@ pub async fn run_app(args: App) -> Result<()> {
             reset_metadata,
             &args,
         );
+    }
+
+    // The varlink service opens repositories on demand via `OpenRepository`
+    // (handling both hash types), so it bypasses the generic repo-open dispatch
+    // below. A single `CfsctlService` answers both the `org.composefs.Repository`
+    // and (when the `oci` feature is enabled) `org.composefs.Oci` interfaces, so
+    // `cfsctl varlink` and `cfsctl oci varlink` serve the same combined service.
+    if let Command::Varlink { ref address } = args.cmd {
+        let service = crate::varlink::CfsctlService::from_app(&args);
+        return crate::varlink::serve(service, address.as_deref()).await;
+    }
+
+    #[cfg(feature = "oci")]
+    if let Command::Oci {
+        cmd: OciCommand::Varlink { ref address },
+    } = args.cmd
+    {
+        let service = crate::varlink::CfsctlService::from_app(&args);
+        return crate::varlink::serve(service, address.as_deref()).await;
     }
 
     // Commands that only need verity digests (no object storage) can
@@ -815,8 +881,8 @@ fn run_init(
 /// `no_upgrade` is set.
 ///
 /// This is the parameterized core shared by [`open_repo`] (which derives the
-/// path and flags from [`App`]) and other callers that hold these values
-/// directly rather than as a parsed [`App`].
+/// path and flags from [`App`]) and the varlink service (which holds these
+/// values directly).
 pub(crate) fn open_repo_at<ObjectID>(
     path: &Path,
     insecure: bool,
@@ -855,7 +921,7 @@ where
 
 /// Resolve an [`OciReference`] to an [`OciImage`].
 #[cfg(feature = "oci")]
-fn resolve_oci_image<ObjectID: FsVerityHashValue>(
+pub(crate) fn resolve_oci_image<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
     reference: &OciReference,
 ) -> Result<composefs_oci::oci_image::OciImage<ObjectID>> {
@@ -872,7 +938,7 @@ fn resolve_oci_image<ObjectID: FsVerityHashValue>(
 /// When resolving via a named ref, the verity override is ignored since
 /// the image metadata provides the correct verity.
 #[cfg(feature = "oci")]
-fn resolve_oci_config<ObjectID: FsVerityHashValue>(
+pub(crate) fn resolve_oci_config<ObjectID: FsVerityHashValue>(
     repo: &Repository<ObjectID>,
     reference: &OciReference,
     verity_override: Option<ObjectID>,
@@ -1052,9 +1118,6 @@ where
                 .await?;
                 println!("{}", object_id.to_id());
             }
-            OciCommand::LsLayer { ref name } => {
-                composefs_oci::ls_layer(&repo, name)?;
-            }
             OciCommand::Dump { config_opts } => {
                 let fs = load_filesystem_from_oci_image(&repo, config_opts)?;
                 fs.print_dumpfile()?;
@@ -1127,7 +1190,14 @@ where
                 let images = composefs_oci::oci_image::list_images(&repo)?;
 
                 if json {
-                    println!("{}", serde_json::to_string_pretty(&images)?);
+                    let reply = crate::varlink::ListImagesReply {
+                        images: images
+                            .iter()
+                            .map(crate::varlink::ImageEntry::from)
+                            .collect(),
+                    };
+                    serde_json::to_writer_pretty(std::io::stdout().lock(), &reply)?;
+                    println!();
                 } else if images.is_empty() {
                     println!("No images found");
                 } else {
@@ -1178,8 +1248,9 @@ where
                     println!();
                 } else {
                     // Default: output combined JSON with manifest, config, and referrers
-                    let output = img.inspect_json(&repo)?;
-                    println!("{}", serde_json::to_string_pretty(&output)?);
+                    let output = crate::varlink::OciInspectReply::from_image(&repo, &img)?;
+                    serde_json::to_writer_pretty(std::io::stdout().lock(), &output)?;
+                    println!();
                 }
             }
             OciCommand::Tag {
@@ -1200,7 +1271,8 @@ where
             } => {
                 if json {
                     let info = composefs_oci::layer_info(&repo, layer)?;
-                    println!("{}", serde_json::to_string_pretty(&info)?);
+                    serde_json::to_writer_pretty(std::io::stdout().lock(), &info)?;
+                    println!();
                 } else if dumpfile {
                     composefs_oci::layer_dumpfile(&repo, layer, &mut std::io::stdout())?;
                 } else {
@@ -1272,10 +1344,7 @@ where
                     composefs_oci::oci_fsck(&repo).await?
                 };
                 if json {
-                    let output = OciFsckJsonOutput {
-                        ok: result.is_ok(),
-                        result,
-                    };
+                    let output = crate::varlink::OciFsckReply::from(&result);
                     serde_json::to_writer_pretty(std::io::stdout().lock(), &output)?;
                     println!();
                 } else {
@@ -1284,6 +1353,9 @@ where
                         anyhow::bail!("OCI integrity check failed");
                     }
                 }
+            }
+            OciCommand::Varlink { .. } => {
+                unreachable!("oci varlink is handled before opening a repository");
             }
         },
         Command::CreateImage {
@@ -1344,13 +1416,17 @@ where
                 backing_path_only,
             )?;
         }
-        Command::Fsck { json } => {
-            let result = repo.fsck().await?;
+        Command::Fsck {
+            json,
+            metadata_only,
+        } => {
+            let result = if metadata_only {
+                repo.fsck_metadata_only().await?
+            } else {
+                repo.fsck().await?
+            };
             if json {
-                let output = FsckJsonOutput {
-                    ok: result.is_ok(),
-                    result,
-                };
+                let output = crate::varlink::FsckReply::from(&result);
                 serde_json::to_writer_pretty(std::io::stdout().lock(), &output)?;
                 println!();
             } else {
@@ -1359,6 +1435,10 @@ where
                     anyhow::bail!("repository integrity check failed");
                 }
             }
+        }
+        Command::Varlink { .. } => {
+            // Handled in run_app before opening the repo.
+            unreachable!("varlink is handled before opening a repository");
         }
         #[cfg(feature = "http")]
         Command::Fetch { url, name } => {

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -811,13 +811,22 @@ fn run_init(
     Ok(())
 }
 
-/// Open a repo, auto-upgrading old-format repos unless `--no-upgrade` was passed.
-pub fn open_repo<ObjectID>(args: &App) -> Result<Repository<ObjectID>>
+/// Open a repo at an explicit path, auto-upgrading old-format repos unless
+/// `no_upgrade` is set.
+///
+/// This is the parameterized core shared by [`open_repo`] (which derives the
+/// path and flags from [`App`]) and other callers that hold these values
+/// directly rather than as a parsed [`App`].
+pub(crate) fn open_repo_at<ObjectID>(
+    path: &Path,
+    insecure: bool,
+    require_verity: bool,
+    no_upgrade: bool,
+) -> Result<Repository<ObjectID>>
 where
     ObjectID: FsVerityHashValue,
 {
-    let path = resolve_repo_path(args)?;
-    let mut repo = if args.no_upgrade {
+    let mut repo = if no_upgrade {
         Repository::open_path(CWD, path)?
     } else {
         let (repo, _upgraded) = Repository::open_upgrade(CWD, path)?;
@@ -826,13 +835,22 @@ where
     // Hidden --insecure flag for backward compatibility; the default
     // now is to inherit the repo config, but if it's specified we
     // disable requiring verity even if the repo says to use it.
-    if args.insecure {
+    if insecure {
         repo.set_insecure();
     }
-    if args.require_verity {
+    if require_verity {
         repo.require_verity()?;
     }
     Ok(repo)
+}
+
+/// Open a repo, auto-upgrading old-format repos unless `--no-upgrade` was passed.
+pub fn open_repo<ObjectID>(args: &App) -> Result<Repository<ObjectID>>
+where
+    ObjectID: FsVerityHashValue,
+{
+    let path = resolve_repo_path(args)?;
+    open_repo_at(&path, args.insecure, args.require_verity, args.no_upgrade)
 }
 
 /// Resolve an [`OciReference`] to an [`OciImage`].

--- a/crates/composefs-ctl/src/main.rs
+++ b/crates/composefs-ctl/src/main.rs
@@ -25,6 +25,14 @@ fn main() -> Result<()> {
 async fn async_main() -> Result<()> {
     env_logger::init();
 
+    // If we were launched via systemd socket activation (e.g. `varlinkctl
+    // exec:cfsctl`, which passes the connected socket on fd 3 but no
+    // arguments), serve the varlink API directly. This must run before clap,
+    // since a bare activated invocation has no subcommand to parse.
+    if composefs_ctl::run_if_socket_activated().await? {
+        return Ok(());
+    }
+
     let args = App::parse();
     composefs_ctl::run_app(args).await
 }

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -1,0 +1,1756 @@
+//! Varlink RPC service for `cfsctl`.
+//!
+//! Exposes a subset of repository operations over a Unix-socket varlink
+//! interface (`org.composefs.Repository`) so that integration tests and
+//! external callers can consume structured replies instead of scraping the
+//! human-oriented CLI output.
+//!
+//! Repositories are accessed through opaque `u64` handles: a client calls
+//! `OpenRepository` to obtain a handle, passes it to every subsequent method,
+//! and frees it with `CloseRepository`. No repository is opened at startup, so
+//! every call must carry a handle. Each handle stores an already-opened
+//! `Repository<ObjectID>` monomorphized over the digest algorithm detected at
+//! open time, wrapped in an `Arc` so the streaming `Pull` method can move an
+//! owned clone into its `'static` reply stream.
+//!
+//! The zlink server serializes `Service::handle` calls (a single task holds
+//! one `&mut self` borrow at a time), so the handle table is a plain
+//! `HashMap` with no interior locking.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use composefs::fsverity::{Algorithm, FsVerityHashValue, Sha256HashValue, Sha512HashValue};
+use composefs::repository::{FsckResult, Repository, system_path, user_path};
+use rustix::fs::CWD;
+use serde::{Deserialize, Serialize};
+
+use crate::{App, HashType, open_repo_at, resolve_hash_type};
+
+/// Result of a repository consistency check, mirrored for the varlink wire
+/// format.
+///
+/// This is a flattened, snake_case projection of
+/// [`composefs::repository::FsckResult`]; field names follow the varlink
+/// convention rather than the camelCase used by the JSON CLI output.
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+pub struct FsckReply {
+    /// Whether the repository passed the integrity check with no errors.
+    pub ok: bool,
+    /// Whether the repository has a `meta.json` metadata file.
+    pub has_metadata: bool,
+    /// Number of objects whose fs-verity digests were verified.
+    pub objects_checked: u64,
+    /// Number of objects found to have a bad fs-verity digest.
+    pub objects_corrupted: u64,
+    /// Number of splitstreams verified.
+    pub streams_checked: u64,
+    /// Number of splitstreams with issues (bad header, missing refs, etc.).
+    pub streams_corrupted: u64,
+    /// Number of images verified.
+    pub images_checked: u64,
+    /// Number of images with issues.
+    pub images_corrupted: u64,
+    /// Number of broken symlinks found.
+    pub broken_links: u64,
+    /// Number of missing objects referenced by streams.
+    pub missing_objects: u64,
+    /// Human-readable descriptions of each error found.
+    ///
+    /// These are the `Display` rendering of the library's structured
+    /// `FsckError` variants; they carry stable `fsck: <kind>:` prefixes.
+    // TODO: expose the structured `FsckError` variants over the wire once a
+    // varlink-friendly representation (e.g. a tagged struct) is settled on,
+    // so clients can match on error kind instead of parsing strings.
+    pub errors: Vec<String>,
+}
+
+impl From<&FsckResult> for FsckReply {
+    fn from(result: &FsckResult) -> Self {
+        Self {
+            ok: result.is_ok(),
+            has_metadata: result.has_metadata(),
+            objects_checked: result.objects_checked(),
+            objects_corrupted: result.objects_corrupted(),
+            streams_checked: result.streams_checked(),
+            streams_corrupted: result.streams_corrupted(),
+            images_checked: result.images_checked(),
+            images_corrupted: result.images_corrupted(),
+            broken_links: result.broken_links(),
+            missing_objects: result.missing_objects(),
+            errors: result.errors().iter().map(|e| e.to_string()).collect(),
+        }
+    }
+}
+
+/// Result of a garbage-collection run for the varlink wire format.
+///
+/// Wraps the canonical [`composefs::repository::GcResult`] and adds the
+/// `dry_run` flag (which the library type does not carry).
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+pub struct GcReply {
+    /// What was (or would be) removed.
+    pub result: composefs::repository::GcResult,
+    /// Whether this was a dry run (no files actually deleted).
+    pub dry_run: bool,
+}
+
+/// Reply listing the objects referenced by a single image.
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+pub struct ImageObjectsReply {
+    /// The fs-verity object IDs referenced by the image, sorted for
+    /// deterministic output.
+    pub object_ids: Vec<String>,
+}
+
+/// Errors that may be returned by the `org.composefs.Repository` interface.
+#[derive(Debug, zlink::ReplyError, zlink::introspect::ReplyError)]
+#[zlink(interface = "org.composefs.Repository")]
+pub enum RepositoryError {
+    /// The repository could not be found or opened at the configured path.
+    RepoNotFound {
+        /// Description of the failure.
+        message: String,
+    },
+    /// The given handle does not refer to an open repository.
+    InvalidHandle {
+        /// The handle that was not found.
+        handle: u64,
+    },
+    /// The request did not specify a valid repository selector.
+    InvalidSpec {
+        /// Description of the problem with the selector.
+        message: String,
+    },
+    /// The named image/ref does not exist in the repository.
+    NoSuchRef {
+        /// The ref name that was not found.
+        reference: String,
+    },
+    /// An unexpected internal error occurred while servicing the request.
+    InternalError {
+        /// Description of the failure.
+        message: String,
+    },
+}
+
+/// Reply carrying an opaque repository handle.
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+pub struct OpenRepositoryReply {
+    /// The opaque handle to pass to subsequent repository methods.
+    pub handle: u64,
+}
+
+/// Reply from initializing a repository.
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+pub struct InitRepositoryReply {
+    /// `true` if a new repository was created; `false` if one already existed
+    /// at the requested path with the same algorithm (idempotent).
+    pub created: bool,
+}
+
+/// An opened repository, monomorphized over its detected hash algorithm.
+///
+/// Stored as an [`Arc`] so streaming methods can clone an owned handle into a
+/// `'static` reply stream without borrowing the service.
+#[derive(Debug, Clone)]
+pub(crate) enum OpenRepo {
+    /// A repository using the SHA-256 digest algorithm.
+    Sha256(Arc<Repository<Sha256HashValue>>),
+    /// A repository using the SHA-512 digest algorithm.
+    Sha512(Arc<Repository<Sha512HashValue>>),
+}
+
+/// A single entry in the service's open-repository table.
+#[derive(Debug)]
+struct HandleEntry {
+    /// The opened repository.
+    repo: OpenRepo,
+    /// Owning connection id, recorded for a future per-connection disconnect
+    /// hook that will reclaim handles left open by a vanished client. `Option`
+    /// to leave room for handles not tied to a specific connection.
+    #[allow(dead_code)]
+    owner: Option<usize>,
+}
+
+/// Process-wide repository open options, fixed at startup.
+#[derive(Debug, Clone)]
+struct OpenOptions {
+    /// Open the repository in insecure (no verity required) mode.
+    insecure: bool,
+    /// Require fs-verity to be enabled on the repository.
+    require_verity: bool,
+    /// Skip auto-upgrading old-format repositories.
+    no_upgrade: bool,
+}
+
+impl OpenOptions {
+    /// Derive the open options from parsed CLI arguments.
+    fn from_app(args: &App) -> Self {
+        Self {
+            insecure: args.insecure,
+            require_verity: args.require_verity,
+            no_upgrade: args.no_upgrade,
+        }
+    }
+}
+
+impl Default for OpenOptions {
+    /// The uid-default open options used by the socket-activated entry point,
+    /// which serves before CLI parsing and so has no `App` to consult.
+    fn default() -> Self {
+        Self {
+            insecure: false,
+            require_verity: false,
+            no_upgrade: false,
+        }
+    }
+}
+
+/// Varlink service implementation backing the `org.composefs.Repository` (and,
+/// with the `oci` feature, `org.composefs.Oci`) interfaces.
+///
+/// Holds a table of opened repositories keyed by opaque handle. The zlink
+/// server serializes calls to a single service, so the table is a plain
+/// `HashMap` with no interior locking.
+#[derive(Debug)]
+pub(crate) struct CfsctlService {
+    /// Open repositories keyed by opaque handle.
+    repos: HashMap<u64, HandleEntry>,
+    /// Monotonically increasing handle counter; `0` is reserved as "none".
+    next_handle: u64,
+    /// Repository open options fixed at startup.
+    open_opts: OpenOptions,
+}
+
+impl CfsctlService {
+    /// Construct an empty service with the given repository open options.
+    ///
+    /// No repository is opened at startup: a client must explicitly select one
+    /// with `OpenRepository` and pass the returned handle to every subsequent
+    /// call.
+    fn with_open_opts(open_opts: OpenOptions) -> Self {
+        Self {
+            repos: HashMap::new(),
+            next_handle: 0,
+            open_opts,
+        }
+    }
+
+    /// Construct a service from parsed CLI arguments.
+    ///
+    /// The open flags (`--insecure`/`--require-verity`/`--no-upgrade`) carry
+    /// into repositories opened later via `OpenRepository`; the repository
+    /// selection flags (`--repo`/`--user`/`--system`) do not apply, since the
+    /// varlink service opens repositories on demand rather than at startup.
+    pub(crate) fn from_app(args: &App) -> Self {
+        Self::with_open_opts(OpenOptions::from_app(args))
+    }
+
+    /// Construct a service for the socket-activated entry point, which serves
+    /// before CLI parsing and so has no `App` to consult. Uses default open
+    /// options; the client supplies repository paths via `OpenRepository`.
+    pub(crate) fn activated() -> Self {
+        Self::with_open_opts(OpenOptions::default())
+    }
+
+    /// Allocate a fresh, never-reused handle. Starts at `1` (`0` is "none").
+    fn next_handle(&mut self) -> u64 {
+        self.next_handle += 1;
+        self.next_handle
+    }
+
+    /// Look up an open repository by handle for the Repository interface.
+    ///
+    /// Returns an owned [`OpenRepo`] (a cheap `Arc` clone) so callers do not
+    /// hold a borrow of `self` across the subsequent `.await`.
+    fn lookup_repo(&self, handle: u64) -> std::result::Result<OpenRepo, RepositoryError> {
+        self.repos
+            .get(&handle)
+            .map(|entry| entry.repo.clone())
+            .ok_or(RepositoryError::InvalidHandle { handle })
+    }
+
+    /// Look up an open repository by handle for the OCI interface.
+    ///
+    /// Like [`Self::lookup_repo`] but reports the OCI-interface error so the
+    /// wire error name is `org.composefs.Oci.InvalidHandle`.
+    #[cfg(feature = "oci")]
+    fn lookup_oci(&self, handle: u64) -> std::result::Result<OpenRepo, oci::OciError> {
+        self.repos
+            .get(&handle)
+            .map(|entry| entry.repo.clone())
+            .ok_or(oci::OciError::InvalidHandle { handle })
+    }
+
+    /// Resolve, open and register a repository at `path`, returning its handle.
+    ///
+    /// The digest algorithm is detected from the repository metadata; both
+    /// resolution and open failures are reported as
+    /// [`RepositoryError::RepoNotFound`].
+    fn do_open(
+        &mut self,
+        path: &Path,
+        owner: Option<usize>,
+    ) -> std::result::Result<u64, RepositoryError> {
+        let hash_type = resolve_hash_type(path, None, !self.open_opts.no_upgrade).map_err(|e| {
+            RepositoryError::RepoNotFound {
+                message: format!("{e:#}"),
+            }
+        })?;
+        let repo = match hash_type {
+            HashType::Sha256 => OpenRepo::Sha256(Arc::new(
+                open_repo_at::<Sha256HashValue>(
+                    path,
+                    self.open_opts.insecure,
+                    self.open_opts.require_verity,
+                    self.open_opts.no_upgrade,
+                )
+                .map_err(|e| RepositoryError::RepoNotFound {
+                    message: format!("{e:#}"),
+                })?,
+            )),
+            HashType::Sha512 => OpenRepo::Sha512(Arc::new(
+                open_repo_at::<Sha512HashValue>(
+                    path,
+                    self.open_opts.insecure,
+                    self.open_opts.require_verity,
+                    self.open_opts.no_upgrade,
+                )
+                .map_err(|e| RepositoryError::RepoNotFound {
+                    message: format!("{e:#}"),
+                })?,
+            )),
+        };
+        let handle = self.next_handle();
+        self.repos.insert(handle, HandleEntry { repo, owner });
+        Ok(handle)
+    }
+
+    /// Resolve a repository selector (`path`/`user`/`system`) to a path.
+    ///
+    /// Exactly one of the three must be set; otherwise
+    /// [`RepositoryError::InvalidSpec`] is returned.
+    fn resolve_selector(
+        path: Option<String>,
+        user: Option<bool>,
+        system: Option<bool>,
+    ) -> std::result::Result<PathBuf, RepositoryError> {
+        let user = user.unwrap_or(false);
+        let system = system.unwrap_or(false);
+        match (path, user, system) {
+            (Some(p), false, false) => Ok(PathBuf::from(p)),
+            (None, true, false) => user_path().map_err(|e| RepositoryError::InvalidSpec {
+                message: format!("{e:#}"),
+            }),
+            (None, false, true) => Ok(system_path()),
+            _ => Err(RepositoryError::InvalidSpec {
+                message: "exactly one of `path`, `user`, `system` must be set".into(),
+            }),
+        }
+    }
+}
+
+/// Open the repository and run an fsck.
+async fn run_fsck<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    metadata_only: bool,
+) -> std::result::Result<FsckResult, RepositoryError> {
+    let result = if metadata_only {
+        repo.fsck_metadata_only().await
+    } else {
+        repo.fsck().await
+    };
+    result.map_err(|e| RepositoryError::InternalError {
+        message: format!("{e:#}"),
+    })
+}
+
+/// Run garbage collection (or a dry run) on a repository.
+async fn run_gc<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    dry_run: bool,
+    roots: Vec<String>,
+) -> std::result::Result<GcReply, RepositoryError> {
+    let root_refs: Vec<&str> = roots.iter().map(String::as_str).collect();
+    let result = if dry_run {
+        repo.gc_dry_run(&root_refs)
+    } else {
+        repo.gc(&root_refs)
+    }
+    .map_err(|e| RepositoryError::InternalError {
+        message: format!("{e:#}"),
+    })?;
+    Ok(GcReply { result, dry_run })
+}
+
+/// Collect the objects referenced by an image.
+async fn run_image_objects<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: String,
+) -> std::result::Result<ImageObjectsReply, RepositoryError> {
+    let objects = repo.objects_for_image(&name).map_err(|e| {
+        if let Some(nf) = e.downcast_ref::<composefs::ImageNotFound>() {
+            RepositoryError::NoSuchRef {
+                reference: nf.name.clone(),
+            }
+        } else {
+            RepositoryError::InternalError {
+                message: format!("{e:#}"),
+            }
+        }
+    })?;
+    let mut object_ids: Vec<String> = objects.iter().map(|id| id.to_id()).collect();
+    object_ids.sort();
+    Ok(ImageObjectsReply { object_ids })
+}
+
+/// Initialize (or verify) a repository at `path` with the given algorithm.
+///
+/// Creates parent directories if needed, then delegates to
+/// [`Repository::init_path`]. Returns `true` when a new repository was
+/// created and `false` when an identical one already existed (idempotent).
+/// A conflicting existing repository (different algorithm) is an error.
+fn run_init_repository(
+    path: &Path,
+    algorithm: Algorithm,
+    insecure: bool,
+) -> std::result::Result<InitRepositoryReply, RepositoryError> {
+    // Ensure parent directories exist (init_path only creates the final dir).
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| RepositoryError::InternalError {
+            message: format!("creating parent directories for {}: {e:#}", path.display()),
+        })?;
+    }
+
+    let enable_verity = !insecure;
+    let created = match algorithm {
+        Algorithm::Sha256 { .. } => {
+            Repository::<Sha256HashValue>::init_path(CWD, path, algorithm, enable_verity)
+                .map_err(|e| RepositoryError::InternalError {
+                    message: format!("{e:#}"),
+                })?
+                .1
+        }
+        Algorithm::Sha512 { .. } => {
+            Repository::<Sha512HashValue>::init_path(CWD, path, algorithm, enable_verity)
+                .map_err(|e| RepositoryError::InternalError {
+                    message: format!("{e:#}"),
+                })?
+                .1
+        }
+    };
+    Ok(InitRepositoryReply { created })
+}
+
+/// OCI helper functions backing the `org.composefs.Oci` interface, gated behind
+/// the `oci` feature.
+#[cfg(feature = "oci")]
+async fn run_list_images<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    filter: Option<String>,
+) -> std::result::Result<Vec<oci::ImageEntry>, oci::OciError> {
+    composefs_oci::oci_image::list_images(repo)
+        .map(|imgs| {
+            imgs.iter()
+                .filter(|img| match &filter {
+                    Some(needle) => img.name.contains(needle.as_str()),
+                    None => true,
+                })
+                .map(oci::ImageEntry::from)
+                .collect()
+        })
+        .map_err(|e| oci::OciError::InternalError {
+            message: format!("{e:#}"),
+        })
+}
+
+/// Run an OCI-aware consistency check on a repository.
+///
+/// When `image` is `Some`, only that tagged image is checked; otherwise all
+/// tagged images are checked.
+#[cfg(feature = "oci")]
+async fn run_oci_fsck<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    image: Option<String>,
+) -> std::result::Result<oci::OciFsckReply, oci::OciError> {
+    let result = match image {
+        Some(name) => composefs_oci::oci_fsck_image(repo, &name).await,
+        None => composefs_oci::oci_fsck(repo).await,
+    }
+    .map_err(|e| oci::OciError::InternalError {
+        message: format!("{e:#}"),
+    })?;
+    Ok(oci::OciFsckReply::from(&result))
+}
+
+/// Inspect a single OCI image.
+#[cfg(feature = "oci")]
+async fn run_inspect<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    image: String,
+) -> std::result::Result<oci::OciInspectReply, oci::OciError> {
+    let reference: crate::OciReference =
+        image.parse().map_err(|e| oci::OciError::InternalError {
+            message: format!("invalid image reference: {e:#}"),
+        })?;
+    let img = crate::resolve_oci_image(repo, &reference).map_err(|e| {
+        if let Some(nf) = e.downcast_ref::<composefs_oci::OciRefNotFound>() {
+            oci::OciError::NoSuchImage {
+                image: nf.name.clone(),
+            }
+        } else if let Some(nf) = e.downcast_ref::<composefs_oci::OciImageNotFound>() {
+            oci::OciError::NoSuchImage {
+                image: nf.digest.clone(),
+            }
+        } else {
+            oci::OciError::InternalError {
+                message: format!("{e:#}"),
+            }
+        }
+    })?;
+
+    oci::OciInspectReply::from_image(repo, &img).map_err(|e| oci::OciError::InternalError {
+        message: format!("{e:#}"),
+    })
+}
+
+/// Tag a manifest digest with a name.
+#[cfg(feature = "oci")]
+async fn run_tag<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    manifest_digest: String,
+    name: String,
+) -> std::result::Result<(), oci::OciError> {
+    let digest: composefs_oci::OciDigest =
+        manifest_digest
+            .parse()
+            .map_err(|e| oci::OciError::InternalError {
+                message: format!("invalid digest: {e}"),
+            })?;
+    composefs_oci::oci_image::tag_image(repo, &digest, &name).map_err(|e| {
+        oci::OciError::InternalError {
+            message: format!("{e:#}"),
+        }
+    })
+}
+
+/// Remove a tag.
+#[cfg(feature = "oci")]
+async fn run_untag<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    name: String,
+) -> std::result::Result<(), oci::OciError> {
+    composefs_oci::oci_image::untag_image(repo, &name).map_err(|e| oci::OciError::InternalError {
+        message: format!("{e:#}"),
+    })
+}
+
+/// Compute the composefs image ID for an OCI image.
+///
+/// Mirrors the CLI `compute-id` path: digest references (`@sha256:…`) use the
+/// supplied `verity` override, while named refs derive both the config digest
+/// and verity from the stored image metadata (ignoring `verity`).
+#[cfg(feature = "oci")]
+async fn run_compute_id<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    image: String,
+    verity: Option<String>,
+    bootable: bool,
+) -> std::result::Result<oci::OciComputeIdReply, oci::OciError> {
+    let reference: crate::OciReference =
+        image.parse().map_err(|e| oci::OciError::InternalError {
+            message: format!("invalid image reference: {e:#}"),
+        })?;
+    let verity_override =
+        crate::verity_opt::<ObjectID>(&verity).map_err(|e| oci::OciError::InternalError {
+            message: format!("invalid verity: {e:#}"),
+        })?;
+    let (config_digest, config_verity) =
+        crate::resolve_oci_config(repo, &reference, verity_override).map_err(|e| {
+            oci::OciError::InternalError {
+                message: format!("{e:#}"),
+            }
+        })?;
+
+    let mut fs =
+        composefs_oci::image::create_filesystem(repo, &config_digest, config_verity.as_ref())
+            .map_err(|e| oci::OciError::InternalError {
+                message: format!("{e:#}"),
+            })?;
+    if bootable {
+        use composefs_boot::BootOps as _;
+        fs.transform_for_boot(repo)
+            .map_err(|e| oci::OciError::InternalError {
+                message: format!("{e:#}"),
+            })?;
+    }
+    let id = fs.compute_image_id();
+    Ok(oci::OciComputeIdReply {
+        image_id: id.to_hex(),
+    })
+}
+
+// The `zlink::service` macro emits several `pub` helper enums (method dispatch,
+// reply params, etc.) as siblings of the impl block. Those cannot be annotated
+// individually, so the macro invocation lives in a dedicated private submodule
+// where `missing_docs` is relaxed. The generated `Service` trait impl applies
+// to `CfsctlService` regardless of the module it is written in.
+//
+// There are two variants of this module selected at compile time. The macro
+// cannot cfg-gate individual methods (it doesn't propagate `#[cfg]`), and the
+// dispatch enum derives its variants from wire method names (so both
+// interfaces must live in ONE impl block). So when the `oci` feature is on we
+// emit a single impl that hosts BOTH `org.composefs.Repository` and
+// `org.composefs.Oci`; otherwise we emit a Repository-only impl.
+//
+// The interface attribute on each method is "sticky": once a method sets
+// `interface = "org.composefs.Oci"` the macro keeps using it for subsequent
+// methods until changed. The Repository methods come first and inherit the
+// seeded `org.composefs.Repository` interface.
+#[cfg(not(feature = "oci"))]
+mod service_impl {
+    #![allow(missing_docs)]
+
+    use super::{
+        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, OpenRepo,
+        OpenRepositoryReply, RepositoryError, run_fsck, run_gc, run_image_objects,
+        run_init_repository,
+    };
+    use composefs::fsverity::{Algorithm, Sha256HashValue, Sha512HashValue};
+
+    #[zlink::service(
+        interface = "org.composefs.Repository",
+        vendor = "org.composefs",
+        product = "cfsctl",
+        version = env!("CARGO_PKG_VERSION"),
+        url = "https://github.com/composefs/composefs-rs"
+    )]
+    impl<Sock> CfsctlService {
+        /// Initialize a new repository at the given path, or verify that an
+        /// existing one matches the requested algorithm (idempotent).
+        ///
+        /// Creates the directory (and any parents) if they do not exist.
+        /// `algorithm` must be a valid fs-verity algorithm string such as
+        /// `"fsverity-sha512-12"` (the default) or `"fsverity-sha256-12"`.
+        /// When omitted the service default (`fsverity-sha512-12`) is used.
+        /// The `insecure` flag mirrors `cfsctl init --insecure`: when `true`,
+        /// fs-verity is not required on `meta.json`.
+        async fn init_repository(
+            &mut self,
+            path: String,
+            algorithm: Option<String>,
+            insecure: Option<bool>,
+        ) -> std::result::Result<InitRepositoryReply, RepositoryError> {
+            let algorithm: Algorithm = algorithm
+                .as_deref()
+                .unwrap_or("fsverity-sha512-12")
+                .parse()
+                .map_err(|e| RepositoryError::InvalidSpec {
+                    message: format!("invalid algorithm: {e}"),
+                })?;
+            let insecure = insecure.unwrap_or(self.open_opts.insecure);
+            run_init_repository(std::path::Path::new(&path), algorithm, insecure)
+        }
+
+        /// Open and validate a repository, returning an opaque handle.
+        ///
+        /// Exactly one of `path`, `user`, `system` must be set.
+        async fn open_repository(
+            &mut self,
+            path: Option<String>,
+            user: Option<bool>,
+            system: Option<bool>,
+            #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
+        ) -> std::result::Result<OpenRepositoryReply, RepositoryError> {
+            let selected = Self::resolve_selector(path, user, system)?;
+            let handle = self.do_open(&selected, Some(conn.id()))?;
+            Ok(OpenRepositoryReply { handle })
+        }
+
+        /// Close a previously opened repository handle.
+        async fn close_repository(
+            &mut self,
+            handle: u64,
+        ) -> std::result::Result<(), RepositoryError> {
+            self.repos
+                .remove(&handle)
+                .map(|_| ())
+                .ok_or(RepositoryError::InvalidHandle { handle })
+        }
+
+        /// Check repository integrity and return the structured result.
+        ///
+        /// When `metadata_only` is true, the expensive per-object fs-verity
+        /// verification is skipped; only metadata and symlink structure are
+        /// checked.
+        async fn fsck(
+            &self,
+            handle: u64,
+            metadata_only: Option<bool>,
+        ) -> std::result::Result<FsckReply, RepositoryError> {
+            let metadata_only = metadata_only.unwrap_or(false);
+            let result = match self.lookup_repo(handle)? {
+                OpenRepo::Sha256(ref r) => run_fsck::<Sha256HashValue>(r, metadata_only).await,
+                OpenRepo::Sha512(ref r) => run_fsck::<Sha512HashValue>(r, metadata_only).await,
+            }?;
+            Ok(FsckReply::from(&result))
+        }
+
+        /// Run garbage collection (or a dry run) and return what was removed.
+        async fn gc(
+            &self,
+            handle: u64,
+            dry_run: bool,
+            roots: Vec<String>,
+        ) -> std::result::Result<GcReply, RepositoryError> {
+            match self.lookup_repo(handle)? {
+                OpenRepo::Sha256(ref r) => run_gc::<Sha256HashValue>(r, dry_run, roots).await,
+                OpenRepo::Sha512(ref r) => run_gc::<Sha512HashValue>(r, dry_run, roots).await,
+            }
+        }
+
+        /// List the objects referenced by a single image.
+        async fn image_objects(
+            &self,
+            handle: u64,
+            name: String,
+        ) -> std::result::Result<ImageObjectsReply, RepositoryError> {
+            match self.lookup_repo(handle)? {
+                OpenRepo::Sha256(ref r) => run_image_objects::<Sha256HashValue>(r, name).await,
+                OpenRepo::Sha512(ref r) => run_image_objects::<Sha512HashValue>(r, name).await,
+            }
+        }
+    }
+}
+
+// Combined variant: hosts BOTH the `org.composefs.Repository` and
+// `org.composefs.Oci` interfaces from a single impl block on `CfsctlService`,
+// so one service answers both interfaces on one socket. See the comment above
+// for why this can't be cfg-gated method-by-method.
+#[cfg(feature = "oci")]
+mod service_impl {
+    #![allow(missing_docs)]
+
+    use super::oci::{
+        ListImagesReply, OciComputeIdReply, OciError, OciFsckReply, OciInspectReply, PullProgress,
+        parse_local_fetch, pull_stream,
+    };
+    use super::{
+        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, OpenRepo,
+        OpenRepositoryReply, RepositoryError, run_compute_id, run_fsck, run_gc, run_image_objects,
+        run_init_repository, run_inspect, run_list_images, run_oci_fsck, run_tag, run_untag,
+    };
+    use composefs::fsverity::{Algorithm, Sha256HashValue, Sha512HashValue};
+
+    #[zlink::service(
+        interface = "org.composefs.Repository",
+        vendor = "org.composefs",
+        product = "cfsctl",
+        version = env!("CARGO_PKG_VERSION"),
+        url = "https://github.com/composefs/composefs-rs"
+    )]
+    impl<Sock> CfsctlService {
+        // --- org.composefs.Repository (inherits the seeded interface) ---
+
+        /// Initialize a new repository at the given path, or verify that an
+        /// existing one matches the requested algorithm (idempotent).
+        ///
+        /// Creates the directory (and any parents) if they do not exist.
+        /// `algorithm` must be a valid fs-verity algorithm string such as
+        /// `"fsverity-sha512-12"` (the default) or `"fsverity-sha256-12"`.
+        /// When omitted the service default (`fsverity-sha512-12`) is used.
+        /// The `insecure` flag mirrors `cfsctl init --insecure`: when `true`,
+        /// fs-verity is not required on `meta.json`.
+        async fn init_repository(
+            &mut self,
+            path: String,
+            algorithm: Option<String>,
+            insecure: Option<bool>,
+        ) -> std::result::Result<InitRepositoryReply, RepositoryError> {
+            let algorithm: Algorithm = algorithm
+                .as_deref()
+                .unwrap_or("fsverity-sha512-12")
+                .parse()
+                .map_err(|e| RepositoryError::InvalidSpec {
+                    message: format!("invalid algorithm: {e}"),
+                })?;
+            let insecure = insecure.unwrap_or(self.open_opts.insecure);
+            run_init_repository(std::path::Path::new(&path), algorithm, insecure)
+        }
+
+        /// Open and validate a repository, returning an opaque handle.
+        ///
+        /// Exactly one of `path`, `user`, `system` must be set.
+        async fn open_repository(
+            &mut self,
+            path: Option<String>,
+            user: Option<bool>,
+            system: Option<bool>,
+            #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
+        ) -> std::result::Result<OpenRepositoryReply, RepositoryError> {
+            let selected = Self::resolve_selector(path, user, system)?;
+            let handle = self.do_open(&selected, Some(conn.id()))?;
+            Ok(OpenRepositoryReply { handle })
+        }
+
+        /// Close a previously opened repository handle.
+        async fn close_repository(
+            &mut self,
+            handle: u64,
+        ) -> std::result::Result<(), RepositoryError> {
+            self.repos
+                .remove(&handle)
+                .map(|_| ())
+                .ok_or(RepositoryError::InvalidHandle { handle })
+        }
+
+        /// Check repository integrity and return the structured result.
+        ///
+        /// When `metadata_only` is true, the expensive per-object fs-verity
+        /// verification is skipped; only metadata and symlink structure are
+        /// checked.
+        async fn fsck(
+            &self,
+            handle: u64,
+            metadata_only: Option<bool>,
+        ) -> std::result::Result<FsckReply, RepositoryError> {
+            let metadata_only = metadata_only.unwrap_or(false);
+            let result = match self.lookup_repo(handle)? {
+                OpenRepo::Sha256(ref r) => run_fsck::<Sha256HashValue>(r, metadata_only).await,
+                OpenRepo::Sha512(ref r) => run_fsck::<Sha512HashValue>(r, metadata_only).await,
+            }?;
+            Ok(FsckReply::from(&result))
+        }
+
+        /// Run garbage collection (or a dry run) and return what was removed.
+        async fn gc(
+            &self,
+            handle: u64,
+            dry_run: bool,
+            roots: Vec<String>,
+        ) -> std::result::Result<GcReply, RepositoryError> {
+            match self.lookup_repo(handle)? {
+                OpenRepo::Sha256(ref r) => run_gc::<Sha256HashValue>(r, dry_run, roots).await,
+                OpenRepo::Sha512(ref r) => run_gc::<Sha512HashValue>(r, dry_run, roots).await,
+            }
+        }
+
+        /// List the objects referenced by a single image.
+        async fn image_objects(
+            &self,
+            handle: u64,
+            name: String,
+        ) -> std::result::Result<ImageObjectsReply, RepositoryError> {
+            match self.lookup_repo(handle)? {
+                OpenRepo::Sha256(ref r) => run_image_objects::<Sha256HashValue>(r, name).await,
+                OpenRepo::Sha512(ref r) => run_image_objects::<Sha512HashValue>(r, name).await,
+            }
+        }
+
+        // --- org.composefs.Oci ---
+        //
+        // The first OCI method sets `interface = "org.composefs.Oci"`; the
+        // macro then keeps that interface sticky for subsequent methods. Each
+        // OCI method is still annotated explicitly for clarity.
+
+        /// List tagged OCI images in the repository.
+        ///
+        /// When `filter` is given, only images whose name contains that
+        /// substring are returned.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn list_images(
+            &self,
+            handle: u64,
+            filter: Option<String>,
+        ) -> std::result::Result<ListImagesReply, OciError> {
+            let images = match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => run_list_images::<Sha256HashValue>(r, filter).await,
+                OpenRepo::Sha512(ref r) => run_list_images::<Sha512HashValue>(r, filter).await,
+            }?;
+            Ok(ListImagesReply { images })
+        }
+
+        /// Run an OCI-aware consistency check on the repository.
+        ///
+        /// Renamed on the wire to `Check` so it does not collide with the
+        /// repository-level `Fsck` method (the dispatch enum keys on the wire
+        /// method name, which must be globally unique across both interfaces).
+        #[zlink(interface = "org.composefs.Oci", rename = "Check")]
+        async fn oci_fsck(
+            &self,
+            handle: u64,
+            image: Option<String>,
+        ) -> std::result::Result<OciFsckReply, OciError> {
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => run_oci_fsck::<Sha256HashValue>(r, image).await,
+                OpenRepo::Sha512(ref r) => run_oci_fsck::<Sha512HashValue>(r, image).await,
+            }
+        }
+
+        /// Inspect a single OCI image.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn inspect(
+            &self,
+            handle: u64,
+            image: String,
+        ) -> std::result::Result<OciInspectReply, OciError> {
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => run_inspect::<Sha256HashValue>(r, image).await,
+                OpenRepo::Sha512(ref r) => run_inspect::<Sha512HashValue>(r, image).await,
+            }
+        }
+
+        /// Tag a manifest digest with a name.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn tag(
+            &self,
+            handle: u64,
+            manifest_digest: String,
+            name: String,
+        ) -> std::result::Result<(), OciError> {
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => {
+                    run_tag::<Sha256HashValue>(r, manifest_digest, name).await
+                }
+                OpenRepo::Sha512(ref r) => {
+                    run_tag::<Sha512HashValue>(r, manifest_digest, name).await
+                }
+            }
+        }
+
+        /// Remove a tag.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn untag(&self, handle: u64, name: String) -> std::result::Result<(), OciError> {
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => run_untag::<Sha256HashValue>(r, name).await,
+                OpenRepo::Sha512(ref r) => run_untag::<Sha512HashValue>(r, name).await,
+            }
+        }
+
+        /// Compute the composefs image ID for an OCI image.
+        #[zlink(interface = "org.composefs.Oci")]
+        async fn compute_id(
+            &self,
+            handle: u64,
+            image: String,
+            verity: Option<String>,
+            bootable: bool,
+        ) -> std::result::Result<OciComputeIdReply, OciError> {
+            match self.lookup_oci(handle)? {
+                OpenRepo::Sha256(ref r) => {
+                    run_compute_id::<Sha256HashValue>(r, image, verity, bootable).await
+                }
+                OpenRepo::Sha512(ref r) => {
+                    run_compute_id::<Sha512HashValue>(r, image, verity, bootable).await
+                }
+            }
+        }
+
+        /// Pull an OCI image into the repository, streaming progress.
+        ///
+        /// Emits zero or more intermediate [`PullProgress`] frames describing
+        /// fetch progress (only when `more` is true), followed by exactly one
+        /// terminal frame whose `completed` field is set, carrying the pull result.
+        #[zlink(interface = "org.composefs.Oci", more)]
+        #[allow(clippy::too_many_arguments)]
+        async fn pull(
+            &self,
+            more: bool,
+            handle: u64,
+            image: String,
+            name: Option<String>,
+            local_fetch: String,
+            storage_root: Option<String>,
+            bootable: bool,
+        ) -> impl zlink::futures_util::Stream<
+            Item = std::result::Result<zlink::Reply<PullProgress>, OciError>,
+        > + Send {
+            let lf = parse_local_fetch(&local_fetch);
+            let sr = storage_root.map(std::path::PathBuf::from);
+            // Resolve the handle synchronously and clone an owned Arc out so the
+            // returned stream owns everything it needs ('static). On a missing
+            // handle, yield a one-shot error stream (`pull_stream` and the
+            // error path share the same boxed-trait-object return type).
+            match self.repos.get(&handle).map(|entry| &entry.repo) {
+                Some(OpenRepo::Sha256(r)) => {
+                    pull_stream::<Sha256HashValue>(r.clone(), image, name, lf, sr, bootable, more)
+                }
+                Some(OpenRepo::Sha512(r)) => {
+                    pull_stream::<Sha512HashValue>(r.clone(), image, name, lf, sr, bootable, more)
+                }
+                None => {
+                    use zlink::futures_util::stream;
+                    Box::pin(stream::once(async move {
+                        Err(OciError::InvalidHandle { handle })
+                    }))
+                }
+            }
+        }
+    }
+}
+
+/// A `Listener` that yields a single pre-connected socket, then blocks forever.
+///
+/// Used for socket activation where a connected socket pair is
+/// passed on fd 3. After the first `accept()` returns the connection, subsequent
+/// calls pend indefinitely (the server will be killed by the parent process once
+/// the connection closes).
+#[derive(Debug)]
+pub(crate) struct ActivatedListener {
+    /// The connection to yield on the first accept(), consumed after use.
+    conn: Option<zlink::Connection<zlink::unix::Stream>>,
+}
+
+impl zlink::Listener for ActivatedListener {
+    type Socket = zlink::unix::Stream;
+
+    async fn accept(&mut self) -> zlink::Result<zlink::Connection<Self::Socket>> {
+        match self.conn.take() {
+            Some(conn) => Ok(conn),
+            None => std::future::pending().await,
+        }
+    }
+}
+
+/// Try to build an [`ActivatedListener`] from a socket-activated fd.
+///
+/// Uses `libsystemd` to receive file descriptors passed by the service
+/// manager (checks `LISTEN_FDS`/`LISTEN_PID` and clears the env vars).
+/// Returns `None` when the process was not socket-activated.
+#[allow(unsafe_code)]
+pub(crate) fn try_activated_listener() -> Result<Option<ActivatedListener>> {
+    use std::os::fd::{FromRawFd as _, IntoRawFd as _};
+
+    let fds = libsystemd::activation::receive_descriptors(true)
+        .map_err(|e| anyhow::anyhow!("Failed to receive activation fds: {e}"))?;
+
+    let fd = match fds.into_iter().next() {
+        Some(fd) => fd,
+        None => return Ok(None),
+    };
+
+    // SAFETY: `libsystemd::activation::receive_descriptors(true)` validated
+    // the fd and transferred ownership. `into_raw_fd()` consumes the
+    // `FileDescriptor` wrapper, giving us sole ownership of a valid fd.
+    let std_stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd.into_raw_fd()) };
+    std_stream
+        .set_nonblocking(true)
+        .context("setting systemd socket to non-blocking")?;
+    let tokio_stream = tokio::net::UnixStream::from_std(std_stream)
+        .context("converting systemd UnixStream to tokio")?;
+    let zlink_stream = zlink::unix::Stream::from(tokio_stream);
+    let conn = zlink::Connection::from(zlink_stream);
+    Ok(Some(ActivatedListener { conn: Some(conn) }))
+}
+
+/// Serve `service` on an already-obtained socket-activated listener.
+///
+/// Status is logged, never written to stdout: under socket activation (e.g.
+/// varlinkctl's `exec:` transport) the parent may treat our stdout as part of
+/// the protocol handshake, and any stray bytes there reset the connection.
+pub(crate) async fn serve_activated<S>(service: S, listener: ActivatedListener) -> Result<()>
+where
+    S: zlink::Service<zlink::unix::Stream>,
+{
+    log::info!("Listening on systemd-activated socket");
+    let server = zlink::Server::new(listener, service);
+    server
+        .run()
+        .await
+        .context("running varlink server (activated)")
+}
+
+/// Serve `service` either on a systemd-activated connected socket or by
+/// binding a fresh Unix socket at `address`.
+///
+/// Socket activation takes precedence: if the process was started with a
+/// connected activation socket, `address` is ignored. Otherwise `address`
+/// must be `Some`, or this returns an error.
+pub(crate) async fn serve<S>(service: S, address: Option<&Path>) -> Result<()>
+where
+    S: zlink::Service<zlink::unix::Stream>,
+{
+    if let Some(activated) = try_activated_listener()? {
+        return serve_activated(service, activated).await;
+    }
+    let address = address.context("no --address given and not socket-activated")?;
+    let listener = zlink::unix::bind(address)
+        .with_context(|| format!("binding varlink socket at {}", address.display()))?;
+    log::info!("Listening on {}", address.display());
+    let server = zlink::Server::new(listener, service);
+    server.run().await.context("running varlink server")
+}
+
+/// Varlink support for the OCI interface (`org.composefs.Oci`).
+///
+/// Gated behind the `oci` feature; collected in one module so the feature
+/// gate lives in a single place rather than on every item.
+#[cfg(feature = "oci")]
+pub mod oci {
+    use super::*;
+
+    /// Summary of a stored OCI image for the varlink wire format.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct ImageEntry {
+        /// Tag/name of the image.
+        pub name: String,
+        /// Manifest digest, e.g. "sha256:...".
+        pub manifest_digest: String,
+        /// Whether this is a container image (vs an artifact).
+        pub is_container: bool,
+        /// Architecture (empty for artifacts).
+        pub architecture: String,
+        /// Operating system (empty for artifacts).
+        pub os: String,
+        /// Creation timestamp, if recorded.
+        pub created: Option<String>,
+        /// Number of layers/blobs.
+        pub layer_count: u64,
+        /// Number of OCI referrers (signatures, attestations, etc.).
+        pub referrer_count: u64,
+    }
+
+    impl From<&composefs_oci::oci_image::ImageInfo> for ImageEntry {
+        fn from(info: &composefs_oci::oci_image::ImageInfo) -> Self {
+            Self {
+                name: info.name.clone(),
+                manifest_digest: info.manifest_digest.to_string(),
+                is_container: info.is_container,
+                architecture: info.architecture.clone(),
+                os: info.os.clone(),
+                created: info.created.clone(),
+                layer_count: info.layer_count as u64,
+                referrer_count: info.referrer_count as u64,
+            }
+        }
+    }
+
+    /// Reply format for listing OCI images.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct ListImagesReply {
+        /// The images found in the repository.
+        pub images: Vec<ImageEntry>,
+    }
+
+    /// Result of an OCI-level consistency check for the varlink wire format.
+    ///
+    /// Flattened projection of [`composefs_oci::oci_fsck`]'s `OciFsckResult`; the
+    /// embedded [`FsckReply`] carries the underlying repository-level results.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct OciFsckReply {
+        /// Whether no corruption or errors were found at any level.
+        pub ok: bool,
+        /// Number of OCI images checked.
+        pub images_checked: u64,
+        /// Number of OCI images found to have issues.
+        pub images_corrupted: u64,
+        /// Human-readable descriptions of each OCI-level error found.
+        pub errors: Vec<String>,
+        /// The underlying repository-level fsck results.
+        pub repo: FsckReply,
+    }
+
+    impl From<&composefs_oci::OciFsckResult> for OciFsckReply {
+        fn from(result: &composefs_oci::OciFsckResult) -> Self {
+            Self {
+                ok: result.is_ok(),
+                images_checked: result.images_checked(),
+                images_corrupted: result.images_corrupted(),
+                errors: result.errors().iter().map(|e| e.to_string()).collect(),
+                repo: FsckReply::from(result.repo_result()),
+            }
+        }
+    }
+
+    /// Reply with the manifest, config and referrers of a single OCI image.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct OciInspectReply {
+        /// The raw manifest JSON as stored, as a UTF-8 string.
+        pub manifest: String,
+        /// The raw config JSON as stored, as a UTF-8 string.
+        pub config: String,
+        /// Digests of the OCI referrers (signatures, attestations, etc.).
+        pub referrers: Vec<String>,
+        /// Hex fs-verity ID of the linked composefs EROFS image, if any.
+        pub composefs_erofs: Option<String>,
+        /// Hex fs-verity ID of the linked bootable composefs EROFS image, if any.
+        ///
+        /// Present when the image was pulled with `bootable` support; bootc and
+        /// other GC-aware callers use this to keep the derived boot EROFS object
+        /// alive alongside the primary image.
+        pub composefs_boot_erofs: Option<String>,
+    }
+
+    impl OciInspectReply {
+        /// Build an inspect reply from a resolved image, reading its manifest,
+        /// config and referrers from the repository.
+        pub fn from_image<ObjectID: FsVerityHashValue>(
+            repo: &Repository<ObjectID>,
+            img: &composefs_oci::oci_image::OciImage<ObjectID>,
+        ) -> anyhow::Result<Self> {
+            let manifest = String::from_utf8(img.read_manifest_json(repo)?)
+                .context("manifest is not valid UTF-8")?;
+            let config = String::from_utf8(img.read_config_json(repo)?)
+                .context("config is not valid UTF-8")?;
+            let referrers = composefs_oci::oci_image::list_referrers(repo, img.manifest_digest())?
+                .iter()
+                .map(|(digest, _verity)| digest.to_string())
+                .collect();
+            Ok(Self {
+                manifest,
+                config,
+                referrers,
+                composefs_erofs: img.image_ref().map(|id| id.to_hex()),
+                composefs_boot_erofs: img.boot_image_ref().map(|id| id.to_hex()),
+            })
+        }
+    }
+
+    /// Reply carrying the computed composefs image ID for an OCI image.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct OciComputeIdReply {
+        /// The hex-encoded composefs image ID.
+        pub image_id: String,
+    }
+
+    /// A single progress frame emitted by the streaming `Pull` method.
+    ///
+    /// varlink has no tagged/data-union type, so a sum-of-events is modelled as a
+    /// struct with one optional field per event shape: exactly one field is set
+    /// per frame, and its presence acts as the discriminant. (zlink does support
+    /// nested struct fields, hence the dedicated [`Started`]/[`Progress`]/etc.
+    /// payload types rather than a flat bag of always-empty columns.)
+    ///
+    /// The stream yields zero or more intermediate frames (with `continues=true`)
+    /// describing fetch progress, followed by exactly one terminal frame whose
+    /// [`completed`](PullProgress::completed) field is set (and `continues=false`)
+    /// carrying the pull result.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct PullProgress {
+        /// A new component started downloading.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub started: Option<Started>,
+        /// Incremental transfer progress for a component.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub progress: Option<Progress>,
+        /// A component was skipped because it was already present.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub skipped: Option<Skipped>,
+        /// A component finished downloading.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub done: Option<Done>,
+        /// A human-readable status message.
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub message: Option<String>,
+        /// The terminal frame carrying the pull result. Its presence marks the
+        /// end of the stream (the reply also has `continues=false`).
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        pub completed: Option<Completed>,
+    }
+
+    /// Unit of measurement for [`Started`]/[`Progress`] counters.
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, zlink::introspect::Type)]
+    pub enum ProgressUnit {
+        /// Counters are byte counts.
+        Bytes,
+        /// Counters are discrete item counts.
+        Items,
+    }
+
+    impl From<composefs::progress::ProgressUnit> for ProgressUnit {
+        fn from(unit: composefs::progress::ProgressUnit) -> Self {
+            use composefs::progress::ProgressUnit as U;
+            match unit {
+                U::Bytes => ProgressUnit::Bytes,
+                U::Items => ProgressUnit::Items,
+                // `ProgressUnit` is `#[non_exhaustive]`; default to items.
+                _ => ProgressUnit::Items,
+            }
+        }
+    }
+
+    /// A new component (layer/object) started downloading.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct Started {
+        /// Component id (layer/object digest).
+        pub id: String,
+        /// Total bytes/items to transfer, if known.
+        pub total: Option<u64>,
+        /// Unit of `total` and subsequent [`Progress`] counters.
+        pub unit: ProgressUnit,
+    }
+
+    /// Incremental transfer progress for a component.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct Progress {
+        /// Component id (layer/object digest).
+        pub id: String,
+        /// Bytes/items transferred so far.
+        pub fetched: u64,
+        /// Total bytes/items to transfer, if known.
+        pub total: Option<u64>,
+    }
+
+    /// A component was skipped because it was already present.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct Skipped {
+        /// Component id (layer/object digest).
+        pub id: String,
+    }
+
+    /// A component finished downloading.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct Done {
+        /// Component id (layer/object digest).
+        pub id: String,
+        /// Total bytes/items actually transferred.
+        pub transferred: u64,
+    }
+
+    /// The result of a completed pull.
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+    pub struct Completed {
+        /// Manifest digest of the pulled image.
+        pub manifest_digest: String,
+        /// Config digest of the pulled image.
+        pub config_digest: String,
+        /// Hex fs-verity of the manifest splitstream.
+        pub manifest_verity: String,
+        /// Hex fs-verity of the config splitstream.
+        pub config_verity: String,
+        /// `Display` rendering of the import stats.
+        pub stats: String,
+        /// Hex fs-verity of the generated boot EROFS image, when a bootable pull
+        /// was requested; `None` otherwise.
+        pub boot_image: Option<String>,
+    }
+
+    impl PullProgress {
+        /// An empty frame with every variant cleared. Construct a frame by
+        /// setting exactly one field.
+        fn empty() -> Self {
+            PullProgress {
+                started: None,
+                progress: None,
+                skipped: None,
+                done: None,
+                message: None,
+                completed: None,
+            }
+        }
+    }
+
+    impl From<composefs::progress::ProgressEvent> for PullProgress {
+        /// Map a library [`composefs::progress::ProgressEvent`] to a wire frame,
+        /// consuming the event so owned fields (e.g. a `Message` string) move
+        /// rather than clone.
+        fn from(event: composefs::progress::ProgressEvent) -> Self {
+            use composefs::progress::ProgressEvent;
+
+            let mut p = PullProgress::empty();
+            match event {
+                ProgressEvent::Started { id, total, unit } => {
+                    p.started = Some(Started {
+                        id: id.into_inner(),
+                        total,
+                        unit: unit.into(),
+                    });
+                }
+                ProgressEvent::Progress { id, fetched, total } => {
+                    p.progress = Some(Progress {
+                        id: id.into_inner(),
+                        fetched,
+                        total,
+                    });
+                }
+                ProgressEvent::Skipped { id } => {
+                    p.skipped = Some(Skipped {
+                        id: id.into_inner(),
+                    });
+                }
+                ProgressEvent::Done { id, transferred } => {
+                    p.done = Some(Done {
+                        id: id.into_inner(),
+                        transferred,
+                    });
+                }
+                ProgressEvent::Message(s) => {
+                    p.message = Some(s);
+                }
+                // `ProgressEvent` is `#[non_exhaustive]`; map unknown variants to a
+                // message frame so future additions remain forward-compatible.
+                other => {
+                    p.message = Some(format!("{other:?}"));
+                }
+            }
+            p
+        }
+    }
+
+    /// A [`composefs::progress::ProgressReporter`] that forwards each event as a
+    /// [`PullProgress`] frame over an unbounded channel to the streaming method.
+    struct ChannelReporter {
+        tx: tokio::sync::mpsc::UnboundedSender<PullProgress>,
+    }
+
+    impl std::fmt::Debug for ChannelReporter {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ChannelReporter").finish_non_exhaustive()
+        }
+    }
+
+    impl composefs::progress::ProgressReporter for ChannelReporter {
+        fn report(&self, event: composefs::progress::ProgressEvent) {
+            // The receiver may have been dropped (client cancelled the stream);
+            // dropping the event is the right behaviour in that case.
+            let _ = self.tx.send(PullProgress::from(event));
+        }
+    }
+
+    /// Aborts the wrapped pull task when dropped.
+    ///
+    /// If the client disconnects before the stream completes, dropping the
+    /// returned stream drops this guard, which aborts the in-flight pull instead
+    /// of leaking the task.
+    struct AbortOnDrop {
+        handle: Option<tokio::task::JoinHandle<std::result::Result<(), OciError>>>,
+    }
+
+    impl AbortOnDrop {
+        /// Take the join handle out, disarming the abort-on-drop behaviour.
+        fn take(&mut self) -> Option<tokio::task::JoinHandle<std::result::Result<(), OciError>>> {
+            self.handle.take()
+        }
+    }
+
+    impl std::fmt::Debug for AbortOnDrop {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("AbortOnDrop").finish_non_exhaustive()
+        }
+    }
+
+    impl Drop for AbortOnDrop {
+        fn drop(&mut self) {
+            if let Some(handle) = &self.handle {
+                handle.abort();
+            }
+        }
+    }
+
+    /// Parse the wire `local_fetch` string into a [`composefs_oci::LocalFetchOpt`].
+    ///
+    /// Unknown values fall back to [`LocalFetchOpt::Disabled`](composefs_oci::LocalFetchOpt::Disabled).
+    pub(crate) fn parse_local_fetch(value: &str) -> composefs_oci::LocalFetchOpt {
+        use composefs_oci::LocalFetchOpt;
+        match value {
+            "auto" | "if-possible" => LocalFetchOpt::IfPossible,
+            "zerocopy" | "zero-copy" => LocalFetchOpt::ZeroCopy,
+            _ => LocalFetchOpt::Disabled,
+        }
+    }
+
+    /// Run a streaming pull against an already-opened repository, returning a
+    /// boxed stream of [`PullProgress`] frames.
+    ///
+    /// The return type is a concrete boxed trait object rather than `impl Stream`
+    /// so that both monomorphisations (Sha256/Sha512) of this generic function
+    /// produce the *same* type — letting the non-generic service `pull` method
+    /// unify the two match arms under a single `impl Stream` return.
+    ///
+    /// When `more` is `false` the client asked for a single reply, so no progress
+    /// reporter is attached and the stream yields only the terminal `completed`
+    /// frame (or an error).
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn pull_stream<ObjectID: FsVerityHashValue>(
+        repo: Arc<Repository<ObjectID>>,
+        image: String,
+        name: Option<String>,
+        local_fetch: composefs_oci::LocalFetchOpt,
+        storage_root: Option<PathBuf>,
+        bootable: bool,
+        more: bool,
+    ) -> std::pin::Pin<
+        Box<
+            dyn zlink::futures_util::Stream<
+                    Item = std::result::Result<zlink::Reply<PullProgress>, OciError>,
+                > + Send,
+        >,
+    > {
+        use zlink::futures_util::stream;
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<PullProgress>();
+        // Only attach a progress reporter when the client wants streaming frames.
+        let reporter: Option<composefs::progress::SharedReporter> = if more {
+            Some(std::sync::Arc::new(ChannelReporter { tx: tx.clone() }))
+        } else {
+            None
+        };
+
+        // The task owns everything it needs ('static): it runs the pull, builds the
+        // terminal `completed` frame from the result (plus optional boot image),
+        // and sends it through the channel before the sender drops.  Pull errors
+        // are carried out via the task's `JoinHandle` return value.
+        let task_tx = tx.clone();
+        let handle = tokio::spawn(async move {
+            let opts = composefs_oci::PullOptions {
+                local_fetch,
+                storage_root: storage_root.as_deref(),
+                progress: reporter,
+                ..Default::default()
+            };
+            let result = composefs_oci::pull(&repo, &image, name.as_deref(), opts)
+                .await
+                .map_err(|e| OciError::InternalError {
+                    message: format!("{e:#}"),
+                })?;
+
+            let boot_image = if bootable {
+                let id = composefs_oci::generate_boot_image(&repo, &result.manifest_digest)
+                    .map_err(|e| OciError::InternalError {
+                        message: format!("{e:#}"),
+                    })?;
+                Some(id.to_hex())
+            } else {
+                None
+            };
+
+            let completed = PullProgress {
+                completed: Some(Completed {
+                    manifest_digest: result.manifest_digest.to_string(),
+                    config_digest: result.config_digest.to_string(),
+                    manifest_verity: result.manifest_verity.to_hex(),
+                    config_verity: result.config_verity.to_hex(),
+                    stats: result.stats.to_string(),
+                    boot_image,
+                }),
+                ..PullProgress::empty()
+            };
+            // If the receiver is gone the client cancelled; that's fine.
+            let _ = task_tx.send(completed);
+            Ok(())
+        });
+
+        // Drop our extra sender handle so the channel closes once the task's clone
+        // is dropped (i.e. when the task finishes).
+        drop(tx);
+
+        struct State {
+            rx: tokio::sync::mpsc::UnboundedReceiver<PullProgress>,
+            handle: Option<AbortOnDrop>,
+            done: bool,
+        }
+
+        let state = State {
+            rx,
+            handle: Some(AbortOnDrop {
+                handle: Some(handle),
+            }),
+            done: false,
+        };
+
+        let stream = stream::unfold(state, |mut state| async move {
+            if state.done {
+                return None;
+            }
+            match state.rx.recv().await {
+                Some(frame) => {
+                    let is_completed = frame.completed.is_some();
+                    if is_completed {
+                        state.done = true;
+                        // Disarm the abort guard: the task has produced its result
+                        // frame and is finished, so there is nothing left to abort.
+                        if let Some(guard) = state.handle.as_mut() {
+                            let _ = guard.take();
+                        }
+                    }
+                    let reply = zlink::Reply::new(Some(frame)).set_continues(Some(!is_completed));
+                    Some((Ok(reply), state))
+                }
+                None => {
+                    // Channel closed without a terminal frame: the pull failed (or
+                    // the task panicked). Await the join handle to recover the error.
+                    state.done = true;
+                    // Take the join handle out (disarming the abort guard, since
+                    // the task has already finished) and recover the pull error.
+                    let join = state.handle.as_mut().and_then(AbortOnDrop::take);
+                    let err = match join {
+                        Some(join) => match join.await {
+                            Ok(Ok(())) => OciError::InternalError {
+                                message: "pull completed without a result frame".to_string(),
+                            },
+                            Ok(Err(e)) => e,
+                            Err(_) => OciError::InternalError {
+                                message: "pull task panicked".to_string(),
+                            },
+                        },
+                        None => OciError::InternalError {
+                            message: "pull task panicked".to_string(),
+                        },
+                    };
+                    Some((Err(err), state))
+                }
+            }
+        });
+
+        Box::pin(stream)
+    }
+
+    /// Errors that may be returned by the `org.composefs.Oci` interface.
+    #[derive(Debug, zlink::ReplyError, zlink::introspect::ReplyError)]
+    #[zlink(interface = "org.composefs.Oci")]
+    pub enum OciError {
+        /// The repository could not be found or opened at the configured path.
+        RepoNotFound {
+            /// Description of the failure.
+            message: String,
+        },
+        /// The given handle does not refer to an open repository.
+        InvalidHandle {
+            /// The handle that was not found.
+            handle: u64,
+        },
+        /// The named OCI image/reference does not exist.
+        NoSuchImage {
+            /// The image reference that was not found.
+            image: String,
+        },
+        /// An unexpected internal error occurred while servicing the request.
+        InternalError {
+            /// Description of the failure.
+            message: String,
+        },
+    }
+}
+
+/// Typed Rust client bindings (the native-API mirror of the on-the-wire
+/// varlink interfaces). These let a Rust consumer — the integration tests
+/// today, and a future cfsctl-as-client — call the service with generated,
+/// type-checked proxy methods, in addition to the wire protocol exercised by
+/// external clients such as `varlinkctl`.
+pub mod proxy {
+    #![allow(missing_docs)]
+
+    #[cfg(feature = "oci")]
+    use super::oci::{
+        ListImagesReply, OciComputeIdReply, OciError, OciFsckReply, OciInspectReply, PullProgress,
+    };
+    use super::{
+        FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, OpenRepositoryReply,
+        RepositoryError,
+    };
+    #[cfg(feature = "oci")]
+    use zlink::futures_util::Stream;
+
+    /// Typed client for the `org.composefs.Repository` interface.
+    #[zlink::proxy(interface = "org.composefs.Repository")]
+    pub trait RepositoryProxy {
+        /// Initialize a new repository (or verify an existing one).
+        async fn init_repository(
+            &mut self,
+            path: &str,
+            algorithm: Option<&str>,
+            insecure: Option<bool>,
+        ) -> zlink::Result<Result<InitRepositoryReply, RepositoryError>>;
+
+        /// Open and validate a repository, returning an opaque handle.
+        async fn open_repository(
+            &mut self,
+            path: Option<&str>,
+            user: Option<bool>,
+            system: Option<bool>,
+        ) -> zlink::Result<Result<OpenRepositoryReply, RepositoryError>>;
+
+        /// Close a previously opened repository handle.
+        async fn close_repository(
+            &mut self,
+            handle: u64,
+        ) -> zlink::Result<Result<(), RepositoryError>>;
+
+        /// Check repository integrity.
+        async fn fsck(
+            &mut self,
+            handle: u64,
+            metadata_only: Option<bool>,
+        ) -> zlink::Result<Result<FsckReply, RepositoryError>>;
+
+        /// Run garbage collection (or a dry run).
+        async fn gc(
+            &mut self,
+            handle: u64,
+            dry_run: bool,
+            roots: Vec<String>,
+        ) -> zlink::Result<Result<GcReply, RepositoryError>>;
+
+        /// List the objects referenced by a single image.
+        async fn image_objects(
+            &mut self,
+            handle: u64,
+            name: &str,
+        ) -> zlink::Result<Result<ImageObjectsReply, RepositoryError>>;
+    }
+
+    /// Typed client for the `org.composefs.Oci` interface.
+    #[cfg(feature = "oci")]
+    #[zlink::proxy(interface = "org.composefs.Oci")]
+    pub trait OciProxy {
+        /// List tagged OCI images.
+        async fn list_images(
+            &mut self,
+            handle: u64,
+            filter: Option<&str>,
+        ) -> zlink::Result<Result<ListImagesReply, OciError>>;
+
+        /// Run an OCI-aware consistency check (wire method `Check`).
+        #[zlink(rename = "Check")]
+        async fn oci_fsck(
+            &mut self,
+            handle: u64,
+            image: Option<&str>,
+        ) -> zlink::Result<Result<OciFsckReply, OciError>>;
+
+        /// Inspect a single OCI image.
+        async fn inspect(
+            &mut self,
+            handle: u64,
+            image: &str,
+        ) -> zlink::Result<Result<OciInspectReply, OciError>>;
+
+        /// Tag a manifest digest with a name.
+        async fn tag(
+            &mut self,
+            handle: u64,
+            manifest_digest: &str,
+            name: &str,
+        ) -> zlink::Result<Result<(), OciError>>;
+
+        /// Remove a tag.
+        async fn untag(&mut self, handle: u64, name: &str) -> zlink::Result<Result<(), OciError>>;
+
+        /// Compute the composefs image ID for an OCI image.
+        async fn compute_id(
+            &mut self,
+            handle: u64,
+            image: &str,
+            verity: Option<&str>,
+            bootable: bool,
+        ) -> zlink::Result<Result<OciComputeIdReply, OciError>>;
+
+        /// Pull an OCI image, streaming progress frames.
+        #[zlink(more, rename = "Pull")]
+        async fn pull(
+            &mut self,
+            handle: u64,
+            image: &str,
+            name: Option<&str>,
+            local_fetch: &str,
+            storage_root: Option<&str>,
+            bootable: bool,
+        ) -> zlink::Result<impl Stream<Item = zlink::Result<Result<PullProgress, OciError>>>>;
+    }
+}
+
+#[cfg(feature = "oci")]
+pub(crate) use oci::*;

--- a/crates/composefs-integration-tests/Cargo.toml
+++ b/crates/composefs-integration-tests/Cargo.toml
@@ -36,6 +36,10 @@ composefs = { workspace = true }
 # Only the test_util module is used — for creating test OCI images.
 # All verification must go through the cfsctl CLI.
 composefs-oci = { workspace = true, features = ["test", "boot", "containers-storage"] }
+# Used by the varlink tests to drive the service through zlink's native typed
+# proxy bindings (alongside the external `varlinkctl` CLI), and to assert on the
+# typed wire reply/error types.
+composefs-ctl = { workspace = true, features = ["oci"] }
 hex = "0.4"
 libtest-mimic = "0.8"
 linkme = "0.3"
@@ -48,6 +52,7 @@ tar = "0.4"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 xshell = "0.2"
+zlink = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/composefs-integration-tests/src/tests/cli.rs
+++ b/crates/composefs-integration-tests/src/tests/cli.rs
@@ -19,7 +19,10 @@ const OCI_LAYOUT_COMPOSEFS_ID: &str = "f26c6eb439749b82f0d1520e83455bb21766572fb
 /// Create a fresh initialized insecure repository in a tempdir.
 ///
 /// Returns the tempdir (for lifetime) and the path to the repo.
-fn init_insecure_repo(sh: &Shell, cfsctl: &std::path::Path) -> Result<tempfile::TempDir> {
+pub(crate) fn init_insecure_repo(
+    sh: &Shell,
+    cfsctl: &std::path::Path,
+) -> Result<tempfile::TempDir> {
     let repo_dir = tempfile::tempdir()?;
     let repo = repo_dir.path();
     cmd!(sh, "{cfsctl} --repo {repo} init --insecure").read()?;
@@ -199,11 +202,14 @@ fn test_oci_images_json_empty_repo() -> Result<()> {
     let repo = repo_dir.path();
 
     let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci images --json").read()?;
-    // Empty JSON array
+    // Empty image list: { "images": [] }
     let parsed: serde_json::Value = serde_json::from_str(&output)?;
     assert!(
-        parsed.as_array().map(|a| a.is_empty()).unwrap_or(false),
-        "expected empty JSON array, got: {output}"
+        parsed["images"]
+            .as_array()
+            .map(|a| a.is_empty())
+            .unwrap_or(false),
+        "expected empty images array, got: {output}"
     );
     Ok(())
 }
@@ -212,7 +218,7 @@ integration_test!(test_oci_images_json_empty_repo);
 /// Creates a minimal OCI image layout directory for testing using the ocidir crate.
 ///
 /// Returns the path to the OCI layout directory.
-fn create_oci_layout(parent: &std::path::Path) -> Result<std::path::PathBuf> {
+pub(crate) fn create_oci_layout(parent: &std::path::Path) -> Result<std::path::PathBuf> {
     use cap_std_ext::cap_std;
     use ocidir::oci_spec::image::{
         ConfigBuilder, ImageConfigurationBuilder, Platform, PlatformBuilder, RootFsBuilder,
@@ -316,7 +322,7 @@ fn test_oci_pull_and_inspect() -> Result<()> {
     // List images as JSON
     let json_output = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci images --json").read()?;
     let images: serde_json::Value = serde_json::from_str(&json_output)?;
-    let arr = images.as_array().expect("expected array");
+    let arr = images["images"].as_array().expect("expected images array");
     assert_eq!(arr.len(), 1, "expected 1 image");
     assert_eq!(arr[0]["name"], "test-image");
     assert_eq!(arr[0]["architecture"], "amd64");
@@ -622,7 +628,7 @@ integration_test!(test_dump_files);
 ///
 /// Walks `objects/XX/` directories, deletes the first regular file found,
 /// and replaces it with junk data. Panics if no object is found.
-fn corrupt_one_object(repo: &std::path::Path) -> Result<()> {
+pub(crate) fn corrupt_one_object(repo: &std::path::Path) -> Result<()> {
     use cap_std_ext::cap_std;
 
     let dir = cap_std::fs::Dir::open_ambient_dir(repo, cap_std::ambient_authority())?;
@@ -902,8 +908,8 @@ fn test_fsck_empty_repo() -> Result<()> {
     let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} fsck --json").read()?;
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v["ok"], true);
-    assert_eq!(v["objectsChecked"], 0);
-    assert_eq!(v["objectsCorrupted"], 0);
+    assert_eq!(v["objects_checked"], 0);
+    assert_eq!(v["objects_corrupted"], 0);
     assert!(v["errors"].as_array().unwrap().is_empty());
     Ok(())
 }
@@ -926,8 +932,8 @@ fn test_fsck_healthy_repo() -> Result<()> {
     let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} fsck --json").read()?;
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v["ok"], true);
-    assert!(v["objectsChecked"].as_u64().unwrap() > 0);
-    assert_eq!(v["objectsCorrupted"], 0);
+    assert!(v["objects_checked"].as_u64().unwrap() > 0);
+    assert_eq!(v["objects_corrupted"], 0);
     assert!(v["errors"].as_array().unwrap().is_empty());
     Ok(())
 }
@@ -951,7 +957,7 @@ fn test_fsck_detects_corrupted_object() -> Result<()> {
     let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} fsck --json").read()?;
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v["ok"], false);
-    assert!(v["objectsCorrupted"].as_u64().unwrap() > 0);
+    assert!(v["objects_corrupted"].as_u64().unwrap() > 0);
     assert!(!v["errors"].as_array().unwrap().is_empty());
     Ok(())
 }
@@ -997,8 +1003,8 @@ fn test_oci_fsck_healthy() -> Result<()> {
     let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci fsck --json").read()?;
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v["ok"], true);
-    assert_eq!(v["imagesChecked"], 1);
-    assert_eq!(v["imagesCorrupted"], 0);
+    assert_eq!(v["images_checked"], 1);
+    assert_eq!(v["images_corrupted"], 0);
     Ok(())
 }
 integration_test!(test_oci_fsck_healthy);
@@ -1070,7 +1076,7 @@ fn test_oci_fsck_single_image() -> Result<()> {
     .read()?;
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v["ok"], true);
-    assert_eq!(v["imagesChecked"], 1);
+    assert_eq!(v["images_checked"], 1);
 
     // A nonexistent image is a hard error (not a corruption finding)
     cmd!(
@@ -1214,7 +1220,7 @@ fn test_fsck_detects_broken_image_ref() -> Result<()> {
     let output = cmd!(sh, "{cfsctl} --insecure --repo {repo} fsck --json").read()?;
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v["ok"], false);
-    assert!(v["brokenLinks"].as_u64().unwrap() > 0);
+    assert!(v["broken_links"].as_u64().unwrap() > 0);
     Ok(())
 }
 integration_test!(test_fsck_detects_broken_image_ref);
@@ -1441,7 +1447,7 @@ fn test_oci_tag_and_untag() -> Result<()> {
     // Both tags should appear in list
     let list_output = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci images --json").read()?;
     let images: serde_json::Value = serde_json::from_str(&list_output)?;
-    let names: Vec<&str> = images
+    let names: Vec<&str> = images["images"]
         .as_array()
         .unwrap()
         .iter()
@@ -1459,7 +1465,7 @@ fn test_oci_tag_and_untag() -> Result<()> {
     // Only the remaining tag should appear
     let list_output = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci images --json").read()?;
     let images: serde_json::Value = serde_json::from_str(&list_output)?;
-    let names: Vec<&str> = images
+    let names: Vec<&str> = images["images"]
         .as_array()
         .unwrap()
         .iter()
@@ -1500,7 +1506,8 @@ fn test_oci_gc_removes_untagged() -> Result<()> {
 
     // Verify it exists
     let list_before = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci images --json").read()?;
-    let images_before: Vec<serde_json::Value> = serde_json::from_str(&list_before)?;
+    let images_before: serde_json::Value = serde_json::from_str(&list_before)?;
+    let images_before = images_before["images"].as_array().expect("images array");
     assert_eq!(images_before.len(), 1, "expected 1 image before untag");
 
     // Untag it
@@ -1515,7 +1522,8 @@ fn test_oci_gc_removes_untagged() -> Result<()> {
 
     // Verify image is gone
     let list_after = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci images --json").read()?;
-    let images_after: Vec<serde_json::Value> = serde_json::from_str(&list_after)?;
+    let images_after: serde_json::Value = serde_json::from_str(&list_after)?;
+    let images_after = images_after["images"].as_array().expect("images array");
     assert!(
         images_after.is_empty(),
         "expected no images after GC, got: {:?}",
@@ -1644,7 +1652,10 @@ fn test_compute_image_id() -> Result<()> {
     )
     .read()?;
     let inspect: serde_json::Value = serde_json::from_str(&inspect_output)?;
-    let config_digest = inspect["manifest"]["config"]["digest"]
+    // The inspect reply carries the manifest as a raw JSON string.
+    let manifest: serde_json::Value =
+        serde_json::from_str(inspect["manifest"].as_str().expect("manifest string"))?;
+    let config_digest = manifest["config"]["digest"]
         .as_str()
         .expect("expected config digest");
     // Digests must be prefixed with '@' to distinguish from named refs

--- a/crates/composefs-integration-tests/src/tests/cstor.rs
+++ b/crates/composefs-integration-tests/src/tests/cstor.rs
@@ -442,7 +442,7 @@ fn privileged_test_cstor_bootable() -> Result<()> {
     // Verify the image is visible via oci images (OCI manifest tag was created)
     let ls_output = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci images --json").read()?;
     let images: serde_json::Value = serde_json::from_str(&ls_output)?;
-    let images_arr = images.as_array().expect("oci ls should return array");
+    let images_arr = images["images"].as_array().expect("oci ls images array");
     assert!(
         !images_arr.is_empty(),
         "oci ls should show at least one image after cstor pull"

--- a/crates/composefs-integration-tests/src/tests/mod.rs
+++ b/crates/composefs-integration-tests/src/tests/mod.rs
@@ -5,3 +5,4 @@ pub mod cstor;
 pub mod digest_stability;
 pub mod old_format;
 pub mod privileged;
+pub mod varlink;

--- a/crates/composefs-integration-tests/src/tests/varlink.rs
+++ b/crates/composefs-integration-tests/src/tests/varlink.rs
@@ -1,0 +1,1392 @@
+//! Integration tests for the `cfsctl` varlink RPC API.
+//!
+//! These drive the service the same way an external consumer would: they spawn
+//! `cfsctl varlink --address <socket>` (or `cfsctl oci varlink ...`) as a
+//! separate process and talk to it over the Unix socket.
+//!
+//! ## Two clients, on purpose
+//!
+//! The suite deliberately uses *both* of the ways a consumer can talk to the
+//! service, because they prove different things:
+//!
+//! * **`varlinkctl`** (systemd's CLI) exercises the real on-the-wire varlink
+//!   protocol against the *canonical* implementation. This is the interop
+//!   guarantee — it proves the bytes we put on the socket are what the
+//!   ecosystem expects. Most tests use this path (the `call`/`call_more`/
+//!   `call_expect_err` helpers).
+//! * **zlink's typed Rust proxy** (the `#[zlink::proxy]` bindings exposed by
+//!   `composefs_ctl::varlink::proxy`) exercises the generated, type-checked
+//!   client bindings — the same path a future cfsctl-as-client would use. This
+//!   catches type-level regressions `varlinkctl` cannot see (a renamed field or
+//!   changed shape still serialises to *some* JSON, but fails to deserialise
+//!   into the typed reply). A small, high-value subset uses this path (the
+//!   `proxy_*` helpers), notably the negative tests, which assert the *exact*
+//!   typed error variant rather than merely "something failed".
+//!
+//! When adding a test, prefer `varlinkctl` for wire/interop coverage; reach for
+//! the typed proxy when you specifically want to pin down a typed reply or a
+//! typed error variant. Avoid converting the whole suite to either side.
+//!
+//! A single service answers both the `org.composefs.Repository` and
+//! `org.composefs.Oci` interfaces on one socket, so the `repository()` and
+//! `oci()` spawn helpers below differ only in which CLI subcommand starts the
+//! (identical) combined service.
+//!
+//! ## Handle-based API
+//!
+//! The service now requires an explicit repository handle on every method call.
+//! On startup, the service pre-opens the repo passed via `--repo` and assigns
+//! it handle `1`. `VarlinkService::spawn` fetches this default handle and
+//! stores it; `call` and `call_more` automatically inject `"handle":N` into
+//! the params object. Use `call_raw` / `call_more_raw` to skip injection (e.g.
+//! for negative tests).
+
+use std::path::Path;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use composefs_ctl::varlink::oci::{OciError, OciInspectReply, PullProgress};
+use composefs_ctl::varlink::proxy::{OciProxy, RepositoryProxy};
+use composefs_ctl::varlink::{ImageObjectsReply, InitRepositoryReply, RepositoryError};
+use serde_json::{Value, json};
+use xshell::{Shell, cmd};
+use zlink::futures_util::TryStreamExt;
+
+use crate::tests::cli::{corrupt_one_object, create_oci_layout, init_insecure_repo};
+use crate::{cfsctl, create_test_rootfs, integration_test};
+
+/// A `cfsctl` varlink service spawned on a Unix socket for the duration of a
+/// test. Killed on drop.
+struct VarlinkService {
+    child: std::process::Child,
+    socket: std::path::PathBuf,
+    /// Handle for the test repository, opened via `OpenRepository` at spawn and
+    /// auto-injected into subsequent calls.
+    handle: u64,
+    /// Current-thread runtime used to drive the async zlink proxy client from
+    /// the synchronous test functions.
+    rt: tokio::runtime::Runtime,
+    // Keep the tempdir holding the socket alive for the service's lifetime.
+    _socket_dir: tempfile::TempDir,
+}
+
+impl Drop for VarlinkService {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl VarlinkService {
+    /// Spawn `cfsctl <service_args...> --address <sock>`, wait for the socket to
+    /// appear, then open `repo` via `OpenRepository` and cache its handle.
+    ///
+    /// The varlink service opens no repository at startup, so the test repo is
+    /// opened explicitly here; the returned handle is auto-injected into
+    /// subsequent calls. The repository's insecure mode is auto-detected from
+    /// its metadata, so no open flags are needed.
+    fn spawn(repo: &Path, service_args: &[&str]) -> Result<Self> {
+        let cfsctl = cfsctl()?;
+        let socket_dir = tempfile::tempdir()?;
+        let socket = socket_dir.path().join("varlink.sock");
+
+        let mut cmd = Command::new(&cfsctl);
+        cmd.args(service_args);
+        cmd.arg("--address").arg(&socket);
+        let child = cmd.spawn().context("spawning cfsctl varlink server")?;
+
+        // Wait (briefly) for the service to bind the socket.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !socket.exists() {
+            if Instant::now() > deadline {
+                bail!("timed out waiting for varlink socket {}", socket.display());
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        let handle = Self::open_repository(&socket, repo)?;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("building tokio runtime for zlink client")?;
+
+        Ok(VarlinkService {
+            child,
+            socket,
+            handle,
+            rt,
+            _socket_dir: socket_dir,
+        })
+    }
+
+    /// Open a repository via `OpenRepository` and return its handle value.
+    fn open_repository(socket: &Path, repo: &Path) -> Result<u64> {
+        let sock_str = socket.to_string_lossy();
+        let params = json!({"path": repo.to_str().context("repo path not UTF-8")?}).to_string();
+        let output = Command::new("varlinkctl")
+            .args([
+                "--json=short",
+                "call",
+                &sock_str,
+                "org.composefs.Repository.OpenRepository",
+                &params,
+            ])
+            .output()
+            .context("running varlinkctl for OpenRepository")?;
+        if !output.status.success() {
+            bail!(
+                "OpenRepository failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let stdout = String::from_utf8(output.stdout).context("varlinkctl output not UTF-8")?;
+        let line = stdout
+            .lines()
+            .map(|l| l.trim_start_matches('\u{1e}').trim())
+            .find(|l| !l.is_empty())
+            .context("no reply from OpenRepository")?;
+        let reply: Value = serde_json::from_str(line)
+            .with_context(|| format!("parsing OpenRepository reply: {line}"))?;
+        reply["handle"]
+            .as_u64()
+            .context("OpenRepository reply missing numeric 'handle'")
+    }
+
+    /// Spawn the combined service via the top-level `varlink` subcommand.
+    fn repository(repo: &Path) -> Result<Self> {
+        Self::spawn(repo, &["varlink"])
+    }
+
+    /// Spawn the combined service via the `oci varlink` subcommand. Serves the
+    /// same interfaces as [`Self::repository`]; kept to exercise both CLI entry
+    /// points.
+    fn oci(repo: &Path) -> Result<Self> {
+        Self::spawn(repo, &["oci", "varlink"])
+    }
+
+    fn socket_str(&self) -> String {
+        self.socket.to_string_lossy().into_owned()
+    }
+
+    /// Inject `"handle": self.handle` into a JSON object params value if the
+    /// caller did not already set it. Non-object params are returned unchanged.
+    fn inject_handle(&self, mut params: Value) -> Value {
+        if let Value::Object(ref mut map) = params {
+            map.entry("handle").or_insert_with(|| json!(self.handle));
+        }
+        params
+    }
+
+    /// Invoke `varlinkctl call <socket> <method> <params>` and return the
+    /// parsed JSON reply. Automatically injects `"handle"` into object params.
+    /// Returns an error if the call fails (non-zero exit).
+    fn call(&self, method: &str, params: Value) -> Result<Value> {
+        let params = self.inject_handle(params);
+        self.run(&["call", &self.socket_str(), method, &params.to_string()])
+            .map(|frames| frames.into_iter().next().unwrap_or(Value::Null))
+    }
+
+    /// Like [`call`] but does NOT inject the handle. Use for negative tests
+    /// that need precise control over the params (e.g. testing `InvalidHandle`
+    /// or `InvalidSpec`).
+    fn call_raw(&self, method: &str, params: Value) -> Result<Value> {
+        self.run(&["call", &self.socket_str(), method, &params.to_string()])
+            .map(|frames| frames.into_iter().next().unwrap_or(Value::Null))
+    }
+
+    /// Like [`call_raw`] but expects the call to **fail**. Returns the
+    /// stderr string (containing the varlink error name) on non-zero exit,
+    /// or bails if the call unexpectedly succeeds.
+    fn call_expect_err(&self, method: &str, params: Value) -> Result<String> {
+        let output = Command::new("varlinkctl")
+            .arg("--json=short")
+            .args(["call", &self.socket_str(), method, &params.to_string()])
+            .output()
+            .context("running varlinkctl (is systemd's varlinkctl installed?)")?;
+        if output.status.success() {
+            bail!("expected {method} to fail, but it succeeded");
+        }
+        Ok(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+
+    // ── zlink typed proxy client ─────────────────────────────────────────
+    //
+    // These drive the *same* spawned `cfsctl varlink` process, but via zlink's
+    // generated Rust bindings instead of the `varlinkctl` CLI. The outer
+    // `zlink::Result` is a transport/protocol error (wrong method, connection
+    // dropped, malformed reply); the inner `Result<_, E>` is the typed varlink
+    // error reply. Negative tests assert the inner typed error variant, which a
+    // bare `is_err()` (that also catches transport failures) could not.
+
+    /// Connect a fresh zlink client to the service socket.
+    async fn connect(&self) -> zlink::Result<zlink::unix::Connection> {
+        zlink::unix::connect(&self.socket).await
+    }
+
+    /// `org.composefs.Oci.Inspect` via the typed proxy, using the cached handle.
+    fn proxy_inspect(&self, image: &str) -> zlink::Result<Result<OciInspectReply, OciError>> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            conn.inspect(self.handle, image).await
+        })
+    }
+
+    /// `org.composefs.Repository.ImageObjects` via the typed proxy.
+    fn proxy_image_objects(
+        &self,
+        name: &str,
+    ) -> zlink::Result<Result<ImageObjectsReply, RepositoryError>> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            conn.image_objects(self.handle, name).await
+        })
+    }
+
+    /// `org.composefs.Repository.InitRepository` via the typed proxy.
+    fn proxy_init_repository(
+        &self,
+        path: &str,
+        algorithm: Option<&str>,
+        insecure: Option<bool>,
+    ) -> zlink::Result<Result<InitRepositoryReply, RepositoryError>> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            conn.init_repository(path, algorithm, insecure).await
+        })
+    }
+
+    /// `org.composefs.Oci.Pull` via the typed streaming proxy. Collects all
+    /// `PullProgress` frames into a `Vec`, surfacing the first error (transport
+    /// or typed) encountered.
+    fn proxy_pull(
+        &self,
+        image: &str,
+        name: Option<&str>,
+        bootable: bool,
+    ) -> zlink::Result<Result<Vec<PullProgress>, OciError>> {
+        self.rt.block_on(async {
+            let mut conn = self.connect().await?;
+            let stream = conn
+                .pull(self.handle, image, name, "disabled", None, bootable)
+                .await?;
+            zlink::futures_util::pin_mut!(stream);
+            let mut frames = Vec::new();
+            while let Some(item) = stream.try_next().await? {
+                match item {
+                    Ok(frame) => frames.push(frame),
+                    Err(e) => return Ok(Err(e)),
+                }
+            }
+            Ok(Ok(frames))
+        })
+    }
+
+    /// Run a streaming (`--more`) call and return all reply frames.
+    /// Automatically injects `"handle"` into object params.
+    fn call_more(&self, method: &str, params: Value) -> Result<Vec<Value>> {
+        let params = self.inject_handle(params);
+        self.run(&[
+            "--more",
+            "call",
+            &self.socket_str(),
+            method,
+            &params.to_string(),
+        ])
+    }
+
+    /// Invoke `varlinkctl` and parse its stdout (one JSON object per line) into
+    /// reply frames. `--json=short` forces single-line JSON regardless of
+    /// whether stdout is a tty.
+    fn run(&self, args: &[&str]) -> Result<Vec<Value>> {
+        let output = Command::new("varlinkctl")
+            .arg("--json=short")
+            .args(args)
+            .output()
+            .context("running varlinkctl (is systemd's varlinkctl installed?)")?;
+        if !output.status.success() {
+            bail!(
+                "varlinkctl {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let stdout = String::from_utf8(output.stdout).context("varlinkctl output not UTF-8")?;
+        let mut frames = Vec::new();
+        for line in stdout.lines() {
+            // `varlinkctl --more` emits JSON-SEQ (RFC 7464): each record is
+            // prefixed with an ASCII record-separator (0x1e). Strip it.
+            let line = line.trim_start_matches('\u{1e}').trim();
+            if line.is_empty() {
+                continue;
+            }
+            frames.push(
+                serde_json::from_str(line).with_context(|| format!("parsing reply: {line}"))?,
+            );
+        }
+        Ok(frames)
+    }
+}
+
+fn test_varlink_fsck_empty_repo() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+    let reply = svc.call("org.composefs.Repository.Fsck", json!({}))?;
+    assert_eq!(reply["ok"], true);
+    assert_eq!(reply["objects_checked"], 0);
+    assert!(reply["errors"].as_array().unwrap().is_empty());
+
+    Ok(())
+}
+integration_test!(test_varlink_fsck_empty_repo);
+
+fn test_varlink_fsck_healthy_repo() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs} my-image"
+    )
+    .read()?;
+
+    let svc = VarlinkService::repository(repo)?;
+    let reply = svc.call("org.composefs.Repository.Fsck", json!({}))?;
+    assert_eq!(reply["ok"], true);
+    assert!(reply["objects_checked"].as_u64().unwrap() > 0);
+    assert_eq!(reply["objects_corrupted"], 0);
+    assert!(reply["errors"].as_array().unwrap().is_empty());
+
+    Ok(())
+}
+integration_test!(test_varlink_fsck_healthy_repo);
+
+fn test_varlink_fsck_metadata_only() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs} my-image"
+    )
+    .read()?;
+
+    let svc = VarlinkService::repository(repo)?;
+    // metadata_only skips per-object verification, so objects_checked stays 0.
+    let reply = svc.call(
+        "org.composefs.Repository.Fsck",
+        json!({"metadata_only": true}),
+    )?;
+    assert_eq!(reply["ok"], true);
+    assert_eq!(reply["objects_checked"], 0);
+    assert!(reply["errors"].as_array().unwrap().is_empty());
+
+    Ok(())
+}
+integration_test!(test_varlink_fsck_metadata_only);
+
+fn test_varlink_fsck_detects_corruption() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs} my-image"
+    )
+    .read()?;
+
+    corrupt_one_object(repo)?;
+
+    let svc = VarlinkService::repository(repo)?;
+    let reply = svc.call("org.composefs.Repository.Fsck", json!({}))?;
+    assert_eq!(reply["ok"], false);
+    assert!(reply["objects_corrupted"].as_u64().unwrap() > 0);
+    assert!(!reply["errors"].as_array().unwrap().is_empty());
+
+    Ok(())
+}
+integration_test!(test_varlink_fsck_detects_corruption);
+
+fn test_varlink_oci_list_images_empty_repo() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::oci(repo)?;
+    let reply = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    assert!(reply["images"].as_array().unwrap().is_empty());
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_list_images_empty_repo);
+
+fn test_varlink_oci_list_images_after_pull() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{layout} test-image"
+    )
+    .run()?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let reply = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    let images = reply["images"].as_array().unwrap();
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0]["name"], "test-image");
+    assert!(
+        images[0]["manifest_digest"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:")
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_list_images_after_pull);
+
+fn test_varlink_oci_list_images_filter() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{layout} keep-me"
+    )
+    .run()?;
+
+    let svc = VarlinkService::oci(repo)?;
+    // A non-matching filter yields nothing; a matching one yields the image.
+    let none = svc.call("org.composefs.Oci.ListImages", json!({"filter": "nope"}))?;
+    assert!(none["images"].as_array().unwrap().is_empty());
+
+    let some = svc.call("org.composefs.Oci.ListImages", json!({"filter": "keep"}))?;
+    assert_eq!(some["images"].as_array().unwrap().len(), 1);
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_list_images_filter);
+
+fn test_varlink_gc_empty_repo() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+    let reply = svc.call(
+        "org.composefs.Repository.Gc",
+        json!({"dry_run": false, "roots": []}),
+    )?;
+    assert_eq!(reply["result"]["objects_removed"], 0);
+    assert_eq!(reply["result"]["objects_bytes"], 0);
+    assert_eq!(reply["dry_run"], false);
+
+    Ok(())
+}
+integration_test!(test_varlink_gc_empty_repo);
+
+fn test_varlink_gc_dry_run() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs} my-image"
+    )
+    .read()?;
+
+    let svc = VarlinkService::repository(repo)?;
+    let reply = svc.call(
+        "org.composefs.Repository.Gc",
+        json!({"dry_run": true, "roots": []}),
+    )?;
+    assert_eq!(reply["dry_run"], true);
+
+    let objects = svc.call(
+        "org.composefs.Repository.ImageObjects",
+        json!({"name": "refs/my-image"}),
+    )?;
+    assert!(!objects["object_ids"].as_array().unwrap().is_empty());
+
+    Ok(())
+}
+integration_test!(test_varlink_gc_dry_run);
+
+fn test_varlink_image_objects() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let rootfs = create_test_rootfs(fixture_dir.path())?;
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} create-image {rootfs} my-image"
+    )
+    .read()?;
+
+    let svc = VarlinkService::repository(repo)?;
+    let reply = svc.call(
+        "org.composefs.Repository.ImageObjects",
+        json!({"name": "refs/my-image"}),
+    )?;
+    let ids: Vec<&str> = reply["object_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(!ids.is_empty());
+    for id in &ids {
+        assert!(id.contains(':'), "id '{id}' should contain a colon");
+    }
+    assert!(ids.windows(2).all(|w| w[0] <= w[1]));
+
+    Ok(())
+}
+integration_test!(test_varlink_image_objects);
+
+fn test_varlink_image_objects_missing() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+    // Typed-proxy path: assert the exact `NoSuchRef` variant rather than a bare
+    // `is_err()` that could also fire on a transport error or wrong method.
+    let inner = svc
+        .proxy_image_objects("refs/does-not-exist")
+        .context("transport/protocol error calling ImageObjects")?;
+    match inner {
+        Err(RepositoryError::NoSuchRef { reference }) => {
+            assert_eq!(reference, "refs/does-not-exist")
+        }
+        other => bail!("expected NoSuchRef error, got: {other:?}"),
+    }
+
+    Ok(())
+}
+integration_test!(test_varlink_image_objects_missing);
+
+fn test_varlink_oci_fsck_healthy() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{layout} test-image"
+    )
+    .run()?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let reply = svc.call("org.composefs.Oci.Check", json!({}))?;
+    assert_eq!(reply["ok"], true);
+    assert_eq!(reply["images_checked"], 1);
+    assert_eq!(reply["images_corrupted"], 0);
+    assert!(reply["errors"].as_array().unwrap().is_empty());
+    assert_eq!(reply["repo"]["ok"], true);
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_fsck_healthy);
+
+fn test_varlink_oci_fsck_single_image() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{layout} test-image"
+    )
+    .run()?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let reply = svc.call("org.composefs.Oci.Check", json!({"image": "test-image"}))?;
+    assert_eq!(reply["ok"], true);
+    assert_eq!(reply["images_checked"], 1);
+    assert_eq!(reply["images_corrupted"], 0);
+    assert!(reply["errors"].as_array().unwrap().is_empty());
+    assert_eq!(reply["repo"]["ok"], true);
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_fsck_single_image);
+
+fn test_varlink_oci_inspect() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{layout} test-image"
+    )
+    .run()?;
+
+    let svc = VarlinkService::oci(repo)?;
+    // Positive round-trip through the typed proxy: this proves the non-trivial
+    // `OciInspectReply` struct (incl. its optional/vec fields) deserialises
+    // correctly through the generated bindings — something `varlinkctl` can't
+    // check, since it only ever sees raw JSON.
+    let reply = svc
+        .proxy_inspect("test-image")
+        .context("transport/protocol error calling Inspect")?
+        .map_err(|e| anyhow::anyhow!("Inspect returned a varlink error: {e:?}"))?;
+    assert!(!reply.manifest.is_empty());
+    assert!(!reply.config.is_empty());
+
+    let m: Value = serde_json::from_str(&reply.manifest)?;
+    assert!(
+        m.get("schemaVersion").is_some() || m.get("layers").is_some() || m.get("config").is_some()
+    );
+
+    let c: Value = serde_json::from_str(&reply.config)?;
+    assert!(c.get("architecture").is_some() || c.get("rootfs").is_some());
+
+    // `referrers` is a typed Vec<String>; just touch it to prove it deserialised.
+    let _: &Vec<String> = &reply.referrers;
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_inspect);
+
+fn test_varlink_oci_tag_and_untag() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{layout} myimage:v1"
+    )
+    .run()?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let list = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    let images = list["images"].as_array().unwrap();
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0]["name"], "myimage:v1");
+    let manifest_digest = images[0]["manifest_digest"].as_str().unwrap().to_string();
+
+    svc.call(
+        "org.composefs.Oci.Tag",
+        json!({"manifest_digest": manifest_digest, "name": "myimage:latest"}),
+    )?;
+
+    let list2 = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    let mut names: Vec<String> = list2["images"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|img| img["name"].as_str().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["myimage:latest".to_string(), "myimage:v1".to_string()]
+    );
+
+    svc.call("org.composefs.Oci.Untag", json!({"name": "myimage:v1"}))?;
+
+    let list3 = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    let images3 = list3["images"].as_array().unwrap();
+    assert_eq!(images3.len(), 1);
+    assert_eq!(images3[0]["name"], "myimage:latest");
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_tag_and_untag);
+
+fn test_varlink_oci_compute_id() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci pull oci:{layout} test-ref-image"
+    )
+    .run()?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let reply = svc.call(
+        "org.composefs.Oci.ComputeId",
+        json!({"image": "test-ref-image", "verity": null, "bootable": false}),
+    )?;
+    let image_id = reply["image_id"].as_str().unwrap();
+    assert!(!image_id.is_empty());
+    assert!(image_id.chars().all(|c| c.is_ascii_hexdigit()));
+
+    let cli_id = cmd!(
+        sh,
+        "{cfsctl} --insecure --repo {repo} oci compute-id test-ref-image"
+    )
+    .read()?;
+    assert_eq!(image_id, cli_id.trim());
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_compute_id);
+
+fn test_varlink_oci_inspect_missing() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::oci(repo)?;
+    // Driven through zlink's typed proxy so we can assert the *exact* varlink
+    // error variant. A bare `is_err()` would also pass for a wrong method name
+    // or a transport failure; here the outer Result must be Ok (the call
+    // reached the service and got a proper reply) and the inner Result must be
+    // the typed `NoSuchImage` error.
+    let inner = svc
+        .proxy_inspect("does-not-exist")
+        .context("transport/protocol error calling Inspect")?;
+    match inner {
+        Err(OciError::NoSuchImage { image }) => assert_eq!(image, "does-not-exist"),
+        other => bail!("expected NoSuchImage error, got: {other:?}"),
+    }
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_inspect_missing);
+
+fn test_varlink_oci_pull_streaming() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "streamed-image",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+
+    assert!(!frames.is_empty(), "stream should emit at least one frame");
+    let last = frames.last().unwrap();
+    let completed = &last["completed"];
+    assert!(completed.is_object(), "last frame should be `completed`");
+    let manifest_digest = completed["manifest_digest"].as_str().unwrap();
+    assert!(manifest_digest.starts_with("sha256:"));
+    assert!(!completed["config_digest"].as_str().unwrap().is_empty());
+    assert!(!completed["manifest_verity"].as_str().unwrap().is_empty());
+    assert!(!completed["stats"].as_str().unwrap().is_empty());
+
+    let completed_count = frames.iter().filter(|f| f["completed"].is_object()).count();
+    assert_eq!(completed_count, 1);
+    // Every non-terminal frame sets exactly one event variant.
+    for frame in &frames {
+        if frame["completed"].is_object() {
+            continue;
+        }
+        let variants = ["started", "progress", "skipped", "done", "message"];
+        let set = variants.iter().filter(|k| !frame[**k].is_null()).count();
+        assert_eq!(set, 1, "exactly one event variant must be set: {frame}");
+    }
+
+    let list = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    let images = list["images"].as_array().unwrap();
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0]["name"], "streamed-image");
+    assert_eq!(images[0]["manifest_digest"], manifest_digest);
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_pull_streaming);
+
+/// Streaming pull driven through zlink's typed `more` proxy. Mirrors
+/// `test_varlink_oci_pull_streaming` (which uses `varlinkctl`) but proves the
+/// generated streaming bindings deserialise each `PullProgress` frame into the
+/// typed sum-of-options shape, including the terminal `completed` frame.
+fn test_varlink_oci_pull_streaming_proxy() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+    let image = format!("oci:{}", layout.display());
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc
+        .proxy_pull(&image, Some("streamed-proxy"), false)
+        .context("transport/protocol error calling Pull")?
+        .map_err(|e| anyhow::anyhow!("Pull returned a varlink error: {e:?}"))?;
+
+    assert!(!frames.is_empty(), "stream should emit at least one frame");
+
+    // Exactly one terminal `completed` frame, and it is the last one.
+    let completed_count = frames.iter().filter(|f| f.completed.is_some()).count();
+    assert_eq!(completed_count, 1, "expected exactly one completed frame");
+    let last = frames.last().unwrap();
+    let completed = last
+        .completed
+        .as_ref()
+        .context("last frame should be the completed frame")?;
+    assert!(completed.manifest_digest.starts_with("sha256:"));
+    assert!(!completed.config_digest.is_empty());
+    assert!(!completed.manifest_verity.is_empty());
+    assert!(!completed.stats.is_empty());
+
+    // Every non-terminal frame sets exactly one event variant.
+    for frame in &frames {
+        if frame.completed.is_some() {
+            continue;
+        }
+        let set = [
+            frame.started.is_some(),
+            frame.progress.is_some(),
+            frame.skipped.is_some(),
+            frame.done.is_some(),
+            frame.message.is_some(),
+        ]
+        .into_iter()
+        .filter(|x| *x)
+        .count();
+        assert_eq!(set, 1, "exactly one event variant must be set: {frame:?}");
+    }
+
+    // The image landed in the repo under the requested tag.
+    let list = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    let images = list["images"].as_array().unwrap();
+    assert_eq!(images.len(), 1);
+    assert_eq!(images[0]["name"], "streamed-proxy");
+    assert_eq!(images[0]["manifest_digest"], completed.manifest_digest);
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_pull_streaming_proxy);
+
+fn test_varlink_oci_pull_then_inspect() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let frames = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "inspectme",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    )?;
+    assert!(frames.last().unwrap()["completed"].is_object());
+
+    let reply = svc.call("org.composefs.Oci.Inspect", json!({"image": "inspectme"}))?;
+    assert!(!reply["manifest"].as_str().unwrap().is_empty());
+    assert!(!reply["config"].as_str().unwrap().is_empty());
+    assert!(reply["composefs_boot_erofs"].is_null());
+
+    let m: Value = serde_json::from_str(reply["manifest"].as_str().unwrap())?;
+    assert!(
+        m.get("schemaVersion").is_some() || m.get("layers").is_some() || m.get("config").is_some()
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_pull_then_inspect);
+
+fn test_varlink_oci_pull_bad_image() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::oci(repo)?;
+    let result = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": "oci:/nonexistent/path/nope",
+            "name": "x",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": false,
+        }),
+    );
+
+    // The pull must fail; either the call errors outright, or no `completed`
+    // frame is produced before the error.
+    match result {
+        Err(_) => {}
+        Ok(frames) => {
+            assert!(
+                !frames.iter().any(|f| f["completed"].is_object()),
+                "no completed frame should be emitted for a bad image pull"
+            );
+        }
+    }
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_pull_bad_image);
+
+fn test_varlink_oci_pull_bootable() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let fixture_dir = tempfile::tempdir()?;
+    let layout = create_oci_layout(fixture_dir.path())?;
+
+    let svc = VarlinkService::oci(repo)?;
+    let result = svc.call_more(
+        "org.composefs.Oci.Pull",
+        json!({
+            "image": format!("oci:{}", layout.display()),
+            "name": "bootme",
+            "local_fetch": "disabled",
+            "storage_root": null,
+            "bootable": true,
+        }),
+    );
+
+    // A synthetic layer lacks boot resources, so the bootable pull either
+    // completes (possibly with no boot image) or fails cleanly.
+    match result {
+        Ok(frames) => {
+            if let Some(frame) = frames.iter().find(|f| f["completed"].is_object())
+                && let Some(boot) = frame["completed"]["boot_image"].as_str()
+            {
+                assert!(
+                    !boot.is_empty(),
+                    "boot image should not be empty if present"
+                );
+            }
+        }
+        Err(_) => {
+            // Clean failure due to missing boot resources is acceptable.
+        }
+    }
+
+    Ok(())
+}
+integration_test!(test_varlink_oci_pull_bootable);
+
+/// Both the `org.composefs.Repository` and `org.composefs.Oci` interfaces are
+/// served on the same socket by a single service process.
+fn test_varlink_both_interfaces_one_socket() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+
+    // A Repository-interface method...
+    let fsck = svc.call(
+        "org.composefs.Repository.Fsck",
+        json!({"metadata_only": true}),
+    )?;
+    assert_eq!(fsck["ok"], true);
+
+    // ...and an Oci-interface method, on the very same socket.
+    let images = svc.call("org.composefs.Oci.ListImages", json!({}))?;
+    assert!(images["images"].as_array().unwrap().is_empty());
+
+    Ok(())
+}
+integration_test!(test_varlink_both_interfaces_one_socket);
+
+/// The service is reachable via systemd socket activation, the way
+/// `varlinkctl exec:<binary>` launches it: the connected socket is passed on fd
+/// 3 with `LISTEN_FDS`/`LISTEN_PID` set, and the process serves varlink without
+/// any subcommand on its command line.
+///
+/// An activated launch must be argument-less, so the client selects a
+/// repository at runtime with `OpenRepository`. (The repository's insecure mode
+/// is auto-detected from its `meta.json`, so no open flags are needed.)
+///
+/// Each `varlinkctl exec:` invocation spawns a *fresh* process, so a handle
+/// obtained from one call cannot be used in a later call — there is no shared,
+/// long-lived service. We therefore assert only that a single activated call
+/// works end to end: `OpenRepository` over `exec:` returns a valid handle,
+/// which proves the socket-activation wiring (the connected socket on fd 3 with
+/// `LISTEN_FDS`/`LISTEN_PID`) and that the service can open a real repository.
+///
+/// `varlinkctl`'s `exec:` reference is a single binary path with no argument
+/// splitting; the binary path is kept space-free so `exec:` can resolve it.
+fn test_varlink_socket_activation() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let reference = format!("exec:{}", cfsctl.display());
+    let params = json!({"path": repo.to_str().unwrap()}).to_string();
+    let output = Command::new("varlinkctl")
+        .args([
+            "--json=short",
+            "call",
+            &reference,
+            "org.composefs.Repository.OpenRepository",
+            &params,
+        ])
+        .output()
+        .context("running varlinkctl (is systemd's varlinkctl installed?)")?;
+    if !output.status.success() {
+        bail!(
+            "varlinkctl exec: OpenRepository failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let stdout = String::from_utf8(output.stdout)?;
+    let line = stdout
+        .lines()
+        .map(|l| l.trim_start_matches('\u{1e}').trim())
+        .find(|l| !l.is_empty())
+        .context("no reply from socket-activated OpenRepository")?;
+    let reply: Value = serde_json::from_str(line).with_context(|| format!("parsing: {line}"))?;
+    let handle = reply["handle"]
+        .as_u64()
+        .context("OpenRepository reply missing numeric 'handle'")?;
+    assert!(handle >= 1, "handle should be >= 1, got {handle}");
+
+    Ok(())
+}
+integration_test!(test_varlink_socket_activation);
+
+// ============================================================================
+// New handle-API tests
+// ============================================================================
+
+/// Opening a repository by path yields a new handle; using that handle works;
+/// closing it makes subsequent calls fail with InvalidHandle.
+fn test_varlink_open_and_close_repository() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+
+    // Open a second handle to the same repo.
+    let open_reply = svc.call_raw(
+        "org.composefs.Repository.OpenRepository",
+        json!({"path": repo.to_str().unwrap()}),
+    )?;
+    let new_handle = open_reply["handle"]
+        .as_u64()
+        .context("OpenRepository reply missing numeric 'handle'")?;
+    assert!(new_handle >= 1, "handle should be >= 1, got {new_handle}");
+
+    // The new handle works.
+    let fsck = svc.call_raw(
+        "org.composefs.Repository.Fsck",
+        json!({"handle": new_handle}),
+    )?;
+    assert_eq!(fsck["ok"], true);
+
+    // Close the handle.
+    svc.call_raw(
+        "org.composefs.Repository.CloseRepository",
+        json!({"handle": new_handle}),
+    )?;
+
+    // After closing, the handle is no longer valid.
+    let err = svc.call_expect_err(
+        "org.composefs.Repository.Fsck",
+        json!({"handle": new_handle}),
+    )?;
+    assert!(
+        err.contains("InvalidHandle"),
+        "expected InvalidHandle error, got: {err}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_open_and_close_repository);
+
+/// `OpenRepository` with zero or multiple selector fields returns `InvalidSpec`.
+fn test_varlink_open_repository_invalid_spec() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+
+    // No selector field at all.
+    let err = svc.call_expect_err("org.composefs.Repository.OpenRepository", json!({}))?;
+    assert!(
+        err.contains("InvalidSpec"),
+        "expected InvalidSpec for empty params, got: {err}"
+    );
+
+    // Two selector fields simultaneously.
+    let err2 = svc.call_expect_err(
+        "org.composefs.Repository.OpenRepository",
+        json!({"path": repo.to_str().unwrap(), "user": true}),
+    )?;
+    assert!(
+        err2.contains("InvalidSpec"),
+        "expected InvalidSpec for conflicting selectors, got: {err2}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_open_repository_invalid_spec);
+
+/// Methods called with an unknown handle return the appropriate `InvalidHandle`
+/// error for both the Repository and Oci interfaces.
+fn test_varlink_invalid_handle() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+
+    // Repository method with bogus handle.
+    let err = svc.call_expect_err("org.composefs.Repository.Fsck", json!({"handle": 999}))?;
+    assert!(
+        err.contains("InvalidHandle"),
+        "expected InvalidHandle from Fsck, got: {err}"
+    );
+
+    // OCI method with bogus handle (org.composefs.Oci.InvalidHandle).
+    let err2 = svc.call_expect_err("org.composefs.Oci.ListImages", json!({"handle": 999}))?;
+    assert!(
+        err2.contains("InvalidHandle"),
+        "expected InvalidHandle from Oci.ListImages, got: {err2}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_invalid_handle);
+
+/// `CloseRepository` with an unknown handle returns `InvalidHandle`.
+fn test_varlink_close_unknown_handle() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let repo_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let repo = repo_dir.path();
+
+    let svc = VarlinkService::repository(repo)?;
+    let err = svc.call_expect_err(
+        "org.composefs.Repository.CloseRepository",
+        json!({"handle": 424242}),
+    )?;
+    assert!(
+        err.contains("InvalidHandle"),
+        "expected InvalidHandle for unknown handle, got: {err}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_close_unknown_handle);
+
+// ============================================================================
+// InitRepository tests
+// ============================================================================
+
+/// `InitRepository` creates a new repository and returns `created: true`; the
+/// freshly-created repo can immediately be opened with `OpenRepository`.
+fn test_varlink_init_repository_creates_new() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    // We need a running service — use an existing insecure repo for that.
+    let existing_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let svc = VarlinkService::repository(existing_dir.path())?;
+
+    // Point InitRepository at a brand-new (non-existent) path.
+    let new_repo_dir = tempfile::tempdir()?;
+    let new_repo_path = new_repo_dir.path().join("new-repo");
+    let path_str = new_repo_path.to_str().context("repo path not UTF-8")?;
+
+    let reply = svc.call_raw(
+        "org.composefs.Repository.InitRepository",
+        json!({"path": path_str, "insecure": true}),
+    )?;
+    assert_eq!(
+        reply["created"], true,
+        "expected created=true for a fresh repo, got: {reply}"
+    );
+
+    // The new repo should be openable.
+    let open_reply = svc.call_raw(
+        "org.composefs.Repository.OpenRepository",
+        json!({"path": path_str}),
+    )?;
+    assert!(
+        open_reply["handle"].as_u64().is_some(),
+        "expected a numeric handle after init, got: {open_reply}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_init_repository_creates_new);
+
+/// Calling `InitRepository` twice on the same path with the same algorithm is
+/// idempotent: the second call returns `created: false`.
+fn test_varlink_init_repository_idempotent() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let existing_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let svc = VarlinkService::repository(existing_dir.path())?;
+
+    let new_repo_dir = tempfile::tempdir()?;
+    let new_repo_path = new_repo_dir.path().join("idempotent-repo");
+    let path_str = new_repo_path.to_str().context("repo path not UTF-8")?;
+
+    // First call: creates the repo.
+    let first = svc.call_raw(
+        "org.composefs.Repository.InitRepository",
+        json!({"path": path_str, "insecure": true}),
+    )?;
+    assert_eq!(first["created"], true, "first call should create the repo");
+
+    // Second call with the same algorithm: idempotent.
+    let second = svc.call_raw(
+        "org.composefs.Repository.InitRepository",
+        json!({"path": path_str, "insecure": true}),
+    )?;
+    assert_eq!(
+        second["created"], false,
+        "second call should be idempotent (created=false)"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_init_repository_idempotent);
+
+/// `InitRepository` with an unrecognised algorithm string returns `InvalidSpec`.
+fn test_varlink_init_repository_invalid_algorithm() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let existing_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let svc = VarlinkService::repository(existing_dir.path())?;
+
+    let new_repo_dir = tempfile::tempdir()?;
+    let path_str = new_repo_dir
+        .path()
+        .join("bad-algo")
+        .to_str()
+        .context("path not UTF-8")?
+        .to_owned();
+
+    let err = svc.call_expect_err(
+        "org.composefs.Repository.InitRepository",
+        json!({"path": path_str, "algorithm": "not-an-algorithm"}),
+    )?;
+    assert!(
+        err.contains("InvalidSpec"),
+        "expected InvalidSpec for bad algorithm, got: {err}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_init_repository_invalid_algorithm);
+
+/// `InitRepository` via the typed zlink proxy — proves the generated client
+/// bindings round-trip the reply and error types correctly.
+fn test_varlink_init_repository_proxy() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    let existing_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let svc = VarlinkService::repository(existing_dir.path())?;
+
+    let new_repo_dir = tempfile::tempdir()?;
+    let new_repo_path = new_repo_dir.path().join("proxy-repo");
+    let path_str = new_repo_path.to_str().context("repo path not UTF-8")?;
+
+    // Fresh init via typed proxy.
+    let reply = svc
+        .proxy_init_repository(path_str, None, Some(true))?
+        .expect("InitRepository should succeed");
+    assert!(reply.created, "expected created=true for a fresh repo");
+
+    // Idempotent second call.
+    let reply2 = svc
+        .proxy_init_repository(path_str, None, Some(true))?
+        .expect("second InitRepository should succeed");
+    assert!(!reply2.created, "expected created=false on second call");
+
+    // Bad algorithm returns the typed InvalidSpec error.
+    let err = svc
+        .proxy_init_repository(path_str, Some("bad-algo"), None)?
+        .expect_err("bad algorithm should return an error");
+    assert!(
+        matches!(err, RepositoryError::InvalidSpec { .. }),
+        "expected InvalidSpec, got: {err:?}"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_init_repository_proxy);

--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -15,6 +15,7 @@ default = ["containers-storage"]
 test = ["tar", "rand", "composefs/test"]
 boot = ["composefs-boot"]
 containers-storage = ["dep:cstorage", "dep:base64", "cstorage/userns-helper"]
+varlink = ['dep:zlink-core', 'composefs/varlink']
 
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
@@ -23,6 +24,7 @@ async-compression = { version = "0.4.0", default-features = false, features = ["
 base64 = { version = "0.22", default-features = false, features = ["std"], optional = true }
 bytes = { version = "1", default-features = false }
 composefs = { workspace = true }
+zlink-core = { workspace = true, optional = true }
 composefs-boot = { workspace = true, optional = true }
 containers-image-proxy = { version = "0.10", default-features = false }
 cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.4.0", optional = true }

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -11,6 +11,10 @@
 //! - Importing from containers-storage with zero-copy reflinks (optional feature)
 
 #![forbid(unsafe_code)]
+// This is a library: emit diagnostics via the `log` crate (or return them),
+// never by writing to the process's stdout/stderr. Genuinely-intentional
+// exceptions carry a local `#[allow]` with justification. Test code is exempt.
+#![cfg_attr(not(test), deny(clippy::print_stdout, clippy::print_stderr))]
 
 pub mod boot;
 #[cfg(feature = "containers-storage")]
@@ -54,7 +58,6 @@ use composefs::{
 };
 
 use crate::skopeo::{OCI_CONFIG_CONTENT_TYPE, TAR_LAYER_CONTENT_TYPE};
-use crate::tar::get_entry;
 
 /// Named ref key for the EROFS image derived from this OCI config.
 pub const IMAGE_REF_KEY: &str = "composefs.image";
@@ -67,10 +70,10 @@ pub const BOOT_IMAGE_REF_KEY: &str = "composefs.image.boot";
 pub use boot::generate_boot_image;
 pub use boot::{boot_image, remove_boot_image};
 pub use oci_image::{
-    ImageInfo, LayerInfo, OCI_REF_PREFIX, OciFsckError, OciFsckResult, OciImage, SplitstreamInfo,
-    add_referrer, layer_dumpfile, layer_info, layer_tar, list_images, list_referrers, list_refs,
-    oci_fsck, oci_fsck_image, remove_referrer, remove_referrers_for_subject, resolve_ref,
-    tag_image, untag_image,
+    ImageInfo, LayerInfo, OCI_REF_PREFIX, OciFsckError, OciFsckResult, OciImage, OciImageNotFound,
+    OciRefNotFound, SplitstreamInfo, add_referrer, layer_dumpfile, layer_info, layer_tar,
+    list_images, list_referrers, list_refs, oci_fsck, oci_fsck_image, remove_referrer,
+    remove_referrers_for_subject, resolve_ref, tag_image, untag_image,
 };
 pub use progress::{ComponentId, NullReporter, ProgressEvent, ProgressReporter, SharedReporter};
 pub use skopeo::pull_image;
@@ -357,27 +360,6 @@ pub async fn import_layer<ObjectID: FsVerityHashValue>(
         .await?;
 
     Ok((object_id, stats))
-}
-
-/// Lists the contents of a container layer stored in the repository.
-///
-/// Reads the split stream for the named layer and prints each tar entry to stdout
-/// in composefs dumpfile format.
-pub fn ls_layer<ObjectID: FsVerityHashValue>(
-    repo: &Repository<ObjectID>,
-    diff_id: &OciDigest,
-) -> Result<()> {
-    let mut split_stream = repo.open_stream(
-        &layer_identifier(diff_id),
-        None,
-        Some(TAR_LAYER_CONTENT_TYPE),
-    )?;
-
-    while let Some(entry) = get_entry(&mut split_stream)? {
-        println!("{entry}");
-    }
-
-    Ok(())
 }
 
 /// Pull the target image, and add the provided tag. If this is a mountable

--- a/crates/composefs-oci/src/oci_image.rs
+++ b/crates/composefs-oci/src/oci_image.rs
@@ -54,6 +54,22 @@ use crate::ContentAndVerity;
 use crate::layer::is_tar_media_type;
 use crate::skopeo::{OCI_BLOB_CONTENT_TYPE, OCI_CONFIG_CONTENT_TYPE, OCI_MANIFEST_CONTENT_TYPE};
 
+/// Error marker: an OCI reference (tag) does not exist.
+#[derive(Debug, thiserror::Error)]
+#[error("OCI reference not found: {name}")]
+pub struct OciRefNotFound {
+    /// The reference name that was not found.
+    pub name: String,
+}
+
+/// Error marker: an OCI manifest/image does not exist in the repository.
+#[derive(Debug, thiserror::Error)]
+#[error("OCI image not found: {digest}")]
+pub struct OciImageNotFound {
+    /// The manifest digest that was not found.
+    pub digest: String,
+}
+
 /// Data and named refs from a splitstream with external object storage.
 type ExternalData<ObjectID> = (Vec<u8>, HashMap<Box<str>, ObjectID>);
 
@@ -186,8 +202,14 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
         let manifest_verity = if let Some(v) = verity {
             v.clone()
         } else {
-            repo.has_stream(&manifest_id)?
-                .context("Manifest not found")?
+            match repo.has_stream(&manifest_id)? {
+                Some(v) => v,
+                None => {
+                    return Err(anyhow::Error::new(OciImageNotFound {
+                        digest: manifest_digest.to_string(),
+                    }));
+                }
+            }
         };
 
         Ok(Self {
@@ -389,40 +411,6 @@ impl<ObjectID: FsVerityHashValue> OciImage<ObjectID> {
         )?;
         Ok(data)
     }
-
-    /// Returns the full inspect output as a JSON value.
-    ///
-    /// This includes the manifest, config, and referrers in a single JSON object.
-    /// The manifest and config are included as their original JSON structure.
-    pub fn inspect_json(&self, repo: &Repository<ObjectID>) -> Result<serde_json::Value> {
-        let manifest_json = self.read_manifest_json(repo)?;
-        let config_json = self.read_config_json(repo)?;
-        let referrers = list_referrers(repo, &self.manifest_digest)?;
-
-        let manifest_value: serde_json::Value = serde_json::from_slice(&manifest_json)?;
-        let config_value: serde_json::Value = serde_json::from_slice(&config_json)?;
-
-        let referrers_value: Vec<serde_json::Value> = referrers
-            .iter()
-            .map(|(digest, _verity)| serde_json::json!({ "digest": digest }))
-            .collect();
-
-        let mut result = serde_json::json!({
-            "manifest": manifest_value,
-            "config": config_value,
-            "referrers": referrers_value,
-        });
-
-        if let Some(ref erofs_id) = self.image_ref {
-            result["composefs_erofs"] = serde_json::json!(erofs_id.to_hex());
-        }
-
-        if let Some(ref boot_id) = self.boot_image_ref {
-            result["composefs_boot_erofs"] = serde_json::json!(boot_id.to_hex());
-        }
-
-        Ok(result)
-    }
 }
 
 // =============================================================================
@@ -476,8 +464,17 @@ pub fn resolve_ref<ObjectID: FsVerityHashValue>(
     let ref_path = format!("streams/refs/{}", oci_ref_path(name));
 
     // Read the symlink to get the manifest path
-    let target = readlinkat(repo.repo_fd(), &ref_path, vec![])
-        .with_context(|| format!("Reference {name} not found"))?;
+    let target = match readlinkat(repo.repo_fd(), &ref_path, vec![]) {
+        Ok(t) => t,
+        Err(Errno::NOENT) => {
+            return Err(anyhow::Error::new(OciRefNotFound {
+                name: name.to_string(),
+            }));
+        }
+        Err(e) => {
+            return Err(e).with_context(|| format!("Reference {name} not found"));
+        }
+    };
 
     let target_str = target
         .to_str()

--- a/crates/composefs-splitfdstream/src/lib.rs
+++ b/crates/composefs-splitfdstream/src/lib.rs
@@ -57,6 +57,11 @@
 //! External chunks have no additional data after the prefix; the content is
 //! retrieved from the file descriptor array passed alongside the stream.
 
+// This is a library: emit diagnostics via the `log` crate (or return them),
+// never by writing to the process's stdout/stderr. Genuinely-intentional
+// exceptions carry a local `#[allow]` with justification. Test code is exempt.
+#![cfg_attr(not(test), deny(clippy::print_stdout, clippy::print_stderr))]
+
 use std::io::{self, Read, Write};
 #[cfg(test)]
 use std::os::fd::AsFd;

--- a/crates/composefs-storage/src/lib.rs
+++ b/crates/composefs-storage/src/lib.rs
@@ -45,6 +45,11 @@
 //! - No absolute paths are constructed during operations
 //! - SQLite database accessed via fd-relative path
 
+// This is a library: emit diagnostics via the `log` crate (or return them),
+// never by writing to the process's stdout/stderr. Genuinely-intentional
+// exceptions carry a local `#[allow]` with justification. Test code is exempt.
+#![cfg_attr(not(test), deny(clippy::print_stdout, clippy::print_stderr))]
+
 // Core storage access
 pub mod config;
 pub mod error;

--- a/crates/composefs-storage/src/userns_helper.rs
+++ b/crates/composefs-storage/src/userns_helper.rs
@@ -238,6 +238,11 @@ pub enum HelperError {
 /// 3. Exit when the parent closes the connection
 ///
 /// If this is not a helper process, this function returns immediately.
+//
+// Runs in a forked helper subprocess whose stdin is the IPC socket; there is
+// no logging facility or error channel back to the parent, so fatal
+// diagnostics are written to stderr before exiting.
+#[allow(clippy::print_stderr)]
 pub fn init_if_helper() {
     // Check if we're a helper via environment variable
     if std::env::var(HELPER_ENV).is_err() {

--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -14,10 +14,12 @@ version.workspace = true
 'pre-6.15' = ['tempfile']
 rhel9 = ['pre-6.15', 'composefs-ioctls/loop-device']
 test = ["tempfile"]
+varlink = ['dep:zlink-core']
 
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
 composefs-ioctls = { workspace = true }
+zlink-core = { workspace = true, optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 fn-error-context = "0.2"
 hex = { version = "0.4.0", default-features = false, features = ["std"] }

--- a/crates/composefs/src/lib.rs
+++ b/crates/composefs/src/lib.rs
@@ -5,6 +5,10 @@
 //! and fs-verity for integrity verification.
 
 #![forbid(unsafe_code)]
+// This is a library: emit diagnostics via the `log` crate (or return them),
+// never by writing to the process's stdout/stderr. Genuinely-intentional
+// exceptions carry a local `#[allow]` with justification. Test code is exempt.
+#![cfg_attr(not(test), deny(clippy::print_stdout, clippy::print_stderr))]
 
 pub mod dumpfile;
 pub mod dumpfile_parse;
@@ -16,6 +20,7 @@ pub mod mount;
 pub mod mountcompat;
 pub mod progress;
 pub mod repository;
+pub use repository::ImageNotFound;
 pub mod splitstream;
 pub mod tree;
 pub mod util;

--- a/crates/composefs/src/mount.rs
+++ b/crates/composefs/src/mount.rs
@@ -63,6 +63,10 @@ impl Drop for FsHandle {
             match rustix::io::read(&self.fd, &mut buffer) {
                 Err(_) => return, // ENODATA, among others?
                 Ok(0) => return,
+                // Surface the kernel's fsopen/fsconfig diagnostic messages,
+                // which are only readable from this fd. We have no error
+                // channel from `drop`, so stderr is the only option.
+                #[allow(clippy::print_stderr)]
                 Ok(size) => eprintln!("{}", String::from_utf8(buffer[0..size].to_vec()).unwrap()),
             }
         }

--- a/crates/composefs/src/progress.rs
+++ b/crates/composefs/src/progress.rs
@@ -21,6 +21,14 @@ impl ComponentId {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    /// Consume the id and return the owned underlying string.
+    ///
+    /// Useful when converting an owned [`ProgressEvent`] into another
+    /// representation without re-allocating the identifier.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
 }
 
 impl<S: Into<String>> From<S> for ComponentId {

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -121,6 +121,14 @@ use crate::{
 /// The filename used for repository metadata.
 pub const REPO_METADATA_FILENAME: &str = "meta.json";
 
+/// Error marker indicating a named image/ref does not exist in the repository.
+#[derive(Debug, thiserror::Error)]
+#[error("image not found: {name}")]
+pub struct ImageNotFound {
+    /// The name/ref that was not found.
+    pub name: String,
+}
+
 /// Errors that can occur when opening a repository.
 #[derive(Debug, thiserror::Error)]
 pub enum RepositoryOpenError {
@@ -771,6 +779,11 @@ enum GCCategoryWalkMode {
 ///
 /// Returned by [`Repository::gc`] to report what was (or would be) removed.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "varlink",
+    derive(serde::Serialize, serde::Deserialize, zlink_core::introspect::Type),
+    zlink(crate = "zlink_core")
+)]
 pub struct GcResult {
     /// Number of unreferenced objects removed (or that would be removed)
     pub objects_removed: u64,
@@ -874,16 +887,26 @@ pub enum FsckError {
 #[derive(Debug, Clone, Default, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FsckResult {
-    pub(crate) has_metadata: bool,
-    pub(crate) objects_checked: u64,
-    pub(crate) objects_corrupted: u64,
-    pub(crate) streams_checked: u64,
-    pub(crate) streams_corrupted: u64,
-    pub(crate) images_checked: u64,
-    pub(crate) images_corrupted: u64,
-    pub(crate) broken_links: u64,
-    pub(crate) missing_objects: u64,
-    pub(crate) errors: Vec<FsckError>,
+    /// Whether the repository has a `meta.json` metadata file.
+    pub has_metadata: bool,
+    /// Number of objects whose fs-verity digests were verified.
+    pub objects_checked: u64,
+    /// Number of objects found to have a bad fs-verity digest.
+    pub objects_corrupted: u64,
+    /// Number of splitstreams verified.
+    pub streams_checked: u64,
+    /// Number of splitstreams with issues (bad header, missing refs, etc.).
+    pub streams_corrupted: u64,
+    /// Number of images verified.
+    pub images_checked: u64,
+    /// Number of images with issues.
+    pub images_corrupted: u64,
+    /// Number of broken symlinks found.
+    pub broken_links: u64,
+    /// Number of missing objects referenced by streams.
+    pub missing_objects: u64,
+    /// Structured descriptions of each error found.
+    pub errors: Vec<FsckError>,
 }
 
 impl FsckResult {
@@ -2230,9 +2253,17 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     /// enabled when mounting it.
     #[context("Opening image '{name}'")]
     pub fn open_image(&self, name: &str) -> Result<(OwnedFd, bool)> {
-        let image = self
-            .openat(&format!("images/{name}"), OFlags::RDONLY)
-            .with_context(|| format!("Opening ref 'images/{name}'"))?;
+        let image = match self.openat(&format!("images/{name}"), OFlags::RDONLY) {
+            Ok(fd) => fd,
+            Err(Errno::NOENT) => {
+                return Err(anyhow::Error::new(ImageNotFound {
+                    name: name.to_string(),
+                }));
+            }
+            Err(e) => {
+                return Err(e).with_context(|| format!("Opening ref 'images/{name}'"));
+            }
+        };
 
         if name.contains("/") {
             return Ok((image, true));
@@ -2809,15 +2840,40 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     /// any repository contents.
     #[context("Running filesystem consistency check")]
     pub async fn fsck(&self) -> Result<FsckResult> {
+        self.fsck_inner(true).await
+    }
+
+    /// Run a metadata-only consistency check.
+    ///
+    /// This validates `meta.json` and the stream/image symlinks (including
+    /// splitstream structure and referenced-object existence) but skips the
+    /// expensive per-object fs-verity digest verification done by [`fsck`].
+    /// Useful for a fast structural check on large repositories.
+    ///
+    /// [`fsck`]: Self::fsck
+    pub async fn fsck_metadata_only(&self) -> Result<FsckResult> {
+        self.fsck_inner(false).await
+    }
+
+    /// Shared implementation for [`fsck`] and [`fsck_metadata_only`].
+    ///
+    /// When `check_objects` is false, the object fs-verity verification phase
+    /// is skipped (so `objects_checked` stays zero).
+    ///
+    /// [`fsck`]: Self::fsck
+    /// [`fsck_metadata_only`]: Self::fsck_metadata_only
+    async fn fsck_inner(&self, check_objects: bool) -> Result<FsckResult> {
         let mut result = FsckResult::default();
 
         // Phase 0: Validate meta.json if present
         self.fsck_metadata(&mut result);
 
         // Phase 1: Verify all objects (parallel across object subdirectories)
-        self.fsck_objects(&mut result)
-            .await
-            .context("Checking objects")?;
+        if check_objects {
+            self.fsck_objects(&mut result)
+                .await
+                .context("Checking objects")?;
+        }
 
         // Phase 2: Verify stream symlinks and splitstream integrity
         self.fsck_category("streams", &mut result)

--- a/crates/composefs/src/test.rs
+++ b/crates/composefs/src/test.rs
@@ -2,6 +2,10 @@
 //!
 //! This module provides helpers for writing tests, including temporary
 //! directory allocation and repository initialization.
+//!
+//! These are test helpers (exposed for downstream crates' tests), so the
+//! diagnostics here intentionally go to stderr.
+#![allow(clippy::print_stderr)]
 
 use std::{ffi::OsString, fs::create_dir_all, path::PathBuf, sync::Arc};
 


### PR DESCRIPTION
We previously had ad-hoc `--json` on some CLI invocations. Let's
offer a varlink API instead.

Closes: https://github.com/composefs/composefs-rs/issues/302

Assisted-by: Opencode (Various models)
Signed-off-by: Colin Walters <walters@verbum.org>