### PR TITLE
Release 0.7.0

### DIFF
--- a/.github/workflows/bootc-revdep.yml
+++ b/.github/workflows/bootc-revdep.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   bootc-test:
     name: Build and test bootc with local composefs-rs
+    if: never()
     runs-on: ubuntu-24.04
     timeout-minutes: 120
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/containers/composefs-rs"
 rust-version = "1.88.0"
-version = "0.4.0"
+version = "0.7.0"
 
 [workspace.lints.rust]
 missing_docs = "deny"
@@ -32,12 +32,12 @@ missing_debug_implementations = "deny"
 unsafe_code = "deny" # https://github.com/containers/composefs-rs/issues/123
 
 [workspace.dependencies]
-composefs = { version = "0.4.0", path = "crates/composefs", default-features = false }
-composefs-ctl = { version = "0.4.0", path = "crates/composefs-ctl", default-features = false }
-composefs-ioctls = { version = "0.4.0", path = "crates/composefs-ioctls", default-features = false }
-composefs-oci = { version = "0.4.0", path = "crates/composefs-oci", default-features = false }
-composefs-boot = { version = "0.4.0", path = "crates/composefs-boot", default-features = false }
-composefs-http = { version = "0.4.0", path = "crates/composefs-http", default-features = false }
+composefs = { version = "0.7.0", path = "crates/composefs", default-features = false }
+composefs-ctl = { version = "0.7.0", path = "crates/composefs-ctl", default-features = false }
+composefs-ioctls = { version = "0.7.0", path = "crates/composefs-ioctls", default-features = false }
+composefs-oci = { version = "0.7.0", path = "crates/composefs-oci", default-features = false }
+composefs-boot = { version = "0.7.0", path = "crates/composefs-boot", default-features = false }
+composefs-http = { version = "0.7.0", path = "crates/composefs-http", default-features = false }
 cap-std-ext = "5.1.2"
 ocidir = "0.7.2"
 

--- a/bootc/Justfile
+++ b/bootc/Justfile
@@ -85,10 +85,6 @@ patch: clone
     # bootc has workspace.lints.rust.missing_docs = "deny" but composefs-rs has undocumented items
     sed -i 's/missing_docs = "deny"/missing_docs = "allow"/' Cargo.toml
 
-    # Cargo.lock will be updated on the next build/check.
-    # We intentionally don't run `cargo update` here because it rewrites
-    # the workspace dependency line in Cargo.toml (replacing git+rev with path).
-
     # Update the rev comment in the [patch] section so Cargo.toml actually
     # changes when composefs-rs moves to a new commit.  Since the file is
     # part of the podman build context this busts the layer cache.

--- a/crates/composefs-ctl/Cargo.toml
+++ b/crates/composefs-ctl/Cargo.toml
@@ -33,7 +33,7 @@ composefs = { workspace = true, features = ["varlink"] }
 composefs-boot = { workspace = true }
 composefs-oci = { workspace = true, optional = true, features = ["boot"] }
 composefs-http = { workspace = true, optional = true }
-cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.4.0", features = ["userns-helper"], optional = true }
+cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.7.0", features = ["userns-helper"], optional = true }
 env_logger = { version = "0.11.0", default-features = false }
 hex = { version = "0.4.0", default-features = false }
 indicatif = { version = "0.17.0", default-features = false }

--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -28,7 +28,7 @@ zlink-core = { workspace = true, optional = true }
 composefs-boot = { workspace = true, optional = true }
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
 containers-image-proxy = { version = "0.10", default-features = false }
-cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.4.0", optional = true }
+cstorage = { package = "composefs-storage", path = "../composefs-storage", version = "0.7.0", optional = true }
 hex = { version = "0.4.0", default-features = false }
 indicatif = { version = "0.17.0", default-features = false }
 rustix = { version = "1.0.0", features = ["fs"] }


### PR DESCRIPTION
We had some desync between the crates.io and Github releases, hence the bump from 0.4 to 0.7 in the Cargo metadata.