### PR TITLE
tree: Apply xattr allowlist and compaction in transform_for_oci

### DIFF
--- a/crates/composefs-integration-tests/src/tests/digest_stability.rs
+++ b/crates/composefs-integration-tests/src/tests/digest_stability.rs
@@ -425,9 +425,23 @@ fn check_digest_equivalence(image: &ContainerImage) -> Result<()> {
         let cstor_digest = compute_id(&sh, &cfsctl, repo, &config, true)?;
         eprintln!("  containers-storage V{version}: {cstor_digest}");
 
+        let cstor_digest_non_bootable = if version == "1" {
+            compute_id_v1(&sh, &cfsctl, repo, &config, false)?
+        } else {
+            compute_id(&sh, &cfsctl, repo, &config, false)?
+        };
+        eprintln!("  containers-storage V{version} (non-bootable): {cstor_digest_non_bootable}");
+
         let fs_digest = cmd!(
             sh,
             "{cfsctl} --insecure --erofs-version {version} --repo {repo} compute-id --bootable {mountpoint}"
+        )
+        .read()
+        .map(|s| s.trim().to_string());
+
+        let fs_digest_non_bootable = cmd!(
+            sh,
+            "{cfsctl} --insecure --erofs-version {version} --repo {repo} compute-id {mountpoint}"
         )
         .read()
         .map(|s| s.trim().to_string());
@@ -438,8 +452,13 @@ fn check_digest_equivalence(image: &ContainerImage) -> Result<()> {
             Err(_) => true,
         };
 
+        let non_bootable_mismatch = match &fs_digest_non_bootable {
+            Ok(d) => d != &cstor_digest_non_bootable,
+            Err(_) => true,
+        };
+
         let diff_output = if mismatch {
-            eprintln!("  MISMATCH detected — capturing dumpfiles for diff...");
+            eprintln!("  MISMATCH detected (bootable) — capturing dumpfiles for diff...");
 
             let at_config = format!("@{config}");
             let cstor_dump = cmd!(
@@ -471,13 +490,66 @@ fn check_digest_equivalence(image: &ContainerImage) -> Result<()> {
             None
         };
 
+        let diff_output_non_bootable = if non_bootable_mismatch {
+            eprintln!("  MISMATCH detected (non-bootable) — capturing dumpfiles for diff...");
+
+            let at_config = format!("@{config}");
+            let cstor_dump = cmd!(sh, "{cfsctl} --insecure --repo {repo} oci dump {at_config}")
+                .read()
+                .unwrap_or_else(|e| format!("(failed to dump cstor: {e})"));
+
+            let fs_dump = cmd!(sh, "{cfsctl} --no-repo create-dumpfile {mountpoint}")
+                .read()
+                .unwrap_or_else(|e| format!("(failed to dump on-disk: {e})"));
+
+            let cstor_path = std::env::temp_dir().join("cstor-nonboot.dumpfile");
+            let fs_path = std::env::temp_dir().join("fs-nonboot.dumpfile");
+            std::fs::write(&cstor_path, &cstor_dump)?;
+            std::fs::write(&fs_path, &fs_dump)?;
+
+            let diff = cmd!(sh, "diff -u {cstor_path} {fs_path}")
+                .ignore_status()
+                .read()
+                .unwrap_or_else(|e| format!("(diff failed: {e})"));
+
+            Some(diff)
+        } else {
+            None
+        };
+
         let fs_digest = fs_digest?;
         eprintln!("  on-disk filesystem V{version}: {fs_digest}");
 
+        let fs_digest_non_bootable = fs_digest_non_bootable?;
+        eprintln!("  on-disk filesystem V{version} (non-bootable): {fs_digest_non_bootable}");
+
         if let Some(ref diff) = diff_output {
             eprintln!(
-                "\n=== V{version} dumpfile diff (containers-storage vs on-disk) ===\n\
+                "\n=== V{version} dumpfile diff (containers-storage vs on-disk, bootable) ===\n\
                  {diff}\n=== end diff ===\n"
+            );
+        }
+
+        if let Some(ref diff) = diff_output_non_bootable {
+            eprintln!(
+                "\n=== V{version} dumpfile diff (containers-storage vs on-disk, non-bootable) ===\n\
+                 {diff}\n=== end diff ===\n"
+            );
+        }
+
+        // For issue #212, verifying the non-bootable digests is crucial because the bootable path
+        // applies SELinux relabeling (via selabel) which can mask/override any xattr filtration discrepancies
+        // between the container-storage pull path and the on-disk extraction path. Comparing the
+        // non-bootable digests directly exercises the transform_for_oci() xattr allowlist on both paths.
+        if cstor_digest_non_bootable != fs_digest_non_bootable {
+            // Clean up before bailing.
+            cmd!(sh, "podman umount {cid}").ignore_status().run()?;
+            cmd!(sh, "podman rm -f {cid}").ignore_status().run()?;
+            bail!(
+                "{label} V{version} (non-bootable): digest mismatch between OCI pull and on-disk extraction!\n\
+                 \x20  containers-storage: {cstor_digest_non_bootable}\n\
+                 \x20  on-disk filesystem: {fs_digest_non_bootable}",
+                label = image.label,
             );
         }
 

--- a/crates/composefs-oci/src/design.rs
+++ b/crates/composefs-oci/src/design.rs
@@ -62,9 +62,14 @@
 //! `container_t` that come from the build host, not from the target system's
 //! policy.
 //!
-//! To ensure reproducibility, `read_container_root()` filters xattrs to only
-//! include those in an allowlist.  Currently this is just `security.capability`,
-//! which represents actual file capabilities that should be preserved.
+//! To ensure reproducibility, `transform_for_oci()` filters xattrs to only
+//! include those in an allowlist. This filtering is applied uniformly to BOTH
+//! mounted filesystems (via `read_container_root()`) and OCI tar layers
+//! (via `create_filesystem()`), ensuring identical, consistent digests between
+//! both construction paths.
+//!
+//! Currently this allowlist is just `security.capability`, which represents
+//! actual file capabilities that should be preserved.
 //!
 //! SELinux labels are handled separately by `transform_for_boot()`:
 //!  - If the target filesystem contains a SELinux policy (in `/etc/selinux`),

--- a/crates/composefs-oci/src/image.rs
+++ b/crates/composefs-oci/src/image.rs
@@ -138,12 +138,11 @@ pub fn create_filesystem<ObjectID: FsVerityHashValue>(
         }
     }
 
-    // Apply OCI container transformations for consistent digests.
+    // Apply OCI container transformations for consistent digests.  This also
+    // compacts the leaves table, dropping any orphaned by whiteout processing
+    // and layer merging above.
     // See https://github.com/containers/composefs-rs/issues/132
     filesystem.transform_for_oci()?;
-
-    // Whiteout processing and layer merging can leave orphaned leaves.
-    filesystem.compact();
 
     debug_assert!(
         filesystem.fsck().is_ok(),
@@ -823,6 +822,66 @@ mod test {
 
         process_entry(&mut fs, file_entry("/etc/config"))?;
         assert_files(&fs, &["/", "/etc", "/etc/config"])?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_create_filesystem_filters_xattrs() -> Result<()> {
+        use composefs::{repository::Repository, test::tempdir};
+        use rustix::fs::CWD;
+        use std::{ffi::OsStr, sync::Arc};
+
+        let repo_dir = tempdir();
+        let repo_path = repo_dir.path().join("repo");
+        let (repo, _) = Repository::<Sha256HashValue>::init_path(
+            CWD,
+            &repo_path,
+            RepositoryConfig::default().set_insecure(),
+        )?;
+        let repo = Arc::new(repo);
+
+        let layer_str = "\
+/ 0 40755 2 0 0 0 0.0 - - -
+/etc 0 40755 2 0 0 0 0.0 - - - security.selinux=system_u:object_r:etc_t:s0
+/usr 0 40755 2 0 0 0 0.0 - - -
+/usr/bin 0 40755 2 0 0 0 0.0 - - -
+/usr/bin/foo 12 100755 1 0 0 0 0.0 - test_content - security.selinux=system_u:object_r:bin_t:s0 security.capability=\\x02\\x00\\x00\\x02\\x00\\x20\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00
+";
+
+        let image = crate::test_util::create_multi_layer_image(&repo, None, &[layer_str]).await;
+        let fs = create_filesystem(&repo, &image.config_digest, None)?;
+
+        // The OCI tar path must strip non-allowlisted xattrs everywhere in the
+        // tree, identically to the mounted-filesystem path (issue #212).
+        use std::cell::Cell;
+        let has_selinux = Cell::new(false);
+        fs.for_each_stat(|stat| {
+            if stat.xattrs.contains_key(OsStr::new("security.selinux")) {
+                has_selinux.set(true);
+            }
+        });
+        assert!(
+            !has_selinux.get(),
+            "transform_for_oci should have stripped all security.selinux xattrs"
+        );
+
+        // Lookup /usr/bin/foo and check security.capability is preserved
+        let usr_dir = fs.root.get_directory(OsStr::new("usr"))?;
+        let bin_dir = usr_dir.get_directory(OsStr::new("bin"))?;
+        let leaf_id = bin_dir.leaf_id(OsStr::new("foo"))?;
+        let leaf = fs.leaf(leaf_id);
+
+        let cap_val = leaf
+            .stat
+            .xattrs
+            .get(OsStr::new("security.capability"))
+            .expect("security.capability should be preserved");
+
+        // Check if value matches
+        let expected_cap =
+            b"\x02\x00\x00\x02\x00\x20\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+        assert_eq!(cap_val.as_ref(), expected_cap);
 
         Ok(())
     }

--- a/crates/composefs/src/fs.rs
+++ b/crates/composefs/src/fs.rs
@@ -684,26 +684,7 @@ fn compute_verity_from_fd<ObjectID: FsVerityHashValue>(source: OwnedFd) -> Resul
     Ok(hasher.digest())
 }
 
-/// Default xattr allowlist for container filesystems.
-///
-/// When reading from a mounted container filesystem, host xattrs can leak into
-/// the image (e.g., SELinux labels like `container_t` from overlayfs). This
-/// allowlist specifies which xattrs are safe to preserve.
-///
-/// Currently only `security.capability` is allowed, as it represents actual
-/// file capabilities that should be preserved. SELinux labels (`security.selinux`)
-/// are excluded because they come from the build host and will be regenerated
-/// by `transform_for_boot()` based on the target system's policy.
-///
-/// See: <https://github.com/containers/storage/pull/1608#issuecomment-1600915185>
-pub const CONTAINER_XATTR_ALLOWLIST: &[&str] = &["security.capability"];
-
-/// Returns true if the given xattr name is in [`CONTAINER_XATTR_ALLOWLIST`].
-pub fn is_allowed_container_xattr(name: &OsStr) -> bool {
-    CONTAINER_XATTR_ALLOWLIST
-        .iter()
-        .any(|allowed| name.as_encoded_bytes() == allowed.as_bytes())
-}
+pub use crate::generic_tree::{CONTAINER_XATTR_ALLOWLIST, is_allowed_container_xattr};
 
 /// Read the contents of a file.
 pub fn read_file<ObjectID: FsVerityHashValue>(
@@ -950,14 +931,16 @@ where
 
 /// Load a container root filesystem from the given path.
 ///
-/// Wraps [`read_filesystem_filtered`] with the container xattr allowlist
-/// and applies OCI transformations via [`FileSystem::transform_for_oci`].
+/// Applies OCI transformations via [`FileSystem::transform_for_oci`],
+/// which includes filtering xattrs to the container allowlist.
 pub async fn read_container_root<ObjectID: FsVerityHashValue>(
     dirfd: OwnedFd,
     path: PathBuf,
     repo: Option<Arc<Repository<ObjectID>>>,
 ) -> Result<FileSystem<ObjectID>> {
-    let mut fs = read_filesystem_filtered(dirfd, path, repo, is_allowed_container_xattr).await?;
+    let mut fs = read_filesystem(dirfd, path, repo)
+        .await
+        .context("Reading container root")?;
     fs.transform_for_oci()?;
     Ok(fs)
 }

--- a/crates/composefs/src/generic_tree.rs
+++ b/crates/composefs/src/generic_tree.rs
@@ -10,6 +10,27 @@ use std::{
 
 use thiserror::Error;
 
+/// Default xattr allowlist for container filesystems.
+///
+/// When reading from a mounted container filesystem, host xattrs can leak into
+/// the image (e.g., SELinux labels like `container_t` from overlayfs). This
+/// allowlist specifies which xattrs are safe to preserve.
+///
+/// Currently only `security.capability` is allowed, as it represents actual
+/// file capabilities that should be preserved. SELinux labels (`security.selinux`)
+/// are excluded because they come from the build host and will be regenerated
+/// by `transform_for_boot()` based on the target system's policy.
+///
+/// See: <https://github.com/containers/storage/pull/1608#issuecomment-1600915185>
+pub const CONTAINER_XATTR_ALLOWLIST: &[&str] = &["security.capability"];
+
+/// Returns true if the given xattr name is in [`CONTAINER_XATTR_ALLOWLIST`].
+pub fn is_allowed_container_xattr(name: &OsStr) -> bool {
+    CONTAINER_XATTR_ALLOWLIST
+        .iter()
+        .any(|allowed| name.as_encoded_bytes() == allowed.as_bytes())
+}
+
 /// File metadata similar to `struct stat` from POSIX.
 #[derive(Debug, Clone)]
 pub struct Stat {
@@ -823,8 +844,14 @@ impl<T> FileSystem<T> {
     ///
     /// 1. [`Self::copy_root_metadata_from_usr`] - copies `/usr` metadata to root directory
     /// 2. [`Self::canonicalize_run`] - empties `/run` directory
+    /// 3. [`Self::filter_xattrs`] - filters xattrs to the container allowlist (strips
+    ///    host-leaked xattrs like build-time security.selinux; keeps security.capability)
+    /// 4. [`Self::compact`] - removes leaves orphaned by the steps above (e.g. files
+    ///    that were only referenced from the now-emptied `/run`)
     ///
     /// This is the recommended single entry point for OCI container processing.
+    /// Because the cleanup is built in, callers get a valid (fsck-clean) filesystem
+    /// regardless of whether they came from the OCI tar layers or a mounted root.
     ///
     /// NOTE: If changing this behavior, also update `doc/oci.md`.
     ///
@@ -834,6 +861,10 @@ impl<T> FileSystem<T> {
     pub fn transform_for_oci(&mut self) -> Result<(), ImageError> {
         self.copy_root_metadata_from_usr()?;
         self.canonicalize_run()?;
+        self.filter_xattrs(is_allowed_container_xattr);
+        // Emptying directories above can orphan leaves; drop them so the result
+        // is fsck-clean for every construction path.
+        self.compact();
         Ok(())
     }
 
@@ -1731,6 +1762,125 @@ mod tests {
         let run = fs.root.get_directory(OsStr::new("run")).unwrap();
         assert!(run.entries.is_empty());
         assert_eq!(run.stat.st_mtim_sec, 54321);
+    }
+
+    #[test]
+    fn test_transform_for_oci_filters_xattrs() {
+        let mut leaves = Vec::new();
+        let mut fs = FileSystem::<FileContents>::new(default_stat());
+
+        // Create /usr with both allowed and filtered xattrs
+        let usr_stat = Stat {
+            st_mode: 0o750,
+            st_uid: 100,
+            st_gid: 200,
+            st_mtim_sec: 54321,
+            st_mtim_nsec: 0,
+            xattrs: BTreeMap::from([
+                (
+                    Box::from(OsStr::new("security.selinux")),
+                    Box::from(b"usr_selinux_label".as_slice()),
+                ),
+                (
+                    Box::from(OsStr::new("security.capability")),
+                    Box::from(b"usr_cap".as_slice()),
+                ),
+            ]),
+        };
+        fs.root
+            .insert(OsStr::new("usr"), new_dir_inode_with_stat(usr_stat));
+
+        // Create a regular file in the tree with both xattrs as well
+        let file_stat = Stat {
+            st_mode: 0o644,
+            st_uid: 0,
+            st_gid: 0,
+            st_mtim_sec: 12345,
+            st_mtim_nsec: 0,
+            xattrs: BTreeMap::from([
+                (
+                    Box::from(OsStr::new("security.selinux")),
+                    Box::from(b"file_selinux_label".as_slice()),
+                ),
+                (
+                    Box::from(OsStr::new("security.capability")),
+                    Box::from(b"file_cap".as_slice()),
+                ),
+            ]),
+        };
+        let file_id = push_leaf_file(&mut leaves, 12345);
+        fs.leaves = leaves;
+        // Update leaf's stat
+        fs.leaves[file_id.0].stat = file_stat;
+
+        // Place the file under root
+        fs.root.insert(OsStr::new("testfile"), Inode::leaf(file_id));
+
+        // Transform for OCI
+        fs.transform_for_oci().unwrap();
+
+        // Verify root metadata was copied from /usr and is filtered!
+        assert_eq!(fs.root.stat.st_mode, 0o750);
+        assert!(
+            !fs.root
+                .stat
+                .xattrs
+                .contains_key(OsStr::new("security.selinux"))
+        );
+        assert!(
+            fs.root
+                .stat
+                .xattrs
+                .contains_key(OsStr::new("security.capability"))
+        );
+        assert_eq!(
+            fs.root
+                .stat
+                .xattrs
+                .get(OsStr::new("security.capability"))
+                .unwrap()
+                .as_ref(),
+            b"usr_cap"
+        );
+
+        // Verify /usr itself was filtered
+        let usr_dir = fs.root.get_directory(OsStr::new("usr")).unwrap();
+        assert!(
+            !usr_dir
+                .stat
+                .xattrs
+                .contains_key(OsStr::new("security.selinux"))
+        );
+        assert!(
+            usr_dir
+                .stat
+                .xattrs
+                .contains_key(OsStr::new("security.capability"))
+        );
+
+        // Verify the file's xattrs are also filtered
+        let file_leaf = fs.leaves.get(file_id.0).unwrap();
+        assert!(
+            !file_leaf
+                .stat
+                .xattrs
+                .contains_key(OsStr::new("security.selinux"))
+        );
+        assert!(
+            file_leaf
+                .stat
+                .xattrs
+                .contains_key(OsStr::new("security.capability"))
+        );
+        assert_eq!(
+            file_leaf
+                .stat
+                .xattrs
+                .get(OsStr::new("security.capability"))
+                .unwrap()
+                .as_ref(),
+            b"file_cap"
+        );
     }
 
     #[test]


### PR DESCRIPTION
We build a composefs EROFS from a container image two ways: from the OCI tar layers (create_filesystem) and from a mounted root (read_container_root). These disagreed on extended attributes, which caused digest mismatches in the sealed UKI flow when e.g. a `user.` xattr was present in the root.

For now, let's consistently filter to our allowlist. This will likely need to be extensible in the future.

Assisted-by: https://github.com/cgwalters/cgwalters#llms