### PR TITLE
Switch away from using PCRE2 alone, and use a native Rust regex engine first

### DIFF
--- a/crates/composefs-boot/Cargo.toml
+++ b/crates/composefs-boot/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
 composefs = { workspace = true }
 hex = { version = "0.4.0", default-features = false, features = ["std"] }
+regex-automata = "0.4.14"
 pcre2 = "0.2.11"
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "std"] }
 thiserror = { version = "2.0.0", default-features = false }

--- a/crates/composefs-boot/src/selabel.rs
+++ b/crates/composefs-boot/src/selabel.rs
@@ -14,9 +14,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, anyhow, bail, ensure};
 use fn_error_context::context;
-use pcre2::bytes::Regex;
+use pcre2::bytes::Regex as PcreRegex;
+// the meta regex engine might be able to beat out specifying
+// another engine sometimes, since it kind of just redirects to a different engine,
+// depending on regex, so might as well use it.
+// It's also fairly easy to swap out here if desired, since really only
+// two methods need to be supported.
+use regex_automata::meta::Regex as AutomataRegex;
 use rustix::{
     fd::AsFd,
     fs::{Mode, OFlags, openat},
@@ -101,10 +107,47 @@ fn process_spec_file(
     Ok(())
 }
 
+/* Most Rust crates don't support lookarounds and other features PCRE2 does, but they perform
+ * a lot better when the regex being parsed doesn't involve them. So, we use the Rust
+ * regex parsers, and if they error out, we'll fall back to PCRE2. */
+
+enum RegexImpl {
+    Automata(AutomataRegex),
+    Pcre2(PcreRegex),
+}
+
+impl RegexImpl {
+    #[inline(always)]
+    fn new(pattern: &str) -> Result<Self> {
+        AutomataRegex::new(pattern)
+            .map(RegexImpl::Automata)
+            .or_else(|automata_err| {
+                PcreRegex::new(pattern)
+                    .map(RegexImpl::Pcre2)
+                    .map_err(|pcre_err| {
+                        anyhow!(
+                            "Failed to compile regex `{}` with regex_automata: {}; PCRE2 fallback failed: {}",
+                            pattern,
+                            automata_err,
+                            pcre_err
+                        )
+                    })
+            })
+    }
+
+    #[inline(always)]
+    fn is_match(&self, input: &[u8]) -> bool {
+        match self {
+            RegexImpl::Automata(re) => re.is_match(input),
+            RegexImpl::Pcre2(re) => re.is_match(input).unwrap_or(false),
+        }
+    }
+}
+
 struct Policy {
     aliases: HashMap<OsString, OsString>,
-    regexes: Vec<Regex>,
-    contexts: Vec<String>,
+    // (regex, context)
+    rules: Vec<(RegexImpl, String)>,
 }
 
 /// Open a file in the composefs store, handling inline vs external files.
@@ -172,16 +215,14 @@ impl Policy {
         regexps.reverse();
         contexts.reverse();
 
-        let mut compiled = Vec::with_capacity(regexps.len());
-        for r in &regexps {
-            compiled.push(Regex::new(r).with_context(|| format!("Compiling PCRE2 regex: {r}"))?);
+        let mut rules = Vec::with_capacity(regexps.len());
+        for (re_src, context) in regexps.into_iter().zip(contexts.into_iter()) {
+            let regex =
+                RegexImpl::new(&re_src).with_context(|| format!("Compiling regex: {re_src}"))?;
+            rules.push((regex, context));
         }
 
-        Ok(Policy {
-            aliases,
-            regexes: compiled,
-            contexts,
-        })
+        Ok(Policy { aliases, rules })
     }
 
     pub fn check_aliased(&self, filename: &OsStr) -> Option<&OsStr> {
@@ -191,10 +232,10 @@ impl Policy {
     pub fn lookup(&self, filename: &OsStr, ifmt: u8) -> Option<&str> {
         let key = &[filename.as_bytes(), &[ifmt]].concat();
 
-        for (i, re) in self.regexes.iter().enumerate() {
-            if re.is_match(key).unwrap_or(false) {
-                let ctx = self.contexts[i].as_str();
-                return (ctx != "<<none>>").then_some(ctx);
+        for rule in &self.rules {
+            if rule.0.is_match(key) {
+                let context = rule.1.as_str();
+                return (context != "<<none>>").then_some(context);
             }
         }
         None


### PR DESCRIPTION
The first command is a secureblue image (which doesn't have any policies using lookarounds), the latter is a bazzite image (which does have a few)

This is with latest `main` (which uses PCRE2 on its own)
```
oro@stitch ~> time sudo bootc/pcre2-bootc container compute-composefs-digest scb-rootfs/
08ed265ec132aefacd211f44127007e4276833d2b5d38c696c81e07fdec470382e3a6800b7302b85600d96fd40df462470306eefeb357abfe1be8595b3f73085

________________________________________________________
Executed in   77.53 secs      fish           external
   usr time    7.47 millis  967.00 micros    6.50 millis
   sys time    9.58 millis    0.00 micros    9.58 millis

oro@stitch ~> time sudo bootc/pcre2-bootc container compute-composefs-digest /ostree/boot.1.0/default/40ad2cc41a58917bee1e7defa7fd9fcdbbd92c688b51d26c64ee4ea4f6970f79/0/
53b063f0f60f3864c0babb869c2c1e7c36c7526a51d15bd1c0d52222f86f3d9667609d3db4bc527dcdd777f849633bcceb978d50c77dda4bdb8d16ab052fa9a5

________________________________________________________
Executed in  130.88 secs      fish           external
   usr time   11.96 millis  330.00 micros   11.63 millis
   sys time    6.18 millis  307.00 micros    5.88 millis
```

The following is with this patch:
```
oro@stitch ~> time sudo Projects/bootc/target/release/bootc container compute-composefs-digest scb-rootfs
08ed265ec132aefacd211f44127007e4276833d2b5d38c696c81e07fdec470382e3a6800b7302b85600d96fd40df462470306eefeb357abfe1be8595b3f73085

________________________________________________________
Executed in   35.65 secs      fish           external
   usr time    6.46 millis    0.00 micros    6.46 millis
   sys time   12.85 millis  848.00 micros   12.00 millis

oro@stitch ~> time sudo Projects/bootc/target/release/bootc container compute-composefs-digest /ostree/boot.1.0/default/40ad2cc41a58917bee1e7defa7fd9fcdbbd92c688b51d26c64ee4ea4f6970f79/0/
86dbfe101a2557d9aa3077795cd4f736169ea31a0bc8c1408579269276ad935d792c0b8929899f7a6088d518ccd8dc29794235d3adf79c18f5af62fb03cb0230

________________________________________________________
Executed in   55.85 secs      fish           external
   usr time    3.16 millis  539.00 micros    2.62 millis
   sys time   16.04 millis  446.00 micros   15.59 millis
```