### PR TITLE
More work on ostree

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -558,6 +558,14 @@ enum OstreeCommand {
     /// List all ostree commits in the repository
     #[clap(name = "images")]
     ListCommits,
+    /// List refs available in a remote ostree repository
+    ListRefs {
+        /// URL of the remote ostree repository
+        ostree_repo_url: String,
+        /// Summary index subset key (defaults to system architecture)
+        #[clap(long)]
+        subset: Option<String>,
+    },
 }
 
 /// Common options for reading a filesystem from a path
@@ -1777,6 +1785,27 @@ where
                     table.set_header(["NAME", "COMMIT"]);
                     for c in commits {
                         table.add_row([c.name.as_str(), &c.commit_id]);
+                    }
+                    println!("{table}");
+                }
+            }
+            OstreeCommand::ListRefs {
+                ref ostree_repo_url,
+                ref subset,
+            } => {
+                let mut ostree_repo = composefs_ostree::RemoteRepo::new(&repo, ostree_repo_url)?;
+                if let Some(s) = subset {
+                    ostree_repo = ostree_repo.with_summary_subset(s);
+                }
+                let refs = ostree_repo.list_remote_refs().await?;
+                if refs.is_empty() {
+                    println!("No refs found");
+                } else {
+                    let mut table = Table::new();
+                    table.load_preset(UTF8_FULL);
+                    table.set_header(["REF", "COMMIT"]);
+                    for (name, checksum) in &refs {
+                        table.add_row([name.as_str(), &hex::encode(checksum)]);
                     }
                     println!("{table}");
                 }

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -47,11 +47,11 @@ use anyhow::{Context as _, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 #[cfg(any(feature = "oci", feature = "ostree"))]
 use comfy_table::{Table, presets::UTF8_FULL};
-#[cfg(any(feature = "oci", feature = "http"))]
+#[cfg(any(feature = "oci", feature = "http", feature = "ostree"))]
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rustix::fs::{CWD, Mode, OFlags};
 
-#[cfg(any(feature = "oci", feature = "http"))]
+#[cfg(any(feature = "oci", feature = "http", feature = "ostree"))]
 use composefs::progress::{
     ComponentId, ProgressEvent, ProgressReporter, ProgressUnit, SharedReporter,
 };
@@ -81,13 +81,13 @@ use composefs::{
 /// Renders per-component progress bars via [`MultiProgress`].  When a component
 /// completes or is skipped the bar is removed; human-readable messages are
 /// printed above the bar group via [`MultiProgress::println`].
-#[cfg(any(feature = "oci", feature = "http"))]
+#[cfg(any(feature = "oci", feature = "http", feature = "ostree"))]
 struct IndicatifReporter {
     multi: MultiProgress,
     bars: Mutex<HashMap<ComponentId, ProgressBar>>,
 }
 
-#[cfg(any(feature = "oci", feature = "http"))]
+#[cfg(any(feature = "oci", feature = "http", feature = "ostree"))]
 impl IndicatifReporter {
     fn new() -> Self {
         IndicatifReporter {
@@ -102,14 +102,14 @@ impl IndicatifReporter {
     }
 }
 
-#[cfg(any(feature = "oci", feature = "http"))]
+#[cfg(any(feature = "oci", feature = "http", feature = "ostree"))]
 impl std::fmt::Debug for IndicatifReporter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IndicatifReporter").finish_non_exhaustive()
     }
 }
 
-#[cfg(any(feature = "oci", feature = "http"))]
+#[cfg(any(feature = "oci", feature = "http", feature = "ostree"))]
 impl ProgressReporter for IndicatifReporter {
     fn report(&self, event: ProgressEvent) {
         match event {
@@ -1687,14 +1687,15 @@ where
                 ref ostree_ref,
                 base_name,
             } => {
-                eprintln!("Fetching {ostree_ref}");
-                let (verity, stats) = composefs_ostree::pull_local(
-                    &repo,
-                    ostree_repo_path,
-                    ostree_ref,
-                    base_name.as_deref(),
-                )
-                .await?;
+                let ostree_repo =
+                    composefs_ostree::LocalRepo::open_path(&repo, CWD, ostree_repo_path)?;
+                let reporter: SharedReporter = IndicatifReporter::new().into_shared();
+                let opts = composefs_ostree::PullOptions {
+                    base_reference: base_name.as_deref(),
+                    progress: Some(reporter),
+                };
+                let (verity, stats) =
+                    composefs_ostree::pull(&repo, ostree_repo, ostree_ref, opts).await?;
 
                 let image_id = composefs_ostree::get_image_ref(&repo, &stats.commit_id)?;
                 println!("commit  {}", stats.commit_id);
@@ -1713,14 +1714,14 @@ where
                 ref ostree_ref,
                 base_name,
             } => {
-                eprintln!("Fetching {ostree_ref}");
-                let (verity, stats) = composefs_ostree::pull(
-                    &repo,
-                    ostree_repo_url,
-                    ostree_ref,
-                    base_name.as_deref(),
-                )
-                .await?;
+                let ostree_repo = composefs_ostree::RemoteRepo::new(&repo, ostree_repo_url)?;
+                let reporter: SharedReporter = IndicatifReporter::new().into_shared();
+                let opts = composefs_ostree::PullOptions {
+                    base_reference: base_name.as_deref(),
+                    progress: Some(reporter),
+                };
+                let (verity, stats) =
+                    composefs_ostree::pull(&repo, ostree_repo, ostree_ref, opts).await?;
 
                 let image_id = composefs_ostree::get_image_ref(&repo, &stats.commit_id)?;
                 println!("commit  {}", stats.commit_id);

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -558,6 +558,11 @@ enum OstreeCommand {
     /// List all ostree commits in the repository
     #[clap(name = "images")]
     ListCommits,
+    /// Apply a static delta to the repository
+    ApplyDelta {
+        /// Path to the delta file (single-file) or superblock
+        delta_path: PathBuf,
+    },
     /// List refs available in a remote ostree repository
     ListRefs {
         /// URL of the remote ostree repository
@@ -1788,6 +1793,17 @@ where
                     }
                     println!("{table}");
                 }
+            }
+            OstreeCommand::ApplyDelta { ref delta_path } => {
+                let (verity, stats) = composefs_ostree::apply_delta_offline(&repo, delta_path)?;
+                let image_id = composefs_ostree::get_image_ref(&repo, &stats.commit_id)?;
+                println!("commit  {}", stats.commit_id);
+                println!("verity  {}", verity.to_hex());
+                println!("image   {}", image_id.to_hex());
+                println!(
+                    "objects {} metadata + {} files applied",
+                    stats.metadata_fetched, stats.files_fetched
+                );
             }
             OstreeCommand::ListRefs {
                 ref ostree_repo_url,

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -837,6 +837,21 @@ where
     run_app(args).await
 }
 
+#[cfg(feature = "ostree")]
+fn print_pull_stats(stats: &composefs_ostree::PullStats) {
+    if stats.delta_parts_applied > 0 {
+        println!(
+            "objects {} metadata + {} files via {} delta parts",
+            stats.metadata_fetched, stats.files_fetched, stats.delta_parts_applied
+        );
+    } else {
+        println!(
+            "objects {} metadata + {} files fetched",
+            stats.metadata_fetched, stats.files_fetched
+        );
+    }
+}
+
 fn get_mount_options(
     upperdir: Option<&Path>,
     workdir: Option<&Path>,
@@ -1717,10 +1732,7 @@ where
                 if !composefs_ostree::is_commit_id(ostree_ref) {
                     println!("tagged  {ostree_ref}");
                 }
-                println!(
-                    "objects {} metadata + {} files fetched",
-                    stats.metadata_fetched, stats.files_fetched
-                );
+                print_pull_stats(&stats);
             }
             OstreeCommand::Pull {
                 ref ostree_repo_url,
@@ -1743,10 +1755,7 @@ where
                 if !composefs_ostree::is_commit_id(ostree_ref) {
                     println!("tagged  {ostree_ref}");
                 }
-                println!(
-                    "objects {} metadata + {} files fetched",
-                    stats.metadata_fetched, stats.files_fetched
-                );
+                print_pull_stats(&stats);
             }
             OstreeCommand::Mount {
                 ref commit,

--- a/crates/composefs-integration-tests/src/tests/ostree.rs
+++ b/crates/composefs-integration-tests/src/tests/ostree.rs
@@ -15,30 +15,110 @@ use composefs_oci::composefs::repository::Repository;
 use crate::integration_test;
 use composefs_integration_tests::create_test_repository;
 
-fn create_ostree_test_content(parent: &Path) -> Result<std::path::PathBuf> {
+/// Create test content for an ostree commit.
+///
+/// `version` controls what content is generated, allowing two versions
+/// to differ in ways that exercise different delta code paths:
+/// - Files unchanged between versions (inherited from base)
+/// - Small files added/removed (OPEN_SPLICE_AND_CLOSE)
+/// - Large files with minor edits (BSPATCH / rollsum)
+/// - New large files (fallback candidates)
+/// - Symlinks with changed targets
+/// - Nested directory changes (new dirtree metadata)
+fn create_ostree_test_content(parent: &Path, version: u32) -> Result<std::path::PathBuf> {
     let root = parent.join("content");
+    if root.exists() {
+        std::fs::remove_dir_all(&root)?;
+    }
+    std::fs::create_dir_all(root.join("bin"))?;
     std::fs::create_dir_all(root.join("subdir"))?;
+    std::fs::create_dir_all(root.join("lib"))?;
+    std::fs::create_dir_all(root.join("share/locale"))?;
+    std::fs::create_dir_all(root.join("share/icons"))?;
 
-    // Small file (will be inlined by ostree)
-    std::fs::write(root.join("small.txt"), "hello")?;
-    // Large file (external object)
-    std::fs::write(root.join("large.bin"), vec![0xABu8; 128 * 1024])?;
-    // Duplicate of large file (shared object)
-    std::fs::write(root.join("large-dup.bin"), vec![0xABu8; 128 * 1024])?;
-    // Symlink
-    std::os::unix::fs::symlink("small.txt", root.join("link.txt"))?;
-    // Nested file
-    std::fs::write(root.join("subdir/nested.txt"), "nested content")?;
+    // --- Files unchanged between versions ---
 
-    // File with xattr
-    let xattr_file = root.join("with-xattr.txt");
-    std::fs::write(&xattr_file, "has xattr")?;
+    // Small file (inlined by ostree)
+    std::fs::write(root.join("README"), "This is a test application.\n")?;
+    // Medium file
+    std::fs::write(
+        root.join("share/locale/messages.po"),
+        "msgid \"hello\"\nmsgstr \"world\"\n".repeat(50),
+    )?;
+    // Large binary (external object, shared across versions)
+    let mut shared_data = vec![0u8; 64 * 1024];
+    for (i, b) in shared_data.iter_mut().enumerate() {
+        *b = (i % 251) as u8;
+    }
+    std::fs::write(root.join("lib/libshared.so"), &shared_data)?;
+    // Duplicate (tests deduplication)
+    std::fs::write(root.join("lib/libshared.so.1"), &shared_data)?;
+
+    // File with xattr (unchanged across versions)
+    let xattr_file = root.join("share/icons/app.png");
+    std::fs::write(
+        &xattr_file,
+        vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A],
+    )?;
     rustix::fs::setxattr(
         &xattr_file,
         c"user.testxattr",
         b"testvalue",
         rustix::fs::XattrFlags::CREATE,
     )?;
+
+    // Symlink (unchanged across versions)
+    std::os::unix::fs::symlink("libshared.so.1", root.join("lib/libcompat.so"))?;
+
+    // --- Files that vary by version ---
+
+    // Small config file that changes between versions
+    std::fs::write(
+        root.join("config.ini"),
+        format!("[app]\nversion={version}\nname=testapp\n"),
+    )?;
+
+    // Large binary with a minor edit (triggers bspatch in delta)
+    let mut app_binary = vec![0u8; 256 * 1024];
+    for (i, b) in app_binary.iter_mut().enumerate() {
+        *b = ((i * 7 + 13) % 256) as u8;
+    }
+    // Embed version near the start so most of the file is unchanged
+    let version_bytes = version.to_le_bytes();
+    app_binary[100..104].copy_from_slice(&version_bytes);
+    app_binary[200..204].copy_from_slice(&version_bytes);
+    std::fs::write(root.join("bin/app"), &app_binary)?;
+
+    // Another large file with version-dependent content
+    let mut data_file = vec![0u8; 128 * 1024];
+    for (i, b) in data_file.iter_mut().enumerate() {
+        *b = ((i * 3 + version as usize) % 256) as u8;
+    }
+    std::fs::write(root.join("share/data.bin"), &data_file)?;
+
+    // Symlink that changes target between versions
+    std::os::unix::fs::symlink(
+        format!("libshared.so.{version}"),
+        root.join("lib/libcurrent.so"),
+    )?;
+
+    // Nested file that changes
+    std::fs::write(
+        root.join("subdir/nested.txt"),
+        format!("nested content version {version}\n"),
+    )?;
+
+    // Version-specific files (v2 adds extra files, simulating a real update)
+    if version >= 2 {
+        std::fs::create_dir_all(root.join("share/new-feature"))?;
+        std::fs::write(
+            root.join("share/new-feature/data.json"),
+            r#"{"feature": "new", "enabled": true}"#,
+        )?;
+        // A new large file (potential fallback in delta)
+        let new_large = vec![0xCDu8; 192 * 1024];
+        std::fs::write(root.join("share/new-feature/resource.bin"), &new_large)?;
+    }
 
     Ok(root)
 }
@@ -80,7 +160,7 @@ fn pull_and_get_image_id(
 fn test_ostree_pull_local_all_modes() -> Result<()> {
     let sh = Shell::new()?;
     let tmpdir = TempDir::new()?;
-    let content = create_ostree_test_content(tmpdir.path())?;
+    let content = create_ostree_test_content(tmpdir.path(), 1)?;
 
     // Commit to archive-z2 first — some modes can't be committed to directly
     let archive_repo = tmpdir.path().join("ostree-archive-z2");
@@ -154,7 +234,7 @@ integration_test!(test_ostree_pull_local_all_modes);
 fn test_ostree_pull_remote_archive() -> Result<()> {
     let sh = Shell::new()?;
     let tmpdir = TempDir::new()?;
-    let content = create_ostree_test_content(tmpdir.path())?;
+    let content = create_ostree_test_content(tmpdir.path(), 1)?;
 
     // Create archive-z2 repo and commit
     let ostree_repo_path = tmpdir.path().join("ostree-archive");
@@ -166,65 +246,38 @@ fn test_ostree_pull_remote_archive() -> Result<()> {
     let repo_local = create_test_repository(&composefs_dir_local)?;
     let (local_image_id, _) = pull_and_get_image_id(&repo_local, &ostree_repo_path, "test", None)?;
 
-    // Find a free port and start HTTP server
-    let listener = TcpListener::bind("127.0.0.1:0")?;
-    let port = listener.local_addr()?.port();
-    drop(listener);
+    // Pull via HTTP and compare
+    let server = HttpServer::start(&ostree_repo_path)?;
+    let composefs_dir_remote = TempDir::new()?;
+    let repo_remote = create_test_repository(&composefs_dir_remote)?;
 
-    let repo_path_str = ostree_repo_path.to_str().unwrap().to_string();
-    let mut server = Command::new("python3")
-        .args([
-            "-m",
-            "http.server",
-            &port.to_string(),
-            "--directory",
-            &repo_path_str,
-        ])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()?;
+    let rt = tokio::runtime::Runtime::new()?;
+    let ostree_repo = composefs_ostree::RemoteRepo::new(&repo_remote, &server.url())?;
+    let (_obj_id, stats) = rt.block_on(composefs_ostree::pull(
+        &repo_remote,
+        ostree_repo,
+        "test",
+        Default::default(),
+    ))?;
 
-    // Give the server a moment to start
-    std::thread::sleep(std::time::Duration::from_millis(500));
+    assert!(stats.metadata_fetched > 0);
+    assert!(stats.files_fetched > 0);
 
-    let result = (|| -> Result<()> {
-        let composefs_dir_remote = TempDir::new()?;
-        let repo_remote = create_test_repository(&composefs_dir_remote)?;
+    let remote_image_id = composefs_ostree::get_image_ref(&repo_remote, "test")?;
 
-        let rt = tokio::runtime::Runtime::new()?;
-        let url = format!("http://127.0.0.1:{port}");
-        let ostree_repo = composefs_ostree::RemoteRepo::new(&repo_remote, &url)?;
-        let (_obj_id, stats) = rt.block_on(composefs_ostree::pull(
-            &repo_remote,
-            ostree_repo,
-            "test",
-            Default::default(),
-        ))?;
+    assert_eq!(
+        local_image_id, remote_image_id,
+        "remote pull image ID differs from local pull"
+    );
 
-        assert!(stats.metadata_fetched > 0);
-        assert!(stats.files_fetched > 0);
-
-        let remote_image_id = composefs_ostree::get_image_ref(&repo_remote, "test")?;
-
-        assert_eq!(
-            local_image_id, remote_image_id,
-            "remote pull image ID differs from local pull"
-        );
-
-        Ok(())
-    })();
-
-    server.kill().ok();
-    server.wait().ok();
-
-    result
+    Ok(())
 }
 integration_test!(test_ostree_pull_remote_archive);
 
 fn test_ostree_pull_with_base() -> Result<()> {
     let sh = Shell::new()?;
     let tmpdir = TempDir::new()?;
-    let content = create_ostree_test_content(tmpdir.path())?;
+    let content = create_ostree_test_content(tmpdir.path(), 1)?;
 
     // Create archive-z2 repo with initial commit on branch "commit-a"
     let ostree_repo_path = tmpdir.path().join("ostree-repo");
@@ -245,9 +298,9 @@ fn test_ostree_pull_with_base() -> Result<()> {
         Default::default(),
     ))?;
 
-    // Modify content slightly and make commit B on branch "commit-b"
-    std::fs::write(content.join("new-file.txt"), "new content for commit B")?;
-    commit_to_ostree(&sh, &ostree_repo_path, "commit-b", &content)?;
+    // Create version 2 content and commit as branch B
+    let content_v2 = create_ostree_test_content(tmpdir.path(), 2)?;
+    commit_to_ostree(&sh, &ostree_repo_path, "commit-b", &content_v2)?;
 
     // Pull commit B with base
     let ostree_repo =
@@ -290,3 +343,226 @@ fn test_ostree_pull_with_base() -> Result<()> {
     Ok(())
 }
 integration_test!(test_ostree_pull_with_base);
+
+struct HttpServer {
+    child: std::process::Child,
+    port: u16,
+}
+
+impl HttpServer {
+    fn start(directory: &Path) -> Result<Self> {
+        let listener = TcpListener::bind("127.0.0.1:0")?;
+        let port = listener.local_addr()?.port();
+        drop(listener);
+
+        let child = Command::new("python3")
+            .args([
+                "-m",
+                "http.server",
+                &port.to_string(),
+                "--directory",
+                directory.to_str().unwrap(),
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()?;
+
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        Ok(HttpServer { child, port })
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+impl Drop for HttpServer {
+    fn drop(&mut self) {
+        self.child.kill().ok();
+        self.child.wait().ok();
+    }
+}
+
+fn generate_delta(sh: &Shell, repo: &Path, from: Option<&str>, to: &str) -> Result<()> {
+    let repo = repo.to_str().unwrap();
+    if let Some(from) = from {
+        cmd!(
+            sh,
+            "ostree static-delta generate --repo={repo} --from={from} --to={to}"
+        )
+        .run()?;
+    } else {
+        cmd!(
+            sh,
+            "ostree static-delta generate --repo={repo} --empty --to={to}"
+        )
+        .run()?;
+    }
+    Ok(())
+}
+
+fn update_summary(sh: &Shell, repo: &Path) -> Result<()> {
+    let repo = repo.to_str().unwrap();
+    cmd!(sh, "ostree summary --repo={repo} --update").run()?;
+    Ok(())
+}
+
+fn test_ostree_pull_remote_scratch_delta() -> Result<()> {
+    let sh = Shell::new()?;
+    let tmpdir = TempDir::new()?;
+    let content = create_ostree_test_content(tmpdir.path(), 1)?;
+
+    let ostree_repo_path = tmpdir.path().join("ostree-archive");
+    init_ostree_repo(&sh, &ostree_repo_path, "archive-z2")?;
+    let commit_id = commit_to_ostree(&sh, &ostree_repo_path, "test", &content)?;
+
+    generate_delta(&sh, &ostree_repo_path, None, &commit_id)?;
+    update_summary(&sh, &ostree_repo_path)?;
+
+    // Pull via direct object fetch for reference
+    let composefs_dir_ref = TempDir::new()?;
+    let repo_ref = create_test_repository(&composefs_dir_ref)?;
+    let (ref_image_id, _) = pull_and_get_image_id(&repo_ref, &ostree_repo_path, "test", None)?;
+
+    // Pull via HTTP with delta
+    let server = HttpServer::start(&ostree_repo_path)?;
+    let composefs_dir = TempDir::new()?;
+    let repo = create_test_repository(&composefs_dir)?;
+
+    let rt = tokio::runtime::Runtime::new()?;
+    let ostree_repo = composefs_ostree::RemoteRepo::new(&repo, &server.url())?;
+    let (_, stats) = rt.block_on(composefs_ostree::pull(
+        &repo,
+        ostree_repo,
+        "test",
+        Default::default(),
+    ))?;
+
+    assert!(
+        stats.delta_parts_applied > 0,
+        "expected delta to be used, but delta_parts_applied=0"
+    );
+
+    let delta_image_id = composefs_ostree::get_image_ref(&repo, "test")?;
+    assert_eq!(
+        ref_image_id, delta_image_id,
+        "scratch delta image ID differs from local pull"
+    );
+
+    Ok(())
+}
+integration_test!(test_ostree_pull_remote_scratch_delta);
+
+fn test_ostree_pull_remote_diff_delta() -> Result<()> {
+    let sh = Shell::new()?;
+    let tmpdir = TempDir::new()?;
+
+    let ostree_repo_path = tmpdir.path().join("ostree-archive");
+    init_ostree_repo(&sh, &ostree_repo_path, "archive-z2")?;
+
+    let content_v1 = create_ostree_test_content(tmpdir.path(), 1)?;
+    let commit_a = commit_to_ostree(&sh, &ostree_repo_path, "branch-a", &content_v1)?;
+
+    let content_v2 = create_ostree_test_content(tmpdir.path(), 2)?;
+    let commit_b = commit_to_ostree(&sh, &ostree_repo_path, "branch-b", &content_v2)?;
+
+    generate_delta(&sh, &ostree_repo_path, Some(&commit_a), &commit_b)?;
+    update_summary(&sh, &ostree_repo_path)?;
+
+    // Pull commit B via direct local pull for reference image ID
+    let composefs_dir_ref = TempDir::new()?;
+    let repo_ref = create_test_repository(&composefs_dir_ref)?;
+    let (ref_image_id, _) = pull_and_get_image_id(&repo_ref, &ostree_repo_path, "branch-b", None)?;
+
+    // Pull over HTTP: first commit A (no delta), then commit B (should use diff delta)
+    let server = HttpServer::start(&ostree_repo_path)?;
+    let composefs_dir = TempDir::new()?;
+    let repo = create_test_repository(&composefs_dir)?;
+
+    let rt = tokio::runtime::Runtime::new()?;
+
+    let ostree_repo = composefs_ostree::RemoteRepo::new(&repo, &server.url())?;
+    rt.block_on(composefs_ostree::pull(
+        &repo,
+        ostree_repo,
+        "branch-a",
+        Default::default(),
+    ))?;
+
+    let ostree_repo = composefs_ostree::RemoteRepo::new(&repo, &server.url())?;
+    let (_, stats_b) = rt.block_on(composefs_ostree::pull(
+        &repo,
+        ostree_repo,
+        "branch-b",
+        Default::default(),
+    ))?;
+
+    assert!(
+        stats_b.delta_parts_applied > 0,
+        "expected differential delta to be used, but delta_parts_applied=0"
+    );
+
+    let delta_image_id = composefs_ostree::get_image_ref(&repo, "branch-b")?;
+    assert_eq!(
+        ref_image_id, delta_image_id,
+        "differential delta image ID differs from local pull"
+    );
+
+    Ok(())
+}
+integration_test!(test_ostree_pull_remote_diff_delta);
+
+fn test_ostree_apply_delta_offline() -> Result<()> {
+    let sh = Shell::new()?;
+    let tmpdir = TempDir::new()?;
+
+    let ostree_repo_path = tmpdir.path().join("ostree-archive");
+    init_ostree_repo(&sh, &ostree_repo_path, "archive-z2")?;
+
+    let content_v1 = create_ostree_test_content(tmpdir.path(), 1)?;
+    let commit_a = commit_to_ostree(&sh, &ostree_repo_path, "branch-a", &content_v1)?;
+
+    let content_v2 = create_ostree_test_content(tmpdir.path(), 2)?;
+    let commit_b = commit_to_ostree(&sh, &ostree_repo_path, "branch-b", &content_v2)?;
+
+    // Generate an inline delta file
+    let delta_file = tmpdir.path().join("delta.bin");
+    let repo_str = ostree_repo_path.to_str().unwrap();
+    let delta_str = delta_file.to_str().unwrap();
+    cmd!(
+        sh,
+        "ostree static-delta generate --repo={repo_str} --from={commit_a} --to={commit_b} --inline --filename={delta_str}"
+    )
+    .run()?;
+
+    // Pull commit A, then apply delta
+    let composefs_dir = TempDir::new()?;
+    let repo = create_test_repository(&composefs_dir)?;
+
+    let ostree_repo =
+        composefs_ostree::LocalRepo::open_path(&repo, rustix::fs::CWD, &ostree_repo_path)?;
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(composefs_ostree::pull(
+        &repo,
+        ostree_repo,
+        "branch-a",
+        Default::default(),
+    ))?;
+
+    let (_, delta_stats) = composefs_ostree::apply_delta_offline(&repo, &delta_file)?;
+    assert!(delta_stats.metadata_fetched > 0);
+
+    // Pull commit B directly for reference
+    let composefs_dir_ref = TempDir::new()?;
+    let repo_ref = create_test_repository(&composefs_dir_ref)?;
+    let (ref_image_id, _) = pull_and_get_image_id(&repo_ref, &ostree_repo_path, "branch-b", None)?;
+
+    let delta_image_id = composefs_ostree::get_image_ref(&repo, &delta_stats.commit_id)?;
+    assert_eq!(
+        ref_image_id, delta_image_id,
+        "offline delta image ID differs from local pull"
+    );
+
+    Ok(())
+}
+integration_test!(test_ostree_apply_delta_offline);

--- a/crates/composefs-integration-tests/src/tests/ostree.rs
+++ b/crates/composefs-integration-tests/src/tests/ostree.rs
@@ -63,12 +63,14 @@ fn pull_and_get_image_id(
     base_name: Option<&str>,
 ) -> Result<(Sha256HashValue, composefs_ostree::PullStats)> {
     let rt = tokio::runtime::Runtime::new()?;
-    let (_obj_id, stats) = rt.block_on(composefs_ostree::pull_local(
-        repo,
-        ostree_repo_path,
-        ostree_ref,
-        base_name,
-    ))?;
+    let ostree_repo =
+        composefs_ostree::LocalRepo::open_path(repo, rustix::fs::CWD, ostree_repo_path)?;
+    let opts = composefs_ostree::PullOptions {
+        base_reference: base_name,
+        ..Default::default()
+    };
+    let (_obj_id, stats) =
+        rt.block_on(composefs_ostree::pull(repo, ostree_repo, ostree_ref, opts))?;
 
     let image_id = composefs_ostree::get_image_ref(repo, ostree_ref)?;
 
@@ -191,8 +193,13 @@ fn test_ostree_pull_remote_archive() -> Result<()> {
 
         let rt = tokio::runtime::Runtime::new()?;
         let url = format!("http://127.0.0.1:{port}");
-        let (_obj_id, stats) =
-            rt.block_on(composefs_ostree::pull(&repo_remote, &url, "test", None))?;
+        let ostree_repo = composefs_ostree::RemoteRepo::new(&repo_remote, &url)?;
+        let (_obj_id, stats) = rt.block_on(composefs_ostree::pull(
+            &repo_remote,
+            ostree_repo,
+            "test",
+            Default::default(),
+        ))?;
 
         assert!(stats.metadata_fetched > 0);
         assert!(stats.files_fetched > 0);
@@ -229,11 +236,13 @@ fn test_ostree_pull_with_base() -> Result<()> {
     let repo = create_test_repository(&composefs_dir)?;
 
     let rt = tokio::runtime::Runtime::new()?;
-    let (_, _stats_a) = rt.block_on(composefs_ostree::pull_local(
+    let ostree_repo =
+        composefs_ostree::LocalRepo::open_path(&repo, rustix::fs::CWD, &ostree_repo_path)?;
+    let (_, _stats_a) = rt.block_on(composefs_ostree::pull(
         &repo,
-        &ostree_repo_path,
+        ostree_repo,
         "commit-a",
-        None,
+        Default::default(),
     ))?;
 
     // Modify content slightly and make commit B on branch "commit-b"
@@ -241,21 +250,25 @@ fn test_ostree_pull_with_base() -> Result<()> {
     commit_to_ostree(&sh, &ostree_repo_path, "commit-b", &content)?;
 
     // Pull commit B with base
-    let (_, stats_with_base) = rt.block_on(composefs_ostree::pull_local(
-        &repo,
-        &ostree_repo_path,
-        "commit-b",
-        Some("commit-a"),
-    ))?;
+    let ostree_repo =
+        composefs_ostree::LocalRepo::open_path(&repo, rustix::fs::CWD, &ostree_repo_path)?;
+    let opts = composefs_ostree::PullOptions {
+        base_reference: Some("commit-a"),
+        ..Default::default()
+    };
+    let (_, stats_with_base) =
+        rt.block_on(composefs_ostree::pull(&repo, ostree_repo, "commit-b", opts))?;
 
     // Pull commit B without base into a fresh repo
     let composefs_dir2 = TempDir::new()?;
     let repo2 = create_test_repository(&composefs_dir2)?;
-    let (_, stats_without_base) = rt.block_on(composefs_ostree::pull_local(
+    let ostree_repo =
+        composefs_ostree::LocalRepo::open_path(&repo2, rustix::fs::CWD, &ostree_repo_path)?;
+    let (_, stats_without_base) = rt.block_on(composefs_ostree::pull(
         &repo2,
-        &ostree_repo_path,
+        ostree_repo,
         "commit-b",
-        None,
+        Default::default(),
     ))?;
 
     assert!(

--- a/crates/composefs-ostree/Cargo.toml
+++ b/crates/composefs-ostree/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
+bsdiff = { version = "0.2.1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 composefs = { workspace = true }
 configparser = { version = "3.1.0", features = [] }
@@ -25,6 +26,7 @@ reqwest = { version = "0.12.15", features = ["stream", "zstd"] }
 tokio = { version = "1.24.2", default-features = false, features = ["rt", "sync"] }
 tokio-stream = "0.1.18"
 tokio-util = { version = "0.7", default-features = false, features = ["io", "io-util"] }
+xz2 = { version = "0.1.7", default-features = false }
 
 [dev-dependencies]
 similar-asserts = "1.7.0"

--- a/crates/composefs-ostree/Cargo.toml
+++ b/crates/composefs-ostree/Cargo.toml
@@ -18,7 +18,6 @@ configparser = { version = "3.1.0", features = [] }
 flate2 = { version = "1.1.2", default-features = true }
 gvariant = { version = "0.5.1", default-features = true}
 hex = { version = "0.4.0", default-features = false, features = ["std"] }
-indicatif = { version = "0.17.0", default-features = false }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "mount", "process", "std"] }
 sha2 = { version = "0.11.0", default-features = false }
 zerocopy = { version = "0.8.0", default-features = false, features = ["derive", "std"] }

--- a/crates/composefs-ostree/Cargo.toml
+++ b/crates/composefs-ostree/Cargo.toml
@@ -22,7 +22,7 @@ rustix = { version = "1.0.0", default-features = false, features = ["fs", "mount
 sha2 = { version = "0.11.0", default-features = false }
 zerocopy = { version = "0.8.0", default-features = false, features = ["derive", "std"] }
 reqwest = { version = "0.12.15", features = ["stream", "zstd"] }
-tokio = { version = "1.24.2", default-features = false, features = ["rt"] }
+tokio = { version = "1.24.2", default-features = false, features = ["rt", "sync"] }
 tokio-stream = "0.1.18"
 tokio-util = { version = "0.7", default-features = false, features = ["io", "io-util"] }
 

--- a/crates/composefs-ostree/Cargo.toml
+++ b/crates/composefs-ostree/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = { version = "1.0.87", default-features = false }
+base64 = { version = "0.22", default-features = false, features = ["std"] }
 bsdiff = { version = "0.2.1", default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 composefs = { workspace = true }

--- a/crates/composefs-ostree/src/commit.rs
+++ b/crates/composefs-ostree/src/commit.rs
@@ -131,6 +131,10 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
         self.lookup_idx(ostree_id).is_some()
     }
 
+    pub fn lookup_data(&self, ostree_id: &Sha256Digest) -> Option<&AlignedBuf> {
+        self.lookup_idx(ostree_id).map(|i| &self.map[i].data)
+    }
+
     pub fn set_commit_id(&mut self, id: &Sha256Digest) {
         self.commit_id = Some(*id);
     }

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -1,0 +1,1193 @@
+//! OSTree static delta parsing and application.
+//!
+//! Supports applying static deltas (both offline from files and eventually
+//! inline during remote pulls). The delta format is documented in the
+//! ostree source at `ostree-repo-static-delta-private.h`.
+
+use std::fs::File;
+use std::io::Read;
+use std::os::fd::{AsFd, OwnedFd};
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use gvariant::aligned_bytes::{AlignedBuf, TryAsAligned};
+use gvariant::{Marker, Structure, gv};
+use rustix::fs::{Mode, OFlags, openat, seek};
+use sha2::{Digest, Sha256};
+
+use composefs::fsverity::FsVerityHashValue;
+use composefs::repository::Repository;
+use composefs::util::Sha256Digest;
+
+use crate::commit::{CommitReader, CommitWriter};
+use crate::ostree::{
+    ObjectType, OstreeCommit, OstreeDirTree, OstreeFileHeader, should_inline_file,
+};
+use crate::pull::PullStats;
+
+const OBJTYPE_CSUM_LEN: usize = 33; // 1 byte type + 32 bytes SHA-256
+
+// Delta opcodes
+const OP_OPEN_SPLICE_AND_CLOSE: u8 = b'S';
+const OP_OPEN: u8 = b'o';
+const OP_WRITE: u8 = b'w';
+const OP_SET_READ_SOURCE: u8 = b'r';
+const OP_UNSET_READ_SOURCE: u8 = b'R';
+const OP_CLOSE: u8 = b'c';
+const OP_BSPATCH: u8 = b'B';
+
+// Signed delta magic: "OSTSGNDT" in big-endian u64
+const SIGNED_DELTA_MAGIC: u64 = 0x4F53_5453_474E_4454;
+
+// ---------- varint codec ----------
+
+fn read_varuint64(data: &[u8], pos: &mut usize) -> Result<u64> {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        ensure!(*pos < data.len(), "varint extends past end of data");
+        let b = data[*pos];
+        *pos += 1;
+        result |= ((b & 0x7F) as u64) << shift;
+        if b & 0x80 == 0 {
+            return Ok(result);
+        }
+        shift += 7;
+        ensure!(shift < 70, "varint too long");
+    }
+}
+
+// ---------- GVariant framing helpers ----------
+
+fn gv_offset_size(container_size: u64) -> usize {
+    match container_size {
+        0 => 0,
+        0x01..=0xFF => 1,
+        0x100..=0xFFFF => 2,
+        0x1_0000..=0xFFFF_FFFF => 4,
+        _ => 8,
+    }
+}
+
+fn gv_read_offset(data: &[u8], osz: usize, index: usize) -> u64 {
+    let start = index * osz;
+    match osz {
+        1 => data[start] as u64,
+        2 => u16::from_le_bytes(data[start..start + 2].try_into().unwrap()) as u64,
+        4 => u32::from_le_bytes(data[start..start + 4].try_into().unwrap()) as u64,
+        8 => u64::from_le_bytes(data[start..start + 8].try_into().unwrap()),
+        _ => 0,
+    }
+}
+
+fn align_up(offset: u64, alignment: u64) -> u64 {
+    (offset + alignment - 1) & !(alignment - 1)
+}
+
+// ---------- Superblock parser ----------
+
+/// The superblock format `(a{sv}tayay(...)aya(uayttay)a(yaytt))` has 8 children.
+/// Frame offsets at the end cover 6 variable-size children (all except the last).
+/// Child [1] (`t`) is fixed-size (8 bytes).
+const N_SUPERBLOCK_CHILDREN: usize = 8;
+const N_FRAME_OFFSETS: usize = 6;
+
+struct SuperblockChildRanges {
+    ranges: [(u64, u64); N_SUPERBLOCK_CHILDREN],
+}
+
+/// Compute child byte ranges from superblock size and frame offsets.
+///
+/// The superblock tuple `(a{sv} t ay ay (...) ay a(...) a(...))` has:
+/// - 7 variable-size children, 1 fixed-size child (`t` at index 1)
+/// - 6 frame offsets (for variable children 0,2,3,4,5,6; child 7 is LAST)
+///
+/// Frame offset[i] stores the *end* of the i-th variable-size child.
+/// Start of each child is derived from the end of the previous child + alignment.
+fn compute_child_ranges(
+    total_size: u64,
+    frame_offsets: &[u64; N_FRAME_OFFSETS],
+) -> SuperblockChildRanges {
+    // Map: for each variable-size child (0,2,3,4,5,6,7), what frame offset index?
+    // var_children: [(child_index, frame_offset_index_for_end)]
+    // child 0: end = fo[0]
+    // child 1: fixed, 8 bytes
+    // child 2: end = fo[1]
+    // child 3: end = fo[2]
+    // child 4: end = fo[3]
+    // child 5: end = fo[4]
+    // child 6: end = fo[5]
+    // child 7: end = total_size - n_frame_offsets * osz (LAST)
+
+    let osz = gv_offset_size(total_size) as u64;
+    let data_end = total_size - N_FRAME_OFFSETS as u64 * osz;
+
+    let mut ranges = [(0u64, 0u64); N_SUPERBLOCK_CHILDREN];
+
+    // Child 0: a{sv}, starts at 0, ends at fo[0]
+    ranges[0] = (0, frame_offsets[0]);
+
+    // Child 1: t (fixed 8 bytes), starts after child 0 aligned to 8
+    let start_1 = align_up(frame_offsets[0], 8);
+    ranges[1] = (start_1, start_1 + 8);
+
+    // Child 2: ay, starts after child 1 (no alignment needed for ay)
+    let start_2 = ranges[1].1;
+    ranges[2] = (start_2, frame_offsets[1]);
+
+    // Child 3: ay, starts after child 2
+    let start_3 = frame_offsets[1];
+    ranges[3] = (start_3, frame_offsets[2]);
+
+    // Child 4: commit tuple, starts after child 3 aligned to 8
+    let start_4 = align_up(frame_offsets[2], 8);
+    ranges[4] = (start_4, frame_offsets[3]);
+
+    // Child 5: ay, starts after child 4
+    let start_5 = frame_offsets[3];
+    ranges[5] = (start_5, frame_offsets[4]);
+
+    // Child 6: a(uayttay), starts after child 5 aligned to 8
+    let start_6 = align_up(frame_offsets[4], 8);
+    ranges[6] = (start_6, frame_offsets[5]);
+
+    // Child 7: a(yaytt), starts after child 6 (1-byte alignment for outer `a`)
+    // Actually a(yaytt) elements contain `t` so alignment is 8
+    let start_7 = align_up(frame_offsets[5], 8);
+    ranges[7] = (start_7, data_end);
+
+    SuperblockChildRanges { ranges }
+}
+
+/// Reads a byte range from a file descriptor via pread.
+fn pread_range(fd: &impl AsFd, start: u64, end: u64) -> Result<Vec<u8>> {
+    let len = end
+        .checked_sub(start)
+        .ok_or_else(|| anyhow!("invalid range"))? as usize;
+    let mut buf = vec![0u8; len];
+    rustix::io::pread(fd, &mut buf, start)?;
+    Ok(buf)
+}
+
+/// Parsed delta part header from the superblock.
+#[derive(Debug)]
+pub struct DeltaPartHeader {
+    /// SHA-256 checksum of the (compressed) part data.
+    pub checksum: Sha256Digest,
+    /// Compressed size.
+    pub compressed_size: u64,
+    /// Uncompressed size.
+    pub uncompressed_size: u64,
+    /// Objects produced by this part: (type, checksum).
+    pub objects: Vec<(ObjectType, Sha256Digest)>,
+}
+
+/// Parsed fallback entry from the superblock.
+#[derive(Debug)]
+pub struct DeltaFallback {
+    /// Object type.
+    pub obj_type: ObjectType,
+    /// SHA-256 checksum.
+    pub checksum: Sha256Digest,
+    /// Compressed size.
+    pub compressed_size: u64,
+    /// Uncompressed size.
+    pub uncompressed_size: u64,
+}
+
+/// Cached index for the `a{sv}` metadata dict in the superblock.
+///
+/// On construction, reads the offset table and all key strings (which
+/// are short but scattered across the file). Values are read on demand
+/// via pread, so inline part payloads (potentially huge) are never held
+/// in memory until requested.
+struct MetadataDictIndex {
+    entries: Vec<(String, u64, u64)>,
+}
+
+impl MetadataDictIndex {
+    fn load(source: &VariantSource, file_offset: u64, dict_size: u64) -> Result<Self> {
+        if dict_size == 0 {
+            return Ok(MetadataDictIndex { entries: vec![] });
+        }
+
+        let osz = gv_offset_size(dict_size);
+
+        // Read the last offset to find last_end (end of data / start of offset table)
+        let last_ofs_buf = source.read_range(
+            file_offset + dict_size - osz as u64,
+            file_offset + dict_size,
+        )?;
+        let last_end = gv_read_offset(&last_ofs_buf, osz, 0);
+
+        let offset_table_size = dict_size as usize - last_end as usize - osz;
+        let n_entries = offset_table_size.checked_div(osz).map_or(0, |n| n + 1);
+
+        // Read the full offset table (small)
+        let offsets_buf = source.read_range(
+            file_offset + last_end,
+            file_offset + last_end + (offset_table_size + osz) as u64,
+        )?;
+
+        // Read each entry's key string (short, NUL-terminated at start of entry)
+        let mut entries = Vec::with_capacity(n_entries);
+        for i in 0..n_entries {
+            let end = gv_read_offset(&offsets_buf, osz, i).min(last_end);
+            let start = if i == 0 {
+                0u64
+            } else {
+                align_up(gv_read_offset(&offsets_buf, osz, i - 1), 8)
+            };
+            if end <= start {
+                continue;
+            }
+
+            let peek_len = 256u64.min(end - start);
+            let peek = source.read_range(file_offset + start, file_offset + start + peek_len)?;
+
+            let nul_pos = match peek.iter().position(|&b| b == 0) {
+                Some(p) => p,
+                None => continue,
+            };
+            let key = match std::str::from_utf8(&peek[..nul_pos]) {
+                Ok(s) => s.to_string(),
+                Err(_) => continue,
+            };
+
+            // The value starts after the key's NUL, and the {sv} entry
+            // has a framing offset at the end for the variant boundary,
+            // but we just store the full entry range — the caller parses
+            // the value from the raw entry data.
+            entries.push((key, file_offset + start, file_offset + end));
+        }
+
+        Ok(MetadataDictIndex { entries })
+    }
+
+    /// Read the full raw entry data for the given key.
+    fn lookup(&self, source: &VariantSource, key: &str) -> Result<Option<Vec<u8>>> {
+        for (k, start, end) in &self.entries {
+            if k == key {
+                return Ok(Some(source.read_range(*start, *end)?));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Find an entry whose key starts with `prefix` and ends with `suffix`.
+    fn lookup_by_prefix_suffix(
+        &self,
+        source: &VariantSource,
+        prefix: &str,
+        suffix: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        for (k, start, end) in &self.entries {
+            if k.starts_with(prefix) && k.ends_with(suffix) {
+                return Ok(Some(source.read_range(*start, *end)?));
+            }
+        }
+        Ok(None)
+    }
+}
+
+enum VariantSource {
+    File(OwnedFd),
+    Memory(Vec<u8>),
+}
+
+impl VariantSource {
+    fn read_range(&self, start: u64, end: u64) -> Result<Vec<u8>> {
+        match self {
+            VariantSource::File(fd) => pread_range(fd, start, end),
+            VariantSource::Memory(data) => {
+                let s = start as usize;
+                let e = end as usize;
+                data.get(s..e).map(|slice| slice.to_vec()).ok_or_else(|| {
+                    anyhow!("read range {s}..{e} out of bounds (len={})", data.len())
+                })
+            }
+        }
+    }
+}
+
+/// Reader for an ostree static delta superblock.
+///
+/// Uses custom GVariant framing to locate children without loading the
+/// entire file into memory (important when inline parts make the
+/// superblock very large).
+pub struct DeltaSuperblock {
+    source: VariantSource,
+    /// Byte offset where the superblock variant starts within the data.
+    base_offset: u64,
+    /// Total size of the superblock variant.
+    variant_size: u64,
+    children: SuperblockChildRanges,
+    metadata_index: MetadataDictIndex,
+    swap_endian: bool,
+}
+
+impl std::fmt::Debug for DeltaSuperblock {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeltaSuperblock")
+            .field("variant_size", &self.variant_size)
+            .field("swap_endian", &self.swap_endian)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DeltaSuperblock {
+    fn init(source: VariantSource, total_size: u64) -> Result<Self> {
+        // Check for signed delta wrapper
+        let (base_offset, variant_size) = if total_size >= 8 {
+            let magic_buf = source.read_range(0, 8)?;
+            let magic = u64::from_be_bytes(magic_buf[..8].try_into().unwrap());
+            if magic == SIGNED_DELTA_MAGIC {
+                // Signed format (taya{sv}): child 0 is fixed (t=8 bytes),
+                // child 1 (ay) has one frame offset, child 2 (a{sv}) is LAST.
+                let osz = gv_offset_size(total_size);
+                let fo_buf = source.read_range(total_size - osz as u64, total_size)?;
+                let sb_start = 8u64; // ay starts right after the fixed t
+                let sb_end = gv_read_offset(&fo_buf, osz, 0);
+                (sb_start, sb_end - sb_start)
+            } else {
+                (0, total_size)
+            }
+        } else {
+            (0, total_size)
+        };
+
+        // Read frame offsets from the superblock variant.
+        // They are stored at the end, with the last one (nearest the end)
+        // corresponding to the first variable child. We read them in
+        // reverse so frame_offsets[0] = end of first variable child.
+        let osz = gv_offset_size(variant_size);
+        ensure!(osz > 0, "superblock is empty");
+        let fo_size = (N_FRAME_OFFSETS * osz) as u64;
+        ensure!(
+            variant_size >= fo_size,
+            "superblock too small for frame offsets"
+        );
+        let fo_buf = source.read_range(
+            base_offset + variant_size - fo_size,
+            base_offset + variant_size,
+        )?;
+
+        let frame_offsets: [u64; N_FRAME_OFFSETS] =
+            std::array::from_fn(|i| gv_read_offset(&fo_buf, osz, N_FRAME_OFFSETS - 1 - i));
+
+        let children = compute_child_ranges(variant_size, &frame_offsets);
+
+        // Cache the metadata dict offset table and key strings
+        let (meta_start, meta_end) = children.ranges[0];
+        let metadata_index =
+            MetadataDictIndex::load(&source, base_offset + meta_start, meta_end - meta_start)?;
+
+        let swap_endian = Self::detect_endianness(&source, &metadata_index)?;
+
+        Ok(DeltaSuperblock {
+            source,
+            base_offset,
+            variant_size,
+            children,
+            metadata_index,
+            swap_endian,
+        })
+    }
+
+    /// Open a delta superblock from a file path.
+    pub fn open(path: &Path) -> Result<Self> {
+        let fd = openat(
+            rustix::fs::CWD,
+            path,
+            OFlags::RDONLY | OFlags::CLOEXEC,
+            Mode::empty(),
+        )
+        .with_context(|| format!("opening delta at {}", path.display()))?;
+
+        let file_size = seek(&fd, rustix::fs::SeekFrom::End(0))?;
+        Self::init(VariantSource::File(fd), file_size)
+    }
+
+    /// Create a delta superblock from in-memory data.
+    pub fn from_data(data: Vec<u8>) -> Result<Self> {
+        let size = data.len() as u64;
+        Self::init(VariantSource::Memory(data), size)
+    }
+
+    fn read_child(&self, index: usize) -> Result<Vec<u8>> {
+        let (start, end) = self.children.ranges[index];
+        self.source
+            .read_range(self.base_offset + start, self.base_offset + end)
+    }
+
+    fn read_child_aligned(&self, index: usize) -> Result<AlignedBuf> {
+        Ok(self.read_child(index)?.into())
+    }
+
+    fn detect_endianness(
+        source: &VariantSource,
+        metadata_index: &MetadataDictIndex,
+    ) -> Result<bool> {
+        let entry_data = match metadata_index.lookup(source, "ostree.endianness")? {
+            Some(d) => d,
+            None => return Ok(false),
+        };
+
+        // Parse the small {sv} entry with gvariant
+        let aligned: AlignedBuf = entry_data.into();
+        let entry = gv!("{sv}").cast(
+            aligned
+                .try_as_aligned()
+                .map_err(|_| anyhow!("endianness entry not aligned"))?,
+        );
+        let (_key, value) = entry.to_tuple();
+        if let Some(v) = value.get(gv!("y")) {
+            let native = if cfg!(target_endian = "little") {
+                b'l'
+            } else {
+                b'B'
+            };
+            return Ok(*v != native);
+        }
+
+        Ok(false)
+    }
+
+    fn maybe_swap_u64(&self, v: u64) -> u64 {
+        if self.swap_endian { v.swap_bytes() } else { v }
+    }
+
+    /// Returns the from-commit checksum (None for scratch deltas).
+    pub fn from_checksum(&self) -> Result<Option<Sha256Digest>> {
+        let data = self.read_child(2)?;
+        if data.is_empty() {
+            return Ok(None);
+        }
+        ensure!(
+            data.len() == 32,
+            "invalid from-checksum length {}",
+            data.len()
+        );
+        Ok(Some(
+            data.try_into().map_err(|_| anyhow!("bad from-checksum"))?,
+        ))
+    }
+
+    /// Returns the to-commit checksum.
+    pub fn to_checksum(&self) -> Result<Sha256Digest> {
+        let data = self.read_child(3)?;
+        ensure!(
+            data.len() == 32,
+            "invalid to-checksum length {}",
+            data.len()
+        );
+        data.try_into().map_err(|_| anyhow!("bad to-checksum"))
+    }
+
+    /// Returns the commit object data.
+    pub fn commit_data(&self) -> Result<AlignedBuf> {
+        self.read_child_aligned(4)
+    }
+
+    /// Parse the part headers from child [6].
+    pub fn part_headers(&self) -> Result<Vec<DeltaPartHeader>> {
+        let buf = self.read_child_aligned(6)?;
+        let aligned = buf
+            .try_as_aligned()
+            .map_err(|_| anyhow!("part headers not aligned"))?;
+        let entries = gv!("a(uayttay)").cast(aligned);
+
+        entries
+            .iter()
+            .map(|entry| {
+                let (_version, checksum_bytes, comp_size, uncomp_size, objects_bytes) =
+                    entry.to_tuple();
+                let checksum: Sha256Digest =
+                    checksum_bytes.try_into().context("invalid part checksum")?;
+                let compressed_size = self.maybe_swap_u64(u64::from_be(*comp_size));
+                let uncompressed_size = self.maybe_swap_u64(u64::from_be(*uncomp_size));
+
+                let obj_data: &[u8] = objects_bytes;
+                ensure!(
+                    obj_data.len().is_multiple_of(OBJTYPE_CSUM_LEN),
+                    "objects array length {} not a multiple of {OBJTYPE_CSUM_LEN}",
+                    obj_data.len()
+                );
+                let objects = obj_data
+                    .chunks_exact(OBJTYPE_CSUM_LEN)
+                    .map(|chunk| {
+                        let obj_type = ObjectType::from_byte(chunk[0])?;
+                        let csum: Sha256Digest = chunk[1..33]
+                            .try_into()
+                            .map_err(|_| anyhow!("bad object checksum"))?;
+                        Ok((obj_type, csum))
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                Ok(DeltaPartHeader {
+                    checksum,
+                    compressed_size,
+                    uncompressed_size,
+                    objects,
+                })
+            })
+            .collect()
+    }
+
+    /// Parse the fallback entries from child [7].
+    pub fn fallbacks(&self) -> Result<Vec<DeltaFallback>> {
+        let buf = self.read_child_aligned(7)?;
+        let aligned = buf
+            .try_as_aligned()
+            .map_err(|_| anyhow!("fallbacks not aligned"))?;
+        let entries = gv!("a(yaytt)").cast(aligned);
+
+        entries
+            .iter()
+            .map(|entry| {
+                let (obj_type_byte, checksum_bytes, comp_size, uncomp_size) = entry.to_tuple();
+                let obj_type = ObjectType::from_byte(*obj_type_byte)?;
+                let checksum: Sha256Digest = checksum_bytes
+                    .try_into()
+                    .context("invalid fallback checksum")?;
+                let compressed_size = self.maybe_swap_u64(u64::from_be(*comp_size));
+                let uncompressed_size = self.maybe_swap_u64(u64::from_be(*uncomp_size));
+                Ok(DeltaFallback {
+                    obj_type,
+                    checksum,
+                    compressed_size,
+                    uncompressed_size,
+                })
+            })
+            .collect()
+    }
+
+    /// Read part data for the given part index.
+    ///
+    /// Tries inline data in the metadata dict first, then falls back
+    /// to a numbered file in the same directory.
+    pub fn read_part(&self, index: usize, delta_path: &Path) -> Result<Vec<u8>> {
+        if let Some(data) = self.read_inline_part(index)? {
+            return Ok(data);
+        }
+
+        let dir = delta_path
+            .parent()
+            .ok_or_else(|| anyhow!("delta path has no parent directory"))?;
+        let part_path = dir.join(index.to_string());
+        let mut data = Vec::new();
+        File::open(&part_path)
+            .with_context(|| format!("opening delta part {}", part_path.display()))?
+            .read_to_end(&mut data)?;
+        Ok(data)
+    }
+
+    pub(crate) fn read_inline_part(&self, index: usize) -> Result<Option<Vec<u8>>> {
+        let suffix = format!("/{index}");
+        let entry_data =
+            match self
+                .metadata_index
+                .lookup_by_prefix_suffix(&self.source, "deltas/", &suffix)?
+            {
+                Some(d) => d,
+                None => return Ok(None),
+            };
+
+        // Parse the {sv} entry to extract the (yay) value
+        let aligned: AlignedBuf = entry_data.into();
+        let entry = gv!("{sv}").cast(
+            aligned
+                .try_as_aligned()
+                .map_err(|_| anyhow!("inline part entry not aligned"))?,
+        );
+        let (_key, value) = entry.to_tuple();
+        if let Some(yay) = value.get(gv!("(yay)")) {
+            let (comp_type, payload) = yay.to_tuple();
+            let mut raw = Vec::with_capacity(1 + payload.len());
+            raw.push(*comp_type);
+            raw.extend_from_slice(payload);
+            return Ok(Some(raw));
+        }
+
+        Ok(None)
+    }
+}
+
+// ---------- Part decompression ----------
+
+pub(crate) fn decompress_part(raw: &[u8]) -> Result<AlignedBuf> {
+    ensure!(!raw.is_empty(), "empty delta part");
+    let comp_type = raw[0];
+    let payload = &raw[1..];
+
+    match comp_type {
+        0 => Ok(payload.to_vec().into()),
+        b'x' => {
+            let mut decoder = xz2::read::XzDecoder::new(payload);
+            let mut decompressed = Vec::new();
+            decoder.read_to_end(&mut decompressed)?;
+            Ok(decompressed.into())
+        }
+        _ => bail!("unknown delta part compression type {comp_type:#x}"),
+    }
+}
+
+// ---------- Part executor ----------
+
+struct DeltaExecState<'a> {
+    // Object tracking
+    checksum_index: usize,
+    objects: &'a [(ObjectType, Sha256Digest)],
+
+    // Payload and operations
+    payload: &'a [u8],
+    ops: &'a [u8],
+    ops_pos: usize,
+
+    // Mode and xattr dicts (indices into these are used by opcodes)
+    modes: Vec<(u32, u32, u32)>,
+    xattrs: Vec<Vec<(Vec<u8>, Vec<u8>)>>,
+
+    // Current object being built
+    content_buf: Vec<u8>,
+    content_size: u64,
+    current_uid: u32,
+    current_gid: u32,
+    current_mode: u32,
+    current_xattrs: Vec<(Vec<u8>, Vec<u8>)>,
+
+    // Read source for differential ops
+    read_source: Option<Vec<u8>>,
+}
+
+impl<'a> DeltaExecState<'a> {
+    fn read_varuint(&mut self) -> Result<u64> {
+        read_varuint64(self.ops, &mut self.ops_pos)
+    }
+
+    fn current_object(&self) -> Result<&(ObjectType, Sha256Digest)> {
+        self.objects
+            .get(self.checksum_index)
+            .ok_or_else(|| anyhow!("object index {} out of range", self.checksum_index))
+    }
+
+    fn payload_slice(&self, offset: u64, len: u64) -> Result<&'a [u8]> {
+        let start = offset as usize;
+        let end = start
+            .checked_add(len as usize)
+            .ok_or_else(|| anyhow!("payload offset overflow"))?;
+        self.payload.get(start..end).ok_or_else(|| {
+            anyhow!(
+                "payload slice {start}..{end} out of range (len={})",
+                self.payload.len()
+            )
+        })
+    }
+}
+
+/// Execute a single delta part, producing objects into the writer.
+///
+/// `base` is needed to resolve `SET_READ_SOURCE` opcodes that reference
+/// objects from the previous commit.
+pub(crate) fn execute_delta_part<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    writer: &mut CommitWriter<ObjectID>,
+    base: Option<&CommitReader<ObjectID>>,
+    part_data: &AlignedBuf,
+    objects: &[(ObjectType, Sha256Digest)],
+) -> Result<()> {
+    let aligned = part_data
+        .try_as_aligned()
+        .map_err(|_| anyhow!("part payload not aligned"))?;
+    let part = gv!("(a(uuu)aa(ayay)ayay)").cast(aligned);
+    let (mode_dict, xattr_dict, payload_var, ops_var) = part.to_tuple();
+
+    // Parse mode dict
+    let modes: Vec<(u32, u32, u32)> = mode_dict
+        .iter()
+        .map(|m| {
+            let (uid, gid, mode) = m.to_tuple();
+            (u32::from_be(*uid), u32::from_be(*gid), u32::from_be(*mode))
+        })
+        .collect();
+
+    // Parse xattr dict
+    let xattrs: Vec<Vec<(Vec<u8>, Vec<u8>)>> = xattr_dict
+        .iter()
+        .map(|xa| {
+            xa.iter()
+                .map(|pair| {
+                    let (k, v) = pair.to_tuple();
+                    (k.to_vec(), v.to_vec())
+                })
+                .collect()
+        })
+        .collect();
+
+    let payload: &[u8] = payload_var;
+    let ops: &[u8] = ops_var;
+
+    let mut state = DeltaExecState {
+        checksum_index: 0,
+        objects,
+        payload,
+        ops,
+        ops_pos: 0,
+        modes,
+        xattrs,
+        content_buf: Vec::new(),
+        content_size: 0,
+        current_uid: 0,
+        current_gid: 0,
+        current_mode: 0,
+        current_xattrs: Vec::new(),
+        read_source: None,
+    };
+
+    while state.ops_pos < state.ops.len() {
+        let opcode = state.ops[state.ops_pos];
+        state.ops_pos += 1;
+
+        match opcode {
+            OP_OPEN_SPLICE_AND_CLOSE => {
+                dispatch_open_splice_and_close(repo, writer, &mut state)?;
+            }
+            OP_OPEN => {
+                dispatch_open(&mut state)?;
+            }
+            OP_WRITE => {
+                dispatch_write(&mut state)?;
+            }
+            OP_SET_READ_SOURCE => {
+                dispatch_set_read_source(repo, base, &mut state)?;
+            }
+            OP_UNSET_READ_SOURCE => {
+                state.read_source = None;
+            }
+            OP_CLOSE => {
+                dispatch_close(repo, writer, &mut state)?;
+            }
+            OP_BSPATCH => {
+                dispatch_bspatch(&mut state)?;
+            }
+            _ => bail!("unknown delta opcode {opcode:#x}"),
+        }
+    }
+
+    Ok(())
+}
+
+fn dispatch_open_splice_and_close<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    writer: &mut CommitWriter<ObjectID>,
+    state: &mut DeltaExecState,
+) -> Result<()> {
+    let (obj_type, checksum) = *state.current_object()?;
+
+    if obj_type.is_meta() {
+        let content_len = state.read_varuint()? as usize;
+        let content_offset = state.read_varuint()?;
+        let data = state.payload_slice(content_offset, content_len as u64)?;
+        writer.insert(&checksum, None, data);
+    } else {
+        // File object
+        let mode_offset = state.read_varuint()? as usize;
+        let xattr_offset = state.read_varuint()? as usize;
+        let content_size = state.read_varuint()?;
+        let content_offset = state.read_varuint()?;
+
+        let (uid, gid, mode) = *state
+            .modes
+            .get(mode_offset)
+            .ok_or_else(|| anyhow!("mode index {mode_offset} out of range"))?;
+        let xattrs = state
+            .xattrs
+            .get(xattr_offset)
+            .ok_or_else(|| anyhow!("xattr index {xattr_offset} out of range"))?
+            .clone();
+
+        let content_data = state.payload_slice(content_offset, content_size)?;
+
+        let is_symlink = rustix::fs::FileType::from_raw_mode(mode).is_symlink();
+        let symlink_target = if is_symlink {
+            std::str::from_utf8(content_data)
+                .context("symlink target not UTF-8")?
+                .to_string()
+        } else {
+            String::new()
+        };
+        let file_header = OstreeFileHeader {
+            size: if is_symlink { 0 } else { content_size },
+            uid,
+            gid,
+            mode,
+            symlink_target,
+            xattrs,
+        };
+
+        let file_content = if is_symlink {
+            &[] as &[u8]
+        } else {
+            content_data
+        };
+        store_file_object(repo, writer, &checksum, &file_header, file_content)?;
+    }
+
+    state.checksum_index += 1;
+    Ok(())
+}
+
+fn dispatch_open(state: &mut DeltaExecState) -> Result<()> {
+    let mode_offset = state.read_varuint()? as usize;
+    let xattr_offset = state.read_varuint()? as usize;
+    let content_size = state.read_varuint()?;
+
+    let (uid, gid, mode) = *state
+        .modes
+        .get(mode_offset)
+        .ok_or_else(|| anyhow!("mode index {mode_offset} out of range"))?;
+    let xattrs = state
+        .xattrs
+        .get(xattr_offset)
+        .ok_or_else(|| anyhow!("xattr index {xattr_offset} out of range"))?
+        .clone();
+
+    state.content_buf.clear();
+    state.content_size = content_size;
+    state.current_uid = uid;
+    state.current_gid = gid;
+    state.current_mode = mode;
+    state.current_xattrs = xattrs;
+
+    Ok(())
+}
+
+fn dispatch_write(state: &mut DeltaExecState) -> Result<()> {
+    let content_size = state.read_varuint()?;
+    let content_offset = state.read_varuint()?;
+
+    if let Some(ref source) = state.read_source {
+        let start = content_offset as usize;
+        let end = start + content_size as usize;
+        ensure!(end <= source.len(), "read_source offset out of range");
+        state.content_buf.extend_from_slice(&source[start..end]);
+    } else {
+        let data = state.payload_slice(content_offset, content_size)?;
+        state.content_buf.extend_from_slice(data);
+    }
+
+    Ok(())
+}
+
+fn dispatch_set_read_source<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    base: Option<&CommitReader<ObjectID>>,
+    state: &mut DeltaExecState,
+) -> Result<()> {
+    let source_offset = state.read_varuint()? as usize;
+    ensure!(
+        source_offset + 32 <= state.payload.len(),
+        "read source checksum offset out of range"
+    );
+    let checksum: Sha256Digest = state.payload[source_offset..source_offset + 32]
+        .try_into()
+        .map_err(|_| anyhow!("bad read source checksum"))?;
+
+    let base = base.ok_or_else(|| {
+        anyhow!(
+            "SET_READ_SOURCE references {} but no base commit available",
+            hex::encode(checksum)
+        )
+    })?;
+
+    let (obj_id, file_header_data) = base.lookup(&checksum)?.ok_or_else(|| {
+        anyhow!(
+            "SET_READ_SOURCE object {} not found in base commit",
+            hex::encode(checksum)
+        )
+    })?;
+
+    if let Some(id) = obj_id {
+        let data = repo.read_object(id)?;
+        state.read_source = Some(data);
+    } else {
+        // Inline content: everything after the zlib-sized header
+        let header_size = std::mem::size_of::<crate::ostree::SizedVariantHeader>();
+        let variant_size = crate::ostree::get_sized_variant_size(file_header_data)?;
+        let content_start = header_size + variant_size;
+        let content = file_header_data.get(content_start..).unwrap_or(&[]);
+        state.read_source = Some(content.to_vec());
+    }
+
+    Ok(())
+}
+
+fn dispatch_close<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    writer: &mut CommitWriter<ObjectID>,
+    state: &mut DeltaExecState,
+) -> Result<()> {
+    let (_obj_type, checksum) = *state.current_object()?;
+
+    let is_symlink = rustix::fs::FileType::from_raw_mode(state.current_mode).is_symlink();
+    let symlink_target = if is_symlink {
+        std::str::from_utf8(&state.content_buf)
+            .context("symlink target not UTF-8")?
+            .to_string()
+    } else {
+        String::new()
+    };
+    let file_header = OstreeFileHeader {
+        size: if is_symlink { 0 } else { state.content_size },
+        uid: state.current_uid,
+        gid: state.current_gid,
+        mode: state.current_mode,
+        symlink_target,
+        xattrs: state.current_xattrs.clone(),
+    };
+
+    let file_content: &[u8] = if is_symlink { &[] } else { &state.content_buf };
+    store_file_object(repo, writer, &checksum, &file_header, file_content)?;
+
+    state.content_buf.clear();
+    state.read_source = None;
+    state.checksum_index += 1;
+    Ok(())
+}
+
+fn dispatch_bspatch(state: &mut DeltaExecState) -> Result<()> {
+    let offset = state.read_varuint()?;
+    let length = state.read_varuint()?;
+
+    let patch_data = state.payload_slice(offset, length)?;
+    let source = state
+        .read_source
+        .as_ref()
+        .ok_or_else(|| anyhow!("BSPATCH without read source"))?;
+
+    let mut new_data = Vec::new();
+    bsdiff::patch(source, &mut &patch_data[..], &mut new_data).context("bspatch failed")?;
+
+    state.content_buf.extend_from_slice(&new_data);
+    Ok(())
+}
+
+fn store_file_object<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    writer: &mut CommitWriter<ObjectID>,
+    checksum: &Sha256Digest,
+    header: &OstreeFileHeader,
+    content: &[u8],
+) -> Result<()> {
+    let zlib_header = header.serialize_zlib_sized();
+
+    if should_inline_file::<ObjectID>(content.len()) {
+        let mut data = zlib_header;
+        data.with_vec(|v| v.extend_from_slice(content));
+        writer.insert(checksum, None, &data);
+    } else {
+        let obj_id = repo.ensure_object(content)?;
+        writer.insert(checksum, Some(&obj_id), &zlib_header);
+    }
+
+    Ok(())
+}
+
+// ---------- Top-level apply ----------
+
+/// Apply a static delta from a local file.
+///
+/// The `delta_path` can be either a single-file (inline) delta or the
+/// `superblock` file in a delta directory.
+pub fn apply_delta_offline<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    delta_path: &Path,
+) -> Result<(ObjectID, PullStats)> {
+    let superblock = DeltaSuperblock::open(delta_path)?;
+
+    let from_checksum = superblock.from_checksum()?;
+    let to_checksum = superblock.to_checksum()?;
+
+    let commit_hex = hex::encode(to_checksum);
+    let content_id = format!("ostree-commit-{commit_hex}");
+    if let Some(objid) = repo.has_stream(&content_id)? {
+        return Ok((
+            objid,
+            PullStats {
+                commit_id: commit_hex,
+                ..Default::default()
+            },
+        ));
+    }
+
+    let fallbacks = superblock.fallbacks()?;
+    ensure!(
+        fallbacks.is_empty(),
+        "cannot apply delta offline: contains {} fallback entries",
+        fallbacks.len()
+    );
+
+    let part_headers = superblock.part_headers()?;
+
+    // Load base commit if this is a non-scratch delta
+    let base = if let Some(from) = from_checksum {
+        let from_stream = format!("ostree-commit-{}", hex::encode(from));
+        ensure!(
+            repo.has_stream(&from_stream)?.is_some(),
+            "base commit {} not found in repository",
+            hex::encode(from)
+        );
+        Some(CommitReader::<ObjectID>::load(repo, &from_stream)?)
+    } else {
+        None
+    };
+
+    let mut writer = CommitWriter::<ObjectID>::new();
+    let mut stats = PullStats {
+        commit_id: commit_hex.clone(),
+        ..Default::default()
+    };
+
+    // Execute all delta parts
+    for (i, header) in part_headers.iter().enumerate() {
+        let raw = superblock.read_part(i, delta_path)?;
+
+        // Verify checksum of raw part data
+        let actual = Sha256::digest(&raw);
+        if *actual != header.checksum {
+            bail!(
+                "delta part {i} checksum mismatch: expected {}, got {}",
+                hex::encode(header.checksum),
+                hex::encode(actual)
+            );
+        }
+
+        let decompressed = decompress_part(&raw)?;
+        execute_delta_part(
+            repo,
+            &mut writer,
+            base.as_ref(),
+            &decompressed,
+            &header.objects,
+        )?;
+
+        for (obj_type, _) in &header.objects {
+            if obj_type.is_meta() {
+                stats.metadata_fetched += 1;
+            } else {
+                stats.files_fetched += 1;
+            }
+        }
+    }
+
+    // Insert the commit object from the superblock
+    let commit_data = superblock.commit_data()?;
+    writer.insert(&to_checksum, None, &commit_data);
+    writer.set_commit_id(&to_checksum);
+    stats.metadata_fetched += 1;
+
+    // Inherit unchanged objects from base commit
+    if let Some(ref base) = base {
+        inherit_base_objects(&mut writer, base, &commit_data)?;
+    }
+
+    let verity = writer.serialize(repo, &content_id, None, None)?;
+    crate::ensure_ostree_erofs(repo, &stats.commit_id)?;
+
+    Ok((verity, stats))
+}
+
+/// Walk the new commit's DAG and copy any objects not already in the
+/// writer from the base commit's splitstream.
+pub(crate) fn inherit_base_objects<ObjectID: FsVerityHashValue>(
+    writer: &mut CommitWriter<ObjectID>,
+    base: &CommitReader<ObjectID>,
+    commit_data: &[u8],
+) -> Result<()> {
+    let aligned: AlignedBuf = commit_data.to_vec().into();
+    let commit = OstreeCommit::from_data(
+        aligned
+            .try_as_aligned()
+            .map_err(|_| anyhow!("commit data not aligned"))?,
+    )?;
+
+    let mut visited = std::collections::HashSet::new();
+    inherit_dirmeta(writer, base, &commit.root_metadata)?;
+    inherit_dirtree(writer, base, &commit.root_tree, &mut visited)?;
+
+    Ok(())
+}
+
+fn inherit_dirmeta<ObjectID: FsVerityHashValue>(
+    writer: &mut CommitWriter<ObjectID>,
+    base: &CommitReader<ObjectID>,
+    id: &Sha256Digest,
+) -> Result<()> {
+    if writer.contains(id) {
+        return Ok(());
+    }
+    if let Some(data) = base.lookup_data(id)? {
+        writer.insert(id, None, data);
+    }
+    Ok(())
+}
+
+fn inherit_dirtree<ObjectID: FsVerityHashValue>(
+    writer: &mut CommitWriter<ObjectID>,
+    base: &CommitReader<ObjectID>,
+    id: &Sha256Digest,
+    visited: &mut std::collections::HashSet<Sha256Digest>,
+) -> Result<()> {
+    if !visited.insert(*id) {
+        return Ok(());
+    }
+
+    // The dirtree may already be in the writer (produced by the delta) or
+    // only in the base. Either way we need to parse it and walk children,
+    // because children may still need inheriting from the base.
+    if !writer.contains(id) {
+        let data = base.lookup_data(id)?.ok_or_else(|| {
+            anyhow!(
+                "Unexpectedly missing ostree dirtree object {}",
+                hex::encode(id)
+            )
+        })?;
+        writer.insert(id, None, data);
+    }
+    let data: AlignedBuf = writer
+        .lookup_data(id)
+        .ok_or_else(|| anyhow!("dirtree just inserted but not found"))?[..]
+        .to_vec()
+        .into();
+
+    let dirtree = OstreeDirTree::from_data(
+        data.try_as_aligned()
+            .map_err(|_| anyhow!("dirtree not aligned"))?,
+    )?;
+
+    for (_name, file_checksum) in &dirtree.files {
+        inherit_file(writer, base, file_checksum)?;
+    }
+
+    for (_name, tree_checksum, meta_checksum) in &dirtree.dirs {
+        inherit_dirmeta(writer, base, meta_checksum)?;
+        inherit_dirtree(writer, base, tree_checksum, visited)?;
+    }
+
+    Ok(())
+}
+
+fn inherit_file<ObjectID: FsVerityHashValue>(
+    writer: &mut CommitWriter<ObjectID>,
+    base: &CommitReader<ObjectID>,
+    id: &Sha256Digest,
+) -> Result<()> {
+    if writer.contains(id) {
+        return Ok(());
+    }
+    if let Some((obj_id, file_header)) = base.lookup(id)? {
+        writer.insert(id, obj_id, file_header);
+    }
+    Ok(())
+}

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -11,6 +11,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail, ensure};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
 use gvariant::aligned_bytes::{AlignedBuf, TryAsAligned};
 use gvariant::{Marker, Structure, gv};
 use rustix::fs::{Mode, OFlags, openat, seek};
@@ -27,6 +29,35 @@ use crate::ostree::{
 use crate::pull::PullStats;
 
 const OBJTYPE_CSUM_LEN: usize = 33; // 1 byte type + 32 bytes SHA-256
+
+/// Encode a SHA-256 digest to ostree's filesystem-safe base64.
+///
+/// Standard base64 with `/` replaced by `_` and trailing `=` stripped.
+pub(crate) fn checksum_to_b64(csum: &Sha256Digest) -> String {
+    STANDARD_NO_PAD.encode(csum).replace('/', "_")
+}
+
+/// Build the relative delta path for fetching from a remote repo.
+///
+/// Returns `"deltas/{prefix}/{rest}/superblock"` or
+/// `"deltas/{from_prefix}/{from_rest}-{to_prefix}{to_rest}/superblock"`.
+pub(crate) fn delta_path(from: Option<&Sha256Digest>, to: &Sha256Digest, target: &str) -> String {
+    let to_b64 = checksum_to_b64(to);
+
+    if let Some(from) = from {
+        let from_b64 = checksum_to_b64(from);
+        format!(
+            "deltas/{}/{}-{}{}/{}",
+            &from_b64[..2],
+            &from_b64[2..],
+            &to_b64[..2],
+            &to_b64[2..],
+            target
+        )
+    } else {
+        format!("deltas/{}/{}/{}", &to_b64[..2], &to_b64[2..], target)
+    }
+}
 
 // Delta opcodes
 const OP_OPEN_SPLICE_AND_CLOSE: u8 = b'S';

--- a/crates/composefs-ostree/src/design.rs
+++ b/crates/composefs-ostree/src/design.rs
@@ -137,3 +137,80 @@
 //! aligned to 8 bytes with respect to the start of the content area.
 //! This is useful because GVariants (used by ostree) naturally want
 //! 8-byte alignment.
+//!
+//! # Summary caching
+//!
+//! When pulling from a remote OSTree repository, the crate downloads and
+//! caches the repository's **summary** file to resolve ref names to
+//! commit checksums.  The summary is a GVariant in
+//! `OSTREE_SUMMARY_GVARIANT_FORMAT`:
+//!
+//! ```text
+//! (a(s(taya{sv}))a{sv})
+//!   │                │
+//!   │                └─ repository-level metadata
+//!   └─ array of (ref_name, (commit_size, checksum, per-ref metadata))
+//! ```
+//!
+//! ## Summary index (flatpak-style repos)
+//!
+//! Large repositories (e.g. Flathub) serve a **summary index** at
+//! `summary.idx` instead of (or in addition to) the plain `summary`
+//! file.  The index is a small GVariant that maps subset keys to
+//! per-subset subsummary checksums:
+//!
+//! ```text
+//! (a{s(ayaaya{sv})}a{sv})
+//!   │                  │
+//!   │                  └─ index-level metadata
+//!   └─ dict of subset_name → (current_checksum, history, per-subset metadata)
+//! ```
+//!
+//! Subset keys are typically architecture names (e.g. `x86_64`,
+//! `aarch64`) or `{subset}-{arch}` combinations (e.g. `free-x86_64`).
+//! The actual subsummaries are stored gzip-compressed on the server at
+//! `summaries/{checksum}.gz` and have the same GVariant format as a
+//! regular OSTree summary.
+//!
+//! ## Fetch strategy
+//!
+//! [`RemoteRepo`] uses a two-stage strategy:
+//!
+//! 1. **Try the summary index**: fetch `summary.idx` (small, always
+//!    re-downloaded).  Look up the configured subset key (defaults to
+//!    [`std::env::consts::ARCH`]).  If a cached subsummary with a
+//!    matching checksum exists, reuse it; otherwise fetch, decompress,
+//!    and verify the new subsummary.
+//!
+//! 2. **Fall back to the plain summary**: if the index is not available
+//!    (404), fetch the `summary` file using conditional HTTP
+//!    (`If-None-Match` / `If-Modified-Since`) to avoid unnecessary
+//!    re-downloads.
+//!
+//! ## Cache storage
+//!
+//! Cached summaries are stored as splitstreams in the composefs
+//! repository with content type `0x7972616d6d75736f` (`"osummary"` LE).
+//! The splitstream inline data contains a fixed header, variable-length
+//! HTTP caching strings, and the raw summary GVariant bytes.
+//!
+//! ```text
+//! SummaryCacheHeader (36 bytes):
+//!   u16 LE  etag_len           — length of ETag string (0 if absent)
+//!   u16 LE  last_modified_len  — length of Last-Modified string (0 if absent)
+//!   [u8;32] checksum           — SHA-256 of the summary data
+//!
+//! Variable part:
+//!   [etag_len bytes]           — HTTP ETag value
+//!   [last_modified_len bytes]  — HTTP Last-Modified value
+//!
+//! Summary GVariant data:
+//!   [raw bytes]                — (a(s(taya{sv}))a{sv}) format
+//! ```
+//!
+//! Stream identifiers:
+//! - Plain summary: `ostree-summary-{url_key}`
+//! - Subsummary: `ostree-subsummary-{subset}-{url_key}`
+//!
+//! Where `url_key` is the URL with the scheme stripped and `/` replaced
+//! by `-` (e.g. `https://example.com/repo` → `example.com-repo`).

--- a/crates/composefs-ostree/src/lib.rs
+++ b/crates/composefs-ostree/src/lib.rs
@@ -4,19 +4,24 @@
 //! repository, where they can be mounted as composefs images and share storage
 //! (deduplication) with OCI or other image types.
 //!
-//! The main entry points are [`pull_local()`] and [`pull()`], which fetch an
-//! ostree commit (from a local path or HTTP URL respectively), store it as a
-//! splitstream, and produce an EROFS image that can be mounted.  Additional
-//! functions provide reference management ([`tag`]/[`untag`]), listing
-//! ([`list_commits`]), and inspection ([`inspect`]).
+//! The main entry point is [`pull()`], which fetches an ostree commit from an
+//! [`OstreeRepo`] implementation (either [`LocalRepo`] for on-disk repositories
+//! or [`RemoteRepo`] for HTTP), stores it as a splitstream, and produces an
+//! EROFS image that can be mounted.  Additional functions provide reference
+//! management ([`tag`]/[`untag`]), listing ([`list_commits`]), and inspection
+//! ([`inspect`]).
 //!
 
 use anyhow::{Context, Result, bail};
-use rustix::fs::{AtFlags, CWD, Dir, OFlags, readlinkat, unlinkat};
-use std::{path::Path, sync::Arc};
+use rustix::fs::{AtFlags, Dir, OFlags, readlinkat, unlinkat};
+use std::sync::Arc;
 
 use composefs::{
-    fsverity::FsVerityHashValue, repository::Repository, tree::FileSystem, util::parse_sha256,
+    fsverity::FsVerityHashValue,
+    progress::{NullReporter, ProgressEvent, SharedReporter},
+    repository::Repository,
+    tree::FileSystem,
+    util::parse_sha256,
 };
 
 /// Information about a stored ostree commit.
@@ -31,14 +36,43 @@ pub struct CommitInfo {
 mod commit;
 #[cfg(doc)]
 pub mod design;
-mod ostree;
+pub mod ostree;
 mod pull;
-mod repo;
+pub mod repo;
 
 use crate::commit::{CommitReader, CommitWriter};
 use crate::pull::PullOperation;
 pub use crate::pull::PullStats;
-use crate::repo::{LocalRepo, RemoteRepo};
+pub use crate::repo::{LocalRepo, OstreeRepo, RemoteRepo};
+
+/// Options for a [`pull`] operation.
+#[derive(Default)]
+pub struct PullOptions<'a> {
+    /// An existing ostree ref whose objects should be used as a base to avoid
+    /// re-fetching shared content.
+    pub base_reference: Option<&'a str>,
+
+    /// Progress reporter for this pull operation.
+    ///
+    /// When `None`, all progress events are silently discarded.
+    pub progress: Option<SharedReporter>,
+}
+
+impl std::fmt::Debug for PullOptions<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PullOptions")
+            .field("base_reference", &self.base_reference)
+            .field(
+                "progress",
+                if self.progress.is_some() {
+                    &"Some(<ProgressReporter>)"
+                } else {
+                    &"None"
+                },
+            )
+            .finish()
+    }
+}
 
 const OSTREE_REF_PREFIX: &str = "ostree/";
 const IMAGE_REF_KEY: &str = "composefs.image";
@@ -50,49 +84,23 @@ fn ostree_ref_path(name: &str) -> String {
     )
 }
 
-/// Pull from a local ostree repo into the repository.
+/// Pull an ostree commit into the composefs repository.
 ///
+/// The `ostree_repo` can be any [`OstreeRepo`] implementation — typically a
+/// [`LocalRepo`] for on-disk repositories or a [`RemoteRepo`] for HTTP.
 /// Automatically creates the EROFS image and links it from the commit splitstream.
 /// `ostree_ref` can be either a ref name or a 64-character hex commit ID.
-pub async fn pull_local<ObjectID: FsVerityHashValue>(
-    repo: &Arc<Repository<ObjectID>>,
-    ostree_repo_path: &Path,
-    ostree_ref: &str,
-    base_reference: Option<&str>,
-) -> Result<(ObjectID, PullStats)> {
-    let ostree_repo = LocalRepo::open_path(repo, CWD, ostree_repo_path)?;
-
-    let (commit_checksum, reference) = if is_commit_id(ostree_ref) {
-        (parse_sha256(ostree_ref)?, None)
-    } else {
-        let checksum = ostree_repo.read_ref(ostree_ref)?;
-        (checksum, Some(ostree_ref_path(ostree_ref)))
-    };
-
-    let mut op = PullOperation::<ObjectID, LocalRepo<ObjectID>>::new(repo, ostree_repo);
-    if let Some(base_name) = base_reference {
-        let base_ref = format!("refs/{}", ostree_ref_path(base_name));
-        op.add_base(&base_ref)?;
-    }
-
-    let (verity, stats) = op
-        .pull_commit(&commit_checksum, reference.as_deref())
-        .await?;
-    ensure_ostree_erofs(repo, &stats.commit_id)?;
-    Ok((verity, stats))
-}
-
-/// Pull from a remote ostree repo into the repository.
 ///
-/// Automatically creates the EROFS image and links it from the commit splitstream.
-/// `ostree_ref` can be either a ref name or a 64-character hex commit ID.
+/// See [`PullOptions`] for tunable knobs (base commit, progress reporting).
 pub async fn pull<ObjectID: FsVerityHashValue>(
     repo: &Arc<Repository<ObjectID>>,
-    ostree_repo_url: &str,
+    ostree_repo: impl OstreeRepo<ObjectID> + 'static,
     ostree_ref: &str,
-    base_reference: Option<&str>,
+    opts: PullOptions<'_>,
 ) -> Result<(ObjectID, PullStats)> {
-    let ostree_repo = RemoteRepo::new(repo, ostree_repo_url)?;
+    let reporter: SharedReporter = opts.progress.unwrap_or_else(|| Arc::new(NullReporter));
+
+    reporter.report(ProgressEvent::Message(format!("Fetching {ostree_ref}")));
 
     let (commit_checksum, reference) = if is_commit_id(ostree_ref) {
         (parse_sha256(ostree_ref)?, None)
@@ -101,8 +109,8 @@ pub async fn pull<ObjectID: FsVerityHashValue>(
         (checksum, Some(ostree_ref_path(ostree_ref)))
     };
 
-    let mut op = PullOperation::<ObjectID, RemoteRepo<ObjectID>>::new(repo, ostree_repo);
-    if let Some(base_name) = base_reference {
+    let mut op = PullOperation::new(repo, ostree_repo, reporter);
+    if let Some(base_name) = opts.base_reference {
         let base_ref = format!("refs/{}", ostree_ref_path(base_name));
         op.add_base(&base_ref)?;
     }

--- a/crates/composefs-ostree/src/lib.rs
+++ b/crates/composefs-ostree/src/lib.rs
@@ -34,6 +34,7 @@ pub struct CommitInfo {
 }
 
 mod commit;
+pub mod delta;
 #[cfg(doc)]
 pub mod design;
 pub mod ostree;
@@ -42,6 +43,7 @@ pub mod repo;
 
 use crate::commit::{CommitReader, CommitWriter};
 use crate::pull::PullOperation;
+pub use crate::delta::apply_delta_offline;
 pub use crate::pull::PullStats;
 pub use crate::repo::{LocalRepo, OstreeRepo, RemoteRepo};
 

--- a/crates/composefs-ostree/src/lib.rs
+++ b/crates/composefs-ostree/src/lib.rs
@@ -14,6 +14,7 @@
 
 use anyhow::{Context, Result, bail};
 use rustix::fs::{AtFlags, Dir, OFlags, readlinkat, unlinkat};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use composefs::{
@@ -21,7 +22,7 @@ use composefs::{
     progress::{NullReporter, ProgressEvent, SharedReporter},
     repository::Repository,
     tree::FileSystem,
-    util::parse_sha256,
+    util::{Sha256Digest, parse_sha256},
 };
 
 /// Information about a stored ostree commit.
@@ -42,8 +43,8 @@ mod pull;
 pub mod repo;
 
 use crate::commit::{CommitReader, CommitWriter};
-use crate::pull::PullOperation;
 pub use crate::delta::apply_delta_offline;
+use crate::pull::PullOperation;
 pub use crate::pull::PullStats;
 pub use crate::repo::{LocalRepo, OstreeRepo, RemoteRepo};
 
@@ -110,6 +111,15 @@ pub async fn pull<ObjectID: FsVerityHashValue>(
         let checksum = ostree_repo.resolve_ref(ostree_ref).await?;
         (checksum, Some(ostree_ref_path(ostree_ref)))
     };
+
+    // Try delta pull first
+    if let Some((verity, stats)) = ostree_repo.try_pull_delta(repo, &commit_checksum).await? {
+        reporter.report(ProgressEvent::Message("Using static delta".into()));
+        if let Some(ref_name) = reference {
+            repo.name_stream(&format!("ostree-commit-{}", stats.commit_id), &ref_name)?;
+        }
+        return Ok((verity, stats));
+    }
 
     let mut op = PullOperation::new(repo, ostree_repo, reporter);
     if let Some(base_name) = opts.base_reference {
@@ -251,6 +261,31 @@ pub fn list_commits<ObjectID: FsVerityHashValue>(
         .collect();
 
     Ok(commits)
+}
+
+/// Returns the set of ostree commit checksums stored in the repository.
+fn list_local_commit_ids<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+) -> Result<HashSet<Sha256Digest>> {
+    let dir_fd = rustix::fs::openat(
+        repo.repo_fd(),
+        "streams",
+        OFlags::RDONLY | OFlags::DIRECTORY,
+        rustix::fs::Mode::empty(),
+    )?;
+    let mut ids = HashSet::new();
+    for item in Dir::read_from(&dir_fd)? {
+        let entry = item?;
+        let name = entry.file_name().to_bytes();
+        if let Ok(s) = std::str::from_utf8(name)
+            && let Some(hex) = s.strip_prefix("ostree-commit-")
+            && hex.len() == 64
+            && let Ok(checksum) = parse_sha256(hex)
+        {
+            ids.insert(checksum);
+        }
+    }
+    Ok(ids)
 }
 
 /// Ensures the EROFS image exists for a commit and stores a named ref to it

--- a/crates/composefs-ostree/src/ostree.rs
+++ b/crates/composefs-ostree/src/ostree.rs
@@ -10,12 +10,18 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use composefs::{fsverity::FsVerityHashValue, util::Sha256Digest};
 
+/// The storage layout of an ostree repository.
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub(crate) enum RepoMode {
+pub enum RepoMode {
+    /// Objects stored as regular files with original permissions.
     Bare,
+    /// Objects stored compressed; used for HTTP serving.
     Archive,
+    /// Objects stored as regular files owned by the calling user.
     BareUser,
+    /// Like `BareUser` but without xattr or ownership metadata.
     BareUserOnly,
+    /// Like `Bare` but xattrs stored in separate sidecar files.
     BareSplitXAttrs,
 }
 
@@ -34,20 +40,30 @@ impl std::str::FromStr for RepoMode {
     }
 }
 
+/// The type of an ostree content-addressed object.
 #[allow(dead_code)]
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub(crate) enum ObjectType {
+pub enum ObjectType {
+    /// Regular file, symlink, or device node.
     File,
+    /// Directory listing mapping names to file/subtree checksums.
     DirTree,
+    /// Directory metadata (uid, gid, mode, xattrs).
     DirMeta,
+    /// Top-level commit object referencing a root tree.
     Commit,
+    /// Marker for a deleted commit.
     TombstoneCommit,
+    /// Hard-link placeholder pointing to another object.
     PayloadLink,
+    /// Separate xattr storage for a file object.
     FileXAttrs,
+    /// Symlink to shared xattr data.
     FileXAttrsLink,
 }
 
 impl ObjectType {
+    /// Returns the file extension used for this object type on disk.
     pub fn extension(&self, repo_mode: RepoMode) -> &'static str {
         match self {
             ObjectType::File => {
@@ -85,12 +101,14 @@ pub(crate) fn should_inline_file<ObjectID: FsVerityHashValue>(file_size: usize) 
     file_size <= size_of::<ObjectID>() * 2
 }
 
-/// On-disk header prefixed to gvariant data in ostree objects
+/// On-disk header prefixed to gvariant data in ostree objects.
 #[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout)]
 #[repr(C)]
-pub(crate) struct SizedVariantHeader {
-    size: u32,
-    padding: u32,
+pub struct SizedVariantHeader {
+    /// Big-endian size of the following gvariant payload.
+    pub size: u32,
+    /// Padding for 8-byte alignment.
+    pub padding: u32,
 }
 
 pub(crate) fn size_prefix(data: &[u8]) -> AlignedBuf {
@@ -138,16 +156,24 @@ pub(crate) fn split_sized_variant(data: &AlignedSlice<A8>) -> Result<(&AlignedSl
 }
 
 /// Decoded ostree file header (uid, gid, mode, xattrs, symlink target).
-pub(crate) struct OstreeFileHeader {
+#[derive(Debug)]
+pub struct OstreeFileHeader {
+    /// File size in bytes.
     pub size: u64,
+    /// Owner user ID.
     pub uid: u32,
+    /// Owner group ID.
     pub gid: u32,
+    /// Unix file mode bits.
     pub mode: u32,
+    /// Symlink target path (empty string for non-symlinks).
     pub symlink_target: String,
+    /// Extended attributes as (name, value) pairs.
     pub xattrs: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
 impl OstreeFileHeader {
+    /// Deserialize from the zlib-sized format used in archive-mode objects.
     pub fn from_zlib_sized(data: &AlignedSlice<A8>) -> Result<Self> {
         let header_size = size_of::<SizedVariantHeader>();
         let variant_data: &AlignedSlice<A8> = data
@@ -215,14 +241,20 @@ impl OstreeFileHeader {
 }
 
 /// Decoded ostree directory metadata (uid, gid, mode, xattrs).
-pub(crate) struct OstreeDirMeta {
+#[derive(Debug)]
+pub struct OstreeDirMeta {
+    /// Owner user ID.
     pub uid: u32,
+    /// Owner group ID.
     pub gid: u32,
+    /// Unix file mode bits.
     pub mode: u32,
+    /// Extended attributes as (name, value) pairs.
     pub xattrs: Vec<(Vec<u8>, Vec<u8>)>,
 }
 
 impl OstreeDirMeta {
+    /// Deserialize from raw gvariant data.
     pub fn from_data(data: &AlignedSlice<A8>) -> Result<Self> {
         let gv = gv!("(uuua(ayay))").cast(data.as_aligned());
         let (uid, gid, mode, xattrs_data) = gv.to_tuple();
@@ -254,12 +286,16 @@ pub(crate) fn parse_xattr_data(data: &AlignedSlice<A8>) -> Result<Vec<(Vec<u8>, 
 }
 
 /// Decoded ostree directory tree listing files and subdirectories.
-pub(crate) struct OstreeDirTree {
+#[derive(Debug)]
+pub struct OstreeDirTree {
+    /// Files in this directory: (name, content checksum).
     pub files: Vec<(String, Sha256Digest)>,
+    /// Subdirectories: (name, tree checksum, dirmeta checksum).
     pub dirs: Vec<(String, Sha256Digest, Sha256Digest)>,
 }
 
 impl OstreeDirTree {
+    /// Deserialize from raw gvariant data.
     pub fn from_data(data: &AlignedSlice<A8>) -> Result<Self> {
         let gv = gv!("(a(say)a(sayay))").cast(data.as_aligned());
         let (files_data, dirs_data) = gv.to_tuple();
@@ -289,13 +325,21 @@ impl OstreeDirTree {
 }
 
 /// Decoded ostree commit object with metadata, tree root, and optional parent.
-pub(crate) struct OstreeCommit {
+#[derive(Debug)]
+pub struct OstreeCommit {
+    /// Checksum of the parent commit, if any.
     pub parent_commit: Option<Sha256Digest>,
+    /// Commit metadata as (key, value) string pairs.
     pub metadata: Vec<(String, String)>,
+    /// One-line commit subject.
     pub subject: String,
+    /// Extended commit description.
     pub body: String,
+    /// Commit timestamp (seconds since Unix epoch).
     pub timestamp: u64,
+    /// Checksum of the root directory tree object.
     pub root_tree: Sha256Digest,
+    /// Checksum of the root directory metadata object.
     pub root_metadata: Sha256Digest,
 }
 
@@ -328,6 +372,7 @@ fn format_variant(v: &gvariant::Variant) -> String {
 }
 
 impl OstreeCommit {
+    /// Deserialize from raw gvariant data.
     pub fn from_data(data: &AlignedSlice<A8>) -> Result<Self> {
         let gv = gv!("(a{sv}aya(say)sstayay)").cast(data.as_aligned());
         let (

--- a/crates/composefs-ostree/src/ostree.rs
+++ b/crates/composefs-ostree/src/ostree.rs
@@ -63,6 +63,32 @@ pub enum ObjectType {
 }
 
 impl ObjectType {
+    /// Decode from the numeric value used in ostree's on-disk format.
+    pub fn from_byte(b: u8) -> Result<Self> {
+        match b {
+            1 => Ok(ObjectType::File),
+            2 => Ok(ObjectType::DirTree),
+            3 => Ok(ObjectType::DirMeta),
+            4 => Ok(ObjectType::Commit),
+            5 => Ok(ObjectType::TombstoneCommit),
+            7 => Ok(ObjectType::PayloadLink),
+            8 => Ok(ObjectType::FileXAttrs),
+            9 => Ok(ObjectType::FileXAttrsLink),
+            _ => Err(anyhow!("Unknown object type {b}")),
+        }
+    }
+
+    /// Returns true for metadata object types (not file content).
+    pub fn is_meta(&self) -> bool {
+        matches!(
+            self,
+            ObjectType::DirTree
+                | ObjectType::DirMeta
+                | ObjectType::Commit
+                | ObjectType::TombstoneCommit
+        )
+    }
+
     /// Returns the file extension used for this object type on disk.
     pub fn extension(&self, repo_mode: RepoMode) -> &'static str {
         match self {

--- a/crates/composefs-ostree/src/pull.rs
+++ b/crates/composefs-ostree/src/pull.rs
@@ -32,10 +32,12 @@ pub struct PullStats {
     pub metadata_fetched: usize,
     /// Number of file objects fetched.
     pub files_fetched: usize,
+    /// Number of delta parts applied (0 if no delta was used).
+    pub delta_parts_applied: usize,
 }
 
 const MAX_CONCURRENT_METADATA_FETCHES: usize = 32;
-const MAX_CONCURRENT_CONTENT_FETCHES: usize = 8;
+pub(crate) const MAX_CONCURRENT_CONTENT_FETCHES: usize = 8;
 
 struct Outstanding {
     id: Sha256Digest,
@@ -297,8 +299,6 @@ impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
         self.stats.commit_id = commit_hex;
 
         self.enqueue_fetch(commit_id, ObjectType::Commit);
-
-        // TODO: Support deltas
 
         let metadata_id: ComponentId = "metadata".into();
         self.reporter.report(ProgressEvent::Started {

--- a/crates/composefs-ostree/src/pull.rs
+++ b/crates/composefs-ostree/src/pull.rs
@@ -6,9 +6,13 @@
 //! shared objects.
 
 use anyhow::{Result, bail};
-use composefs::{fsverity::FsVerityHashValue, repository::Repository, util::Sha256Digest};
+use composefs::{
+    fsverity::FsVerityHashValue,
+    progress::{ComponentId, ProgressEvent, ProgressUnit, SharedReporter},
+    repository::Repository,
+    util::Sha256Digest,
+};
 use gvariant::aligned_bytes::AlignedBuf;
-use indicatif::ProgressBar;
 use sha2::{Digest, Sha256};
 use std::collections::{HashSet, VecDeque};
 use std::{fmt, sync::Arc};
@@ -61,11 +65,11 @@ enum FetchResult<ObjectID: FsVerityHashValue> {
 }
 
 /// Drives a two-phase pull of an ostree commit into a composefs repository.
-#[derive(Debug)]
 pub(crate) struct PullOperation<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID>> {
     repo: Arc<Repository<ObjectID>>,
     writer: CommitWriter<ObjectID>,
     ostree_repo: Arc<RepoType>,
+    reporter: SharedReporter,
     base_commits: Vec<CommitReader<ObjectID>>,
     outstanding: VecDeque<Outstanding>,
     // All ids that were ever enqueued (including already fetched and currently being fetched)
@@ -76,11 +80,16 @@ pub(crate) struct PullOperation<ObjectID: FsVerityHashValue, RepoType: OstreeRep
 impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
     PullOperation<ObjectID, RepoType>
 {
-    pub fn new(repo: &Arc<Repository<ObjectID>>, ostree_repo: RepoType) -> Self {
+    pub fn new(
+        repo: &Arc<Repository<ObjectID>>,
+        ostree_repo: RepoType,
+        reporter: SharedReporter,
+    ) -> Self {
         PullOperation {
             repo: repo.clone(),
             writer: CommitWriter::<ObjectID>::new(),
             ostree_repo: Arc::new(ostree_repo),
+            reporter,
             outstanding: VecDeque::new(),
             base_commits: vec![],
             fetched: HashSet::new(),
@@ -291,7 +300,12 @@ impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
 
         // TODO: Support deltas
 
-        let metadata_bar = ProgressBar::new_spinner().with_message("Fetching metadata");
+        let metadata_id: ComponentId = "metadata".into();
+        self.reporter.report(ProgressEvent::Started {
+            id: metadata_id.clone(),
+            total: None,
+            unit: ProgressUnit::Items,
+        });
         let metadata_semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_METADATA_FETCHES));
 
         // Phase 1: Fetch all metadata (commits, dirtrees, dirmetas) in parallel.
@@ -322,11 +336,15 @@ impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
 
             match join_set.join_next().await {
                 Some(result) => {
-                    metadata_bar.tick();
                     let fetch = result??;
                     match fetch {
                         FetchResult::Metadata { id, obj_type, data } => {
                             self.stats.metadata_fetched += 1;
+                            self.reporter.report(ProgressEvent::Progress {
+                                id: metadata_id.clone(),
+                                fetched: self.stats.metadata_fetched as u64,
+                                total: None,
+                            });
                             self.process_metadata(&id, obj_type, data)?;
                         }
                         _ => unreachable!(),
@@ -336,7 +354,10 @@ impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
             }
         }
 
-        metadata_bar.finish_and_clear();
+        self.reporter.report(ProgressEvent::Done {
+            id: metadata_id,
+            transferred: self.stats.metadata_fetched as u64,
+        });
 
         // Phase 2: Fetch all files in parallel. Files are leaf objects with
         // no dependencies on each other.
@@ -349,7 +370,13 @@ impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
             return Ok((commit_id, stats));
         }
 
-        let files_bar = ProgressBar::new(files.len() as u64);
+        let files_total = files.len() as u64;
+        let files_id: ComponentId = "files".into();
+        self.reporter.report(ProgressEvent::Started {
+            id: files_id.clone(),
+            total: Some(files_total),
+            unit: ProgressUnit::Items,
+        });
         let content_semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_CONTENT_FETCHES));
         let mut join_set: JoinSet<Result<FetchResult<ObjectID>>> = JoinSet::new();
 
@@ -377,13 +404,20 @@ impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
                 } => {
                     self.stats.files_fetched += 1;
                     self.add_file(&id, obj_id.as_ref(), file_header);
-                    files_bar.inc(1);
+                    self.reporter.report(ProgressEvent::Progress {
+                        id: files_id.clone(),
+                        fetched: self.stats.files_fetched as u64,
+                        total: Some(files_total),
+                    });
                 }
                 _ => unreachable!(),
             }
         }
 
-        files_bar.finish();
+        self.reporter.report(ProgressEvent::Done {
+            id: files_id,
+            transferred: self.stats.files_fetched as u64,
+        });
 
         let commit_id = self
             .writer

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -111,6 +111,19 @@ pub trait OstreeRepo<ObjectID: FsVerityHashValue>: Send + Sync {
         &self,
         checksum: &Sha256Digest,
     ) -> impl Future<Output = Result<(AlignedBuf, Option<ObjectID>)>> + Send;
+
+    /// Try to pull a commit using a static delta.
+    ///
+    /// Returns `Ok(Some(...))` if a delta was found and applied successfully,
+    /// `Ok(None)` if no usable delta is available. The default implementation
+    /// returns `None` (no delta support).
+    fn try_pull_delta(
+        &self,
+        _repo: &Arc<Repository<ObjectID>>,
+        _commit_checksum: &Sha256Digest,
+    ) -> impl Future<Output = Result<Option<(ObjectID, crate::pull::PullStats)>>> + Send {
+        async { Ok(None) }
+    }
 }
 
 const OSTREE_SUMMARY_CONTENT_TYPE: u64 = u64::from_le_bytes(*b"osummary");
@@ -178,6 +191,52 @@ impl SummaryCache {
                 Ok((name.to_str().to_string(), checksum))
             })
             .collect()
+    }
+
+    /// Find available static deltas targeting the given commit.
+    ///
+    /// Returns `(from_checksum, to_checksum)` pairs. `from_checksum` is
+    /// `None` for scratch (from-nothing) deltas.
+    fn find_deltas(&self, to_checksum: &Sha256Digest) -> Vec<(Option<Sha256Digest>, Sha256Digest)> {
+        use gvariant::{Marker, Structure, gv};
+
+        let Ok(aligned) = self.data.try_as_aligned() else {
+            return vec![];
+        };
+        let summary = gv!("(a(s(taya{sv}))a{sv})").cast(aligned);
+        let (_refs_array, metadata) = summary.to_tuple();
+
+        let to_hex = hex::encode(to_checksum);
+        let mut deltas = vec![];
+        for entry in metadata.iter() {
+            let (key, value) = entry.to_tuple();
+            if key.to_str() != "ostree.static-deltas" {
+                continue;
+            }
+            if let Some(delta_dict) = value.get(gv!("a{sv}")) {
+                for delta_entry in delta_dict.iter() {
+                    let (name, _) = delta_entry.to_tuple();
+                    if let Some(from) = parse_delta_name_to(name.to_str(), &to_hex) {
+                        deltas.push((from, *to_checksum));
+                    }
+                }
+            }
+            break;
+        }
+        deltas
+    }
+}
+
+/// Parse a delta name from `ostree.static-deltas` and check if it
+/// targets `to_hex`. Returns `Some(from)` on match, where `from` is
+/// `None` for scratch deltas.
+fn parse_delta_name_to(name: &str, to_hex: &str) -> Option<Option<Sha256Digest>> {
+    if let Some(from_hex) = name.strip_suffix(&format!("-{to_hex}")) {
+        parse_sha256(from_hex).ok().map(Some)
+    } else if name == to_hex {
+        Some(None)
+    } else {
+        None
     }
 }
 
@@ -383,6 +442,138 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
             .pop_if_empty()
             .extend(segments);
         url
+    }
+
+    fn url_for_path(&self, path: &str) -> Url {
+        let segments: Vec<&str> = path.split('/').collect();
+        self.url_for(&segments)
+    }
+
+    /// Find available deltas for the target commit.
+    ///
+    /// Checks both the summary metadata and per-commit delta indexes.
+    pub async fn find_deltas(
+        &self,
+        to_checksum: &Sha256Digest,
+    ) -> Result<Vec<(Option<Sha256Digest>, Sha256Digest)>> {
+        // Try summary metadata first
+        if let Some(cache) = self.load_summary().await? {
+            let deltas = cache.find_deltas(to_checksum);
+            if !deltas.is_empty() {
+                return Ok(deltas);
+            }
+        }
+        // Fall back to per-commit delta index
+        self.fetch_delta_index(to_checksum).await
+    }
+
+    /// Fetch a delta superblock from the remote repository.
+    ///
+    /// Returns `None` if the delta is not found (404).
+    pub async fn fetch_delta_superblock(
+        &self,
+        from: Option<&Sha256Digest>,
+        to: &Sha256Digest,
+    ) -> Result<Option<Vec<u8>>> {
+        let path = crate::delta::delta_path(from, to, "superblock");
+        let url = self.url_for_path(&path);
+        let response = self.client.get(url).send().await?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        response.error_for_status_ref()?;
+        Ok(Some(response.bytes().await?.to_vec()))
+    }
+
+    /// Fetch the delta index for a target commit, if available.
+    ///
+    /// Delta indexes are at `delta-indexes/{b64[0:2]}/{b64[2:]}.index`
+    /// and contain an `a{sv}` dict with `ostree.static-deltas`.
+    async fn fetch_delta_index(
+        &self,
+        to: &Sha256Digest,
+    ) -> Result<Vec<(Option<Sha256Digest>, Sha256Digest)>> {
+        let to_b64 = crate::delta::checksum_to_b64(to);
+        let path = format!("delta-indexes/{}/{}.index", &to_b64[..2], &to_b64[2..]);
+        let url = self.url_for_path(&path);
+
+        let response = match self.client.get(url).send().await {
+            Ok(r) if r.status().is_success() => r,
+            _ => return Ok(vec![]),
+        };
+
+        use gvariant::{Marker, Structure, gv};
+
+        let index_bytes = response.bytes().await?;
+        let aligned: AlignedBuf = index_bytes.to_vec().into();
+        let Ok(aligned) = aligned.try_as_aligned() else {
+            return Ok(vec![]);
+        };
+        let dict = gv!("a{sv}").cast(aligned);
+
+        let to_hex = hex::encode(to);
+        let mut deltas = vec![];
+        for entry in dict.iter() {
+            let (key, value) = entry.to_tuple();
+            if key.to_str() != "ostree.static-deltas" {
+                continue;
+            }
+            if let Some(delta_dict) = value.get(gv!("a{sv}")) {
+                for delta_entry in delta_dict.iter() {
+                    let (name, _) = delta_entry.to_tuple();
+                    if let Some(from) = parse_delta_name_to(name.to_str(), &to_hex) {
+                        deltas.push((from, *to));
+                    }
+                }
+            }
+            break;
+        }
+        Ok(deltas)
+    }
+
+    /// Fetch a delta part from the remote repository.
+    pub async fn fetch_delta_part(
+        &self,
+        from: Option<&Sha256Digest>,
+        to: &Sha256Digest,
+        part_index: usize,
+    ) -> Result<Vec<u8>> {
+        let path = crate::delta::delta_path(from, to, &part_index.to_string());
+        let url = self.url_for_path(&path);
+        let response = self
+            .client
+            .get(url.clone())
+            .send()
+            .await
+            .with_context(|| format!("Fetching delta part {part_index} from {url}"))?;
+        response
+            .error_for_status_ref()
+            .with_context(|| format!("Fetching delta part {part_index} from {url}"))?;
+        Ok(response.bytes().await?.to_vec())
+    }
+
+    async fn fetch_or_read_part(
+        &self,
+        superblock: &crate::delta::DeltaSuperblock,
+        from: Option<&Sha256Digest>,
+        to: &Sha256Digest,
+        index: usize,
+        expected_checksum: &Sha256Digest,
+    ) -> Result<Vec<u8>> {
+        let raw = match superblock.read_inline_part(index)? {
+            Some(data) => data,
+            None => self.fetch_delta_part(from, to, index).await?,
+        };
+        let actual = sha2::Sha256::digest(&raw);
+        if *actual != *expected_checksum {
+            bail!(
+                "delta part {index} checksum mismatch: expected {}, got {}",
+                hex::encode(expected_checksum),
+                hex::encode(actual)
+            );
+        }
+        Ok(raw)
     }
 
     async fn load_summary(&self) -> Result<Option<&SummaryCache>> {
@@ -635,6 +826,144 @@ impl<ObjectID: FsVerityHashValue> OstreeRepo<ObjectID> for RemoteRepo<ObjectID> 
         })
         .await
         .context("spawn_blocking failed")?
+    }
+
+    async fn try_pull_delta(
+        &self,
+        repo: &Arc<Repository<ObjectID>>,
+        commit_checksum: &Sha256Digest,
+    ) -> Result<Option<(ObjectID, crate::pull::PullStats)>> {
+        let deltas = self.find_deltas(commit_checksum).await?;
+        if deltas.is_empty() {
+            return Ok(None);
+        }
+
+        let local_commits = crate::list_local_commit_ids(repo)?;
+
+        // Pick the best delta: prefer differential (from a local commit) over scratch
+        let chosen = deltas
+            .iter()
+            .filter(|(from, _)| from.as_ref().is_none_or(|f| local_commits.contains(f)))
+            .min_by_key(|(from, _)| if from.is_some() { 0 } else { 1 });
+
+        let (from, to) = match chosen {
+            Some(delta) => delta,
+            None => return Ok(None),
+        };
+
+        let superblock_data = match self.fetch_delta_superblock(from.as_ref(), to).await? {
+            Some(data) => data,
+            None => return Ok(None),
+        };
+
+        let superblock = crate::delta::DeltaSuperblock::from_data(superblock_data)?;
+        let part_headers = superblock.part_headers()?;
+
+        let mut base = if let Some(from_csum) = from {
+            let from_stream = format!("ostree-commit-{}", hex::encode(from_csum));
+            Some(crate::commit::CommitReader::<ObjectID>::load(
+                repo,
+                &from_stream,
+            )?)
+        } else {
+            None
+        };
+
+        let mut writer = crate::commit::CommitWriter::<ObjectID>::new();
+        let commit_hex = hex::encode(to);
+        let mut stats = crate::pull::PullStats {
+            commit_id: commit_hex.clone(),
+            ..Default::default()
+        };
+
+        // Pipeline: apply part N in spawn_blocking while fetching
+        // part N+1 on the async runtime via tokio::join!.
+        let mut next_raw = if !part_headers.is_empty() {
+            Some(
+                self.fetch_or_read_part(
+                    &superblock,
+                    from.as_ref(),
+                    to,
+                    0,
+                    &part_headers[0].checksum,
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+
+        for (i, header) in part_headers.iter().enumerate() {
+            let raw = next_raw.take().unwrap()?;
+
+            // Kick off fetching the next part, then apply the current
+            // one in a blocking task. tokio::join! runs both concurrently.
+            let apply = {
+                let objects = header.objects.clone();
+                let repo_clone = repo.clone();
+                tokio::task::spawn_blocking(move || {
+                    let decompressed = crate::delta::decompress_part(&raw)?;
+                    crate::delta::execute_delta_part(
+                        &repo_clone,
+                        &mut writer,
+                        base.as_ref(),
+                        &decompressed,
+                        &objects,
+                    )?;
+                    Ok::<_, anyhow::Error>((writer, base))
+                })
+            };
+
+            let fetch = async {
+                if let Some(next) = part_headers.get(i + 1) {
+                    self.fetch_or_read_part(&superblock, from.as_ref(), to, i + 1, &next.checksum)
+                        .await
+                } else {
+                    Ok(vec![])
+                }
+            };
+
+            let (apply_result, fetch_result) = tokio::join!(apply, fetch);
+            (writer, base) = apply_result.context("delta apply task failed")??;
+            next_raw = Some(fetch_result);
+
+            stats.delta_parts_applied += 1;
+            for (obj_type, _) in &header.objects {
+                if obj_type.is_meta() {
+                    stats.metadata_fetched += 1;
+                } else {
+                    stats.files_fetched += 1;
+                }
+            }
+        }
+
+        // Fetch fallback objects using the existing trait methods
+        for fb in &superblock.fallbacks()? {
+            if fb.obj_type == ObjectType::File {
+                let (file_header, obj_id) = self.fetch_file(&fb.checksum).await?;
+                writer.insert(&fb.checksum, obj_id.as_ref(), &file_header);
+                stats.files_fetched += 1;
+            } else {
+                let data = self.fetch_object(&fb.checksum, fb.obj_type).await?;
+                writer.insert(&fb.checksum, None, &data);
+                stats.metadata_fetched += 1;
+            }
+        }
+
+        let commit_data = superblock.commit_data()?;
+        writer.insert(to, None, &commit_data);
+        writer.set_commit_id(to);
+        stats.metadata_fetched += 1;
+
+        if let Some(ref base) = base {
+            crate::delta::inherit_base_objects(&mut writer, base, &commit_data)?;
+        }
+
+        let content_id = format!("ostree-commit-{commit_hex}");
+        let verity = writer.serialize(repo, &content_id, None, None)?;
+        crate::ensure_ostree_erofs(repo, &stats.commit_id)?;
+
+        Ok(Some((verity, stats)))
     }
 }
 

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -7,8 +7,8 @@
 use anyhow::{Context, Result, anyhow, bail};
 use configparser::ini::Ini;
 use flate2::read::DeflateDecoder;
-use gvariant::aligned_bytes::AlignedBuf;
-use reqwest::{Client, Url};
+use gvariant::aligned_bytes::{AlignedBuf, TryAsAligned};
+use reqwest::{Client, StatusCode, Url, header};
 use rustix::fd::AsRawFd;
 use rustix::fs::{FileType, Mode, OFlags, fstat, getxattr, listxattr, openat, readlinkat};
 use rustix::io::Errno;
@@ -24,8 +24,10 @@ use std::{
     sync::Arc,
 };
 use tokio::io::AsyncReadExt;
+use tokio::sync::OnceCell;
 use tokio_stream::StreamExt;
 use tokio_util::io::StreamReader;
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 use composefs::{
     fsverity::FsVerityHashValue,
@@ -111,12 +113,203 @@ pub trait OstreeRepo<ObjectID: FsVerityHashValue>: Send + Sync {
     ) -> impl Future<Output = Result<(AlignedBuf, Option<ObjectID>)>> + Send;
 }
 
+const OSTREE_SUMMARY_CONTENT_TYPE: u64 = u64::from_le_bytes(*b"osummary");
+
+/// Fixed header for a cached summary splitstream blob.
+///
+/// Followed by `etag_len` bytes of ETag, `last_modified_len` bytes of
+/// Last-Modified, then the raw summary gvariant data.
+#[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout)]
+#[repr(C)]
+struct SummaryCacheHeader {
+    etag_len: u16,
+    last_modified_len: u16,
+    checksum: Sha256Digest,
+}
+
+struct SummaryCacheInfo {
+    etag: Option<String>,
+    last_modified: Option<String>,
+    checksum: Sha256Digest,
+}
+
+/// Cached summary data with lazy gvariant lookup.
+struct SummaryCache {
+    data: AlignedBuf,
+}
+
+impl SummaryCache {
+    fn resolve_ref(&self, ref_name: &str) -> Option<Sha256Digest> {
+        use gvariant::{Marker, Structure, gv};
+
+        let aligned = self.data.try_as_aligned().ok()?;
+        let summary = gv!("(a(s(taya{sv}))a{sv})").cast(aligned);
+        let (refs_array, _metadata) = summary.to_tuple();
+
+        for entry in refs_array.iter() {
+            let (name, ref_data) = entry.to_tuple();
+            if name.to_str() == ref_name {
+                let (_commit_size, checksum_bytes, _per_ref_metadata) = ref_data.to_tuple();
+                return checksum_bytes.try_into().ok();
+            }
+        }
+
+        None
+    }
+}
+
+/// Parsed summary index (`summary.idx`) with lazy subset lookup.
+struct SummaryIndex {
+    data: AlignedBuf,
+}
+
+impl SummaryIndex {
+    fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        Ok(SummaryIndex {
+            data: bytes.to_vec().into(),
+        })
+    }
+
+    fn lookup_checksum(&self, subset: &str) -> Result<Option<Sha256Digest>> {
+        use gvariant::{Marker, Structure, gv};
+
+        let aligned = self
+            .data
+            .try_as_aligned()
+            .map_err(|_| anyhow!("summary index not aligned"))?;
+        let index = gv!("(a{s(ayaaya{sv})}a{sv})").cast(aligned);
+        let (subsummaries, _metadata) = index.to_tuple();
+
+        for entry in subsummaries.iter() {
+            let (name, info) = entry.to_tuple();
+            if name.to_str() == subset {
+                let (current_checksum, _history, _per_entry_metadata) = info.to_tuple();
+                return Ok(Some(
+                    current_checksum
+                        .try_into()
+                        .context("invalid subsummary checksum in index")?,
+                ));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+fn summary_url_key(url: &Url) -> String {
+    let host = url.host_str().unwrap_or("unknown");
+    let path = url.path().trim_end_matches('/');
+    format!("{host}{path}").replace('/', "-")
+}
+
+fn write_summary_cache<ObjectID: FsVerityHashValue>(
+    repo: &Arc<Repository<ObjectID>>,
+    stream_id: &str,
+    info: &SummaryCacheInfo,
+    summary_data: &[u8],
+) -> Result<()> {
+    let etag_bytes = info.etag.as_deref().unwrap_or("").as_bytes();
+    let lm_bytes = info.last_modified.as_deref().unwrap_or("").as_bytes();
+
+    let header = SummaryCacheHeader {
+        etag_len: u16::to_le(
+            u16::try_from(etag_bytes.len()).context("ETag too long for cache header")?,
+        ),
+        last_modified_len: u16::to_le(
+            u16::try_from(lm_bytes.len()).context("Last-Modified too long for cache header")?,
+        ),
+        checksum: info.checksum,
+    };
+
+    let mut ss = repo.create_stream(OSTREE_SUMMARY_CONTENT_TYPE)?;
+    ss.write_inline(header.as_bytes());
+    ss.write_inline(etag_bytes);
+    ss.write_inline(lm_bytes);
+    ss.write_inline(summary_data);
+    repo.write_stream(ss, stream_id, None)?;
+    Ok(())
+}
+
+use composefs::splitstream::SplitStreamReader;
+
+fn read_summary_cache_header<ObjectID: FsVerityHashValue>(
+    reader: &mut SplitStreamReader<ObjectID>,
+) -> Result<SummaryCacheInfo> {
+    let header_size = size_of::<SummaryCacheHeader>();
+    let mut header_buf = vec![0u8; header_size];
+    reader
+        .read_inline_exact(&mut header_buf)
+        .context("reading summary cache header")?;
+    let header = SummaryCacheHeader::ref_from_bytes(&header_buf)
+        .map_err(|e| anyhow!("summary cache header: {e:?}"))?;
+
+    let etag_len = u16::from_le(header.etag_len) as usize;
+    let last_modified_len = u16::from_le(header.last_modified_len) as usize;
+
+    let etag = if etag_len > 0 {
+        let mut buf = vec![0u8; etag_len];
+        reader
+            .read_inline_exact(&mut buf)
+            .context("reading etag")?;
+        Some(std::str::from_utf8(&buf).context("etag is not UTF-8")?.to_string())
+    } else {
+        None
+    };
+    let last_modified = if last_modified_len > 0 {
+        let mut buf = vec![0u8; last_modified_len];
+        reader
+            .read_inline_exact(&mut buf)
+            .context("reading last-modified")?;
+        Some(std::str::from_utf8(&buf).context("last-modified is not UTF-8")?.to_string())
+    } else {
+        None
+    };
+
+    Ok(SummaryCacheInfo {
+        etag,
+        last_modified,
+        checksum: header.checksum,
+    })
+}
+
+fn read_summary_cache_data<ObjectID: FsVerityHashValue>(
+    reader: &mut SplitStreamReader<ObjectID>,
+    repo: &Repository<ObjectID>,
+) -> Result<SummaryCache> {
+    let mut data = Vec::new();
+    reader.cat(repo, &mut data)?;
+    Ok(SummaryCache { data: data.into() })
+}
+
+fn open_cached_summary<ObjectID: FsVerityHashValue>(
+    repo: &Repository<ObjectID>,
+    stream_id: &str,
+) -> Result<Option<SplitStreamReader<ObjectID>>> {
+    if repo.has_stream(stream_id)?.is_some() {
+        Ok(Some(
+            repo.open_stream(stream_id, None, Some(OSTREE_SUMMARY_CONTENT_TYPE))?,
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
 /// Fetches ostree objects over HTTP from an archive-z2 repository.
-#[derive(Debug)]
 pub struct RemoteRepo<ObjectID: FsVerityHashValue> {
     repo: Arc<Repository<ObjectID>>,
     client: Client,
     url: Url,
+    summary_subset: String,
+    summary: OnceCell<Option<SummaryCache>>,
+}
+
+impl<ObjectID: FsVerityHashValue> std::fmt::Debug for RemoteRepo<ObjectID> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RemoteRepo")
+            .field("url", &self.url)
+            .field("summary_subset", &self.summary_subset)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
@@ -126,7 +319,18 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
             repo: repo.clone(),
             client: Client::new(),
             url: Url::parse(url)?,
+            summary_subset: std::env::consts::ARCH.to_string(),
+            summary: OnceCell::new(),
         })
+    }
+
+    /// Override the summary index subset key (defaults to the system architecture).
+    ///
+    /// For flatpak repos this can be e.g. `"free-x86_64"` for a subset, or
+    /// just `"x86_64"` for all refs on that architecture.
+    pub fn with_summary_subset(mut self, subset: &str) -> Self {
+        self.summary_subset = subset.to_string();
+        self
     }
 
     fn url_for(&self, segments: &[&str]) -> Url {
@@ -137,20 +341,183 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
             .extend(segments);
         url
     }
+
+    async fn load_summary(&self) -> Result<Option<&SummaryCache>> {
+        let cached = self
+            .summary
+            .get_or_try_init(|| self.fetch_summary())
+            .await?;
+        Ok(cached.as_ref())
+    }
+
+    async fn fetch_summary(&self) -> Result<Option<SummaryCache>> {
+        // Try the summary index first (flatpak-style repos)
+        if let Some(cache) = self.try_fetch_indexed_summary().await? {
+            return Ok(Some(cache));
+        }
+        // Fall back to plain summary with conditional HTTP
+        self.fetch_plain_summary().await
+    }
+
+    async fn try_fetch_indexed_summary(&self) -> Result<Option<SummaryCache>> {
+        use flate2::read::GzDecoder;
+
+        let url = self.url_for(&["summary.idx"]);
+        let response = match self.client.get(url).send().await {
+            Ok(r) if r.status().is_success() => r,
+            _ => return Ok(None),
+        };
+
+        let index_bytes = response.bytes().await?;
+        let index = SummaryIndex::from_bytes(&index_bytes)?;
+
+        let checksum = match index.lookup_checksum(&self.summary_subset)? {
+            Some(c) => c,
+            None => return Ok(None),
+        };
+
+        let url_key = summary_url_key(&self.url);
+        let stream_id = format!("ostree-subsummary-{}-{url_key}", self.summary_subset);
+
+        // Check if we have a cached subsummary with a matching checksum
+        if let Some(mut reader) = open_cached_summary(&self.repo, &stream_id)?
+            && let Ok(info) = read_summary_cache_header(&mut reader)
+            && info.checksum == checksum
+        {
+            return Ok(Some(read_summary_cache_data(&mut reader, &self.repo)?));
+        }
+
+        // Fetch the new subsummary (gzipped)
+        let checksum_hex = hex::encode(checksum);
+        let filename = format!("{checksum_hex}.gz");
+        let sub_url = self.url_for(&["summaries", &filename]);
+        let response = self
+            .client
+            .get(sub_url.clone())
+            .send()
+            .await
+            .with_context(|| format!("Fetching subsummary from {sub_url}"))?;
+        response
+            .error_for_status_ref()
+            .with_context(|| format!("Fetching subsummary from {sub_url}"))?;
+
+        let compressed = response
+            .bytes()
+            .await
+            .with_context(|| format!("Reading subsummary from {sub_url}"))?;
+
+        let mut decoder = GzDecoder::new(&compressed[..]);
+        let mut summary_data = Vec::new();
+        decoder
+            .read_to_end(&mut summary_data)
+            .context("Decompressing subsummary")?;
+
+        let actual = Sha256::digest(&summary_data);
+        if *actual != checksum {
+            bail!(
+                "subsummary checksum mismatch: expected {}, got {}",
+                checksum_hex,
+                hex::encode(actual)
+            );
+        }
+
+        let info = SummaryCacheInfo {
+            etag: None,
+            last_modified: None,
+            checksum,
+        };
+        write_summary_cache(&self.repo, &stream_id, &info, &summary_data)?;
+
+        Ok(Some(SummaryCache {
+            data: summary_data.into(),
+        }))
+    }
+
+    async fn fetch_plain_summary(&self) -> Result<Option<SummaryCache>> {
+        let url_key = summary_url_key(&self.url);
+        let stream_id = format!("ostree-summary-{url_key}");
+        let url = self.url_for(&["summary"]);
+
+        // Read cached header for conditional HTTP (without reading the summary data)
+        let mut cached_reader = open_cached_summary(&self.repo, &stream_id)?;
+        let cached_info = cached_reader
+            .as_mut()
+            .and_then(|r| read_summary_cache_header(r).ok());
+
+        let mut request = self.client.get(url.clone());
+        if let Some(ref info) = cached_info {
+            if let Some(ref etag) = info.etag {
+                request = request.header(header::IF_NONE_MATCH, etag.as_str());
+            } else if let Some(ref lm) = info.last_modified {
+                request = request.header(header::IF_MODIFIED_SINCE, lm.as_str());
+            }
+        }
+
+        let response = request
+            .send()
+            .await
+            .with_context(|| format!("Fetching summary from {url}"))?;
+
+        if response.status() == StatusCode::NOT_MODIFIED
+            && let Some(mut reader) = cached_reader
+        {
+            return Ok(Some(read_summary_cache_data(&mut reader, &self.repo)?));
+        }
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        response
+            .error_for_status_ref()
+            .with_context(|| format!("Fetching summary from {url}"))?;
+
+        let etag = response
+            .headers()
+            .get(header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+        let last_modified = response
+            .headers()
+            .get(header::LAST_MODIFIED)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        let summary_data = response
+            .bytes()
+            .await
+            .with_context(|| format!("Reading summary from {url}"))?;
+
+        let data_checksum: Sha256Digest = Sha256::digest(&summary_data).into();
+        let info = SummaryCacheInfo {
+            etag,
+            last_modified,
+            checksum: data_checksum,
+        };
+        write_summary_cache(&self.repo, &stream_id, &info, &summary_data)?;
+
+        Ok(Some(SummaryCache {
+            data: summary_data.to_vec().into(),
+        }))
+    }
 }
 
 impl<ObjectID: FsVerityHashValue> OstreeRepo<ObjectID> for RemoteRepo<ObjectID> {
     async fn resolve_ref(&self, ref_name: &str) -> Result<Sha256Digest> {
-        // TODO: Support summary format
-        let url = self.url_for(&["refs", "heads", ref_name]);
+        if let Some(cache) = self.load_summary().await?
+            && let Some(checksum) = cache.resolve_ref(ref_name)
+        {
+            return Ok(checksum);
+        }
 
+        // Fall back to direct ref file fetch (for repos without summaries)
+        let url = self.url_for(&["refs", "heads", ref_name]);
         let response = self.client.get(url.clone()).send().await?;
         response.error_for_status_ref()?;
         let t = response
             .text()
             .await
-            .with_context(|| format!("Cannot get ostree ref at {}", url))?;
-
+            .with_context(|| format!("Cannot get ostree ref at {url}"))?;
         Ok(parse_sha256(t.trim())?)
     }
 

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -92,12 +92,19 @@ fn hash_and_store_file<ObjectID: FsVerityHashValue>(
 }
 
 /// Abstraction over local and remote ostree repository access.
-pub(crate) trait OstreeRepo<ObjectID: FsVerityHashValue>: Send + Sync {
+///
+/// Implemented by [`LocalRepo`] (on-disk) and [`RemoteRepo`] (HTTP).
+/// Pass an implementor to [`crate::pull()`] to fetch an ostree commit.
+pub trait OstreeRepo<ObjectID: FsVerityHashValue>: Send + Sync {
+    /// Resolve a named ref (e.g. `fedora/40/x86_64`) to its commit checksum.
+    fn resolve_ref(&self, ref_name: &str) -> impl Future<Output = Result<Sha256Digest>> + Send;
+    /// Fetch a metadata object (commit, dirtree, dirmeta) by checksum.
     fn fetch_object(
         &self,
         checksum: &Sha256Digest,
         object_type: ObjectType,
     ) -> impl Future<Output = Result<AlignedBuf>> + Send;
+    /// Fetch a file object by checksum, returning the header and optional object ID.
     fn fetch_file(
         &self,
         checksum: &Sha256Digest,
@@ -106,13 +113,14 @@ pub(crate) trait OstreeRepo<ObjectID: FsVerityHashValue>: Send + Sync {
 
 /// Fetches ostree objects over HTTP from an archive-z2 repository.
 #[derive(Debug)]
-pub(crate) struct RemoteRepo<ObjectID: FsVerityHashValue> {
+pub struct RemoteRepo<ObjectID: FsVerityHashValue> {
     repo: Arc<Repository<ObjectID>>,
     client: Client,
     url: Url,
 }
 
 impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
+    /// Create a new remote ostree repo client for the given URL.
     pub fn new(repo: &Arc<Repository<ObjectID>>, url: &str) -> Result<Self> {
         Ok(RemoteRepo {
             repo: repo.clone(),
@@ -129,8 +137,10 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
             .extend(segments);
         url
     }
+}
 
-    pub async fn resolve_ref(&self, ref_name: &str) -> Result<Sha256Digest> {
+impl<ObjectID: FsVerityHashValue> OstreeRepo<ObjectID> for RemoteRepo<ObjectID> {
+    async fn resolve_ref(&self, ref_name: &str) -> Result<Sha256Digest> {
         // TODO: Support summary format
         let url = self.url_for(&["refs", "heads", ref_name]);
 
@@ -143,9 +153,7 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
 
         Ok(parse_sha256(t.trim())?)
     }
-}
 
-impl<ObjectID: FsVerityHashValue> OstreeRepo<ObjectID> for RemoteRepo<ObjectID> {
     async fn fetch_object(
         &self,
         checksum: &Sha256Digest,
@@ -262,7 +270,7 @@ fn read_xattrs_from_path(fd: &impl AsFd) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
 
 /// Reads ostree objects from a local on-disk repository (any mode).
 #[derive(Debug)]
-pub(crate) struct LocalRepo<ObjectID: FsVerityHashValue> {
+pub struct LocalRepo<ObjectID: FsVerityHashValue> {
     repo: Arc<Repository<ObjectID>>,
     mode: RepoMode,
     dir: OwnedFd,
@@ -270,6 +278,7 @@ pub(crate) struct LocalRepo<ObjectID: FsVerityHashValue> {
 }
 
 impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
+    /// Open a local ostree repository at the given path.
     pub fn open_path(
         repo: &Arc<Repository<ObjectID>>,
         dirfd: impl AsFd,
@@ -335,7 +344,7 @@ impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
         })
     }
 
-    pub fn open_object_flags(
+    pub(crate) fn open_object_flags(
         &self,
         checksum: &Sha256Digest,
         object_type: ObjectType,
@@ -347,11 +356,15 @@ impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
             .with_context(|| format!("Cannot open ostree objects object at {}", path))
     }
 
-    pub fn open_object(&self, checksum: &Sha256Digest, object_type: ObjectType) -> Result<OwnedFd> {
+    pub(crate) fn open_object(
+        &self,
+        checksum: &Sha256Digest,
+        object_type: ObjectType,
+    ) -> Result<OwnedFd> {
         self.open_object_flags(checksum, object_type, OFlags::RDONLY | OFlags::NOFOLLOW)
     }
 
-    pub fn read_ref(&self, ref_name: &str) -> Result<Sha256Digest> {
+    pub(crate) fn read_ref(&self, ref_name: &str) -> Result<Sha256Digest> {
         let path1 = format!("refs/{}", ref_name);
         let path2 = format!("refs/heads/{}", ref_name);
 
@@ -484,6 +497,10 @@ impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
 }
 
 impl<ObjectID: FsVerityHashValue> OstreeRepo<ObjectID> for LocalRepo<ObjectID> {
+    async fn resolve_ref(&self, ref_name: &str) -> Result<Sha256Digest> {
+        self.read_ref(ref_name)
+    }
+
     async fn fetch_object(
         &self,
         checksum: &Sha256Digest,

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -439,7 +439,7 @@ impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
 
         let is_symlink = FileType::from_raw_mode(mode).is_symlink();
         let header = OstreeFileHeader {
-            size: st.st_size as u64,
+            size: if is_symlink { 0 } else { st.st_size as u64 },
             uid,
             gid,
             mode,

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -156,6 +156,29 @@ impl SummaryCache {
 
         None
     }
+
+    fn list_refs(&self) -> Result<Vec<(String, Sha256Digest)>> {
+        use gvariant::{Marker, Structure, gv};
+
+        let aligned = self
+            .data
+            .try_as_aligned()
+            .map_err(|_| anyhow!("summary data not aligned"))?;
+        let summary = gv!("(a(s(taya{sv}))a{sv})").cast(aligned);
+        let (refs_array, _metadata) = summary.to_tuple();
+
+        refs_array
+            .iter()
+            .map(|entry| {
+                let (name, ref_data) = entry.to_tuple();
+                let (_commit_size, checksum_bytes, _per_ref_metadata) = ref_data.to_tuple();
+                let checksum: Sha256Digest = checksum_bytes
+                    .try_into()
+                    .context("invalid checksum in summary")?;
+                Ok((name.to_str().to_string(), checksum))
+            })
+            .collect()
+    }
 }
 
 /// Parsed summary index (`summary.idx`) with lazy subset lookup.
@@ -248,10 +271,12 @@ fn read_summary_cache_header<ObjectID: FsVerityHashValue>(
 
     let etag = if etag_len > 0 {
         let mut buf = vec![0u8; etag_len];
-        reader
-            .read_inline_exact(&mut buf)
-            .context("reading etag")?;
-        Some(std::str::from_utf8(&buf).context("etag is not UTF-8")?.to_string())
+        reader.read_inline_exact(&mut buf).context("reading etag")?;
+        Some(
+            std::str::from_utf8(&buf)
+                .context("etag is not UTF-8")?
+                .to_string(),
+        )
     } else {
         None
     };
@@ -260,7 +285,11 @@ fn read_summary_cache_header<ObjectID: FsVerityHashValue>(
         reader
             .read_inline_exact(&mut buf)
             .context("reading last-modified")?;
-        Some(std::str::from_utf8(&buf).context("last-modified is not UTF-8")?.to_string())
+        Some(
+            std::str::from_utf8(&buf)
+                .context("last-modified is not UTF-8")?
+                .to_string(),
+        )
     } else {
         None
     };
@@ -286,9 +315,11 @@ fn open_cached_summary<ObjectID: FsVerityHashValue>(
     stream_id: &str,
 ) -> Result<Option<SplitStreamReader<ObjectID>>> {
     if repo.has_stream(stream_id)?.is_some() {
-        Ok(Some(
-            repo.open_stream(stream_id, None, Some(OSTREE_SUMMARY_CONTENT_TYPE))?,
-        ))
+        Ok(Some(repo.open_stream(
+            stream_id,
+            None,
+            Some(OSTREE_SUMMARY_CONTENT_TYPE),
+        )?))
     } else {
         Ok(None)
     }
@@ -331,6 +362,18 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
     pub fn with_summary_subset(mut self, subset: &str) -> Self {
         self.summary_subset = subset.to_string();
         self
+    }
+
+    /// List all refs available in the remote summary.
+    ///
+    /// Returns `(ref_name, commit_checksum)` pairs. Fetches and caches the
+    /// summary if not already loaded.
+    pub async fn list_remote_refs(&self) -> Result<Vec<(String, Sha256Digest)>> {
+        let cache = self
+            .load_summary()
+            .await?
+            .ok_or_else(|| anyhow!("no summary available from remote"))?;
+        cache.list_refs()
     }
 
     fn url_for(&self, segments: &[&str]) -> Url {

--- a/crates/composefs/src/fsverity/digest.rs
+++ b/crates/composefs/src/fsverity/digest.rs
@@ -3,7 +3,7 @@
 //! This module implements the fs-verity Merkle tree algorithm in userspace,
 //! allowing computation of fs-verity digests without kernel support.
 
-use core::{cmp::min, mem::size_of};
+use core::mem::size_of;
 
 use sha2::Digest;
 
@@ -54,6 +54,8 @@ pub struct FsVerityHasher<H: FsVerityHashValue, const LG_BLKSZ: u8 = 12> {
     layers: Vec<FsVerityLayer<H, LG_BLKSZ>>,
     value: Option<H>,
     n_bytes: u64,
+    partial: Vec<u8>,
+    wrote_final_block: bool,
 }
 
 impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
@@ -62,15 +64,10 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
 
     /// Hash a complete buffer and return the fs-verity digest.
     pub fn hash(buffer: &[u8]) -> H {
+        use std::io::Write;
+
         let mut hasher = Self::new();
-
-        let mut start = 0;
-        while start < buffer.len() {
-            let end = min(start + Self::BLOCK_SIZE, buffer.len());
-            hasher.add_block(&buffer[start..end]);
-            start = end;
-        }
-
+        hasher.write_all(buffer).expect("infallible write");
         hasher.digest()
     }
 
@@ -80,14 +77,30 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
             layers: vec![],
             value: None,
             n_bytes: 0,
+            partial: Vec::with_capacity(Self::BLOCK_SIZE),
+            wrote_final_block: false,
         }
     }
 
-    /// Add a block of data to the hasher.
+    fn add_block_from_partial(&mut self) {
+        let block = std::mem::replace(&mut self.partial, Vec::with_capacity(Self::BLOCK_SIZE));
+        self.add_block(&block);
+    }
+
+    /// Add a complete block of data to the hasher.
     ///
-    /// For correct results, data should be provided in block-sized chunks (4KB)
-    /// except for the final chunk which may be smaller.
+    /// The data must be exactly `BLOCK_SIZE` bytes, except for the
+    /// final block which may be smaller. Prefer the [`std::io::Write`]
+    /// impl which handles buffering automatically.
     pub fn add_block(&mut self, data: &[u8]) {
+        assert!(
+            !self.wrote_final_block,
+            "cannot add data after a partial block"
+        );
+        if data.len() < Self::BLOCK_SIZE {
+            self.wrote_final_block = true;
+        }
+
         if let Some(value) = self.value.take() {
             // We had a complete value, but now we're adding new data.
             // This means that we need to add a new hash layer...
@@ -143,8 +156,11 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
 
     /// Finalize and return the fs-verity digest.
     ///
-    /// This consumes any remaining partial data and computes the final digest.
+    /// Flushes any buffered partial block and computes the final digest.
     pub fn digest(&mut self) -> H {
+        if !self.partial.is_empty() {
+            self.add_block_from_partial();
+        }
         /*
         let mut root_hash = [0u8; 64];
         let result = self.root_hash();
@@ -179,6 +195,27 @@ impl<H: FsVerityHashValue, const LG_BLKSZ: u8> FsVerityHasher<H, LG_BLKSZ> {
         context.update([0; 32]); /* salt */
         context.update([0; 144]); /* reserved */
         context.finalize().into()
+    }
+}
+
+impl<H: FsVerityHashValue, const LG_BLKSZ: u8> std::io::Write for FsVerityHasher<H, LG_BLKSZ> {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        let len = data.len();
+        let mut remaining = data;
+        while !remaining.is_empty() {
+            let space = Self::BLOCK_SIZE - self.partial.len();
+            let n = remaining.len().min(space);
+            self.partial.extend_from_slice(&remaining[..n]);
+            remaining = &remaining[n..];
+            if self.partial.len() == Self::BLOCK_SIZE {
+                self.add_block_from_partial();
+            }
+        }
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
     }
 }
 

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -1558,10 +1558,9 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
                 if buf.is_empty() {
                     break;
                 }
-                let chunk = &buf[..buf.len().min(FsVerityHasher::<ObjectID>::BLOCK_SIZE)];
-                hasher.add_block(chunk);
-                dst.write_all(chunk)?;
-                let n = chunk.len();
+                hasher.write_all(buf)?;
+                dst.write_all(buf)?;
+                let n = buf.len();
                 src.consume(n);
             }
             drop(dst);
@@ -1940,10 +1939,9 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
             if buf.is_empty() {
                 break;
             }
-            // add_block expects at most one block at a time
-            let chunk_size = buf.len().min(FsVerityHasher::<ObjectID>::BLOCK_SIZE);
-            hasher.add_block(&buf[..chunk_size]);
-            reader.consume(chunk_size);
+            hasher.write_all(buf)?;
+            let n = buf.len();
+            reader.consume(n);
         }
 
         Ok(hasher.digest())


### PR DESCRIPTION
This adds some fixes and cleanups to the ostree support, adds a list-refs command, and then adds support for ostree summaries and static deltas.

Also, there is a fix to FsVerityHasher that may be important to non-ostree users as well.