### PR TITLE
Even more ostree work

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -513,6 +513,9 @@ enum OstreeCommand {
         ostree_ref: String,
         #[clap(long)]
         base_name: Option<String>,
+        /// Disable static delta usage, forcing object-by-object fetching
+        #[clap(long)]
+        no_delta: bool,
     },
     /// Mount an ostree commit's composefs EROFS at the given mountpoint
     Mount {
@@ -1721,6 +1724,7 @@ where
                 let opts = composefs_ostree::PullOptions {
                     base_reference: base_name.as_deref(),
                     progress: Some(reporter),
+                    ..Default::default()
                 };
                 let (verity, stats) =
                     composefs_ostree::pull(&repo, ostree_repo, ostree_ref, opts).await?;
@@ -1738,12 +1742,14 @@ where
                 ref ostree_repo_url,
                 ref ostree_ref,
                 base_name,
+                no_delta,
             } => {
                 let ostree_repo = composefs_ostree::RemoteRepo::new(&repo, ostree_repo_url)?;
                 let reporter: SharedReporter = IndicatifReporter::new().into_shared();
                 let opts = composefs_ostree::PullOptions {
                     base_reference: base_name.as_deref(),
                     progress: Some(reporter),
+                    disable_deltas: no_delta,
                 };
                 let (verity, stats) =
                     composefs_ostree::pull(&repo, ostree_repo, ostree_ref, opts).await?;

--- a/crates/composefs-ostree/src/commit.rs
+++ b/crates/composefs-ostree/src/commit.rs
@@ -109,10 +109,6 @@ pub(crate) struct CommitWriter<ObjectID: FsVerityHashValue> {
     map: Vec<WriterEntry<ObjectID>>,
 }
 
-fn align8(x: usize) -> usize {
-    (x + 7) & !7
-}
-
 impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
     pub fn new() -> Self {
         CommitWriter {
@@ -210,7 +206,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
             .iter()
             .map(|e| {
                 let offset = data_size;
-                data_size += align8(e.data.len());
+                data_size += e.data.len().next_multiple_of(8);
                 offset
             })
             .collect();
@@ -256,7 +252,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
         const ZERO_PAD: [u8; 7] = [0; 7];
         for e in self.map.iter() {
             ss.write_inline(&e.data);
-            let padding = align8(e.data.len()) - e.data.len();
+            let padding = e.data.len().next_multiple_of(8) - e.data.len();
             if padding > 0 {
                 ss.write_inline(&ZERO_PAD[..padding]);
             }

--- a/crates/composefs-ostree/src/commit.rs
+++ b/crates/composefs-ostree/src/commit.rs
@@ -59,24 +59,32 @@ const NO_EXTERNAL_INDEX: u32 = u32::MAX;
 #[derive(Debug, FromBytes, Immutable, IntoBytes, KnownLayout, Clone)]
 #[repr(C)]
 struct DataRef {
-    offset: u32,
+    /// Byte offset into the content region, divided by 8 (the alignment).
+    data_block: u32,
     size: u32,
     external_index: u32,
 }
 
 impl DataRef {
-    pub fn new(offset: usize, size: usize, external_index: Option<usize>) -> Self {
-        DataRef {
-            offset: u32::to_le(offset as u32),
-            size: u32::to_le(size as u32),
+    pub fn new(offset: usize, size: usize, external_index: Option<usize>) -> Result<Self> {
+        ensure!(
+            offset.is_multiple_of(8),
+            "data offset {offset} is not 8-byte aligned"
+        );
+        let block = u32::try_from(offset / 8)
+            .map_err(|_| anyhow!("data offset {offset} exceeds 32 GB limit"))?;
+        let size = u32::try_from(size).map_err(|_| anyhow!("data size {size} exceeds u32::MAX"))?;
+        Ok(DataRef {
+            data_block: u32::to_le(block),
+            size: u32::to_le(size),
             external_index: u32::to_le(match external_index {
                 Some(idx) => idx as u32,
                 None => NO_EXTERNAL_INDEX,
             }),
-        }
+        })
     }
     pub fn get_offset(&self) -> usize {
-        u32::from_le(self.offset) as usize
+        u32::from_le(self.data_block) as usize * 8
     }
     pub fn get_size(&self) -> usize {
         u32::from_le(self.size) as usize
@@ -211,11 +219,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
             })
             .collect();
 
-        // Ensure all data can be indexed by u32
-        ensure!(
-            data_size <= u32::MAX as usize,
-            "Too large data in object map"
-        );
+        // DataRef::new() validates that offsets fit in u32 (as offset/8)
 
         // Compute bucket ends
         for e in self.map.iter() {
@@ -244,7 +248,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
                 .external_object
                 .as_ref()
                 .map(|external_object| ss.add_object_ref(external_object));
-            let d = DataRef::new(offset, e.data.len(), idx);
+            let d = DataRef::new(offset, e.data.len(), idx)?;
             ss.write_inline(d.as_bytes());
         }
 

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -101,15 +101,23 @@ fn gv_offset_size(container_size: u64) -> usize {
     }
 }
 
-fn gv_read_offset(data: &[u8], osz: usize, index: usize) -> u64 {
-    let start = index * osz;
-    match osz {
-        1 => data[start] as u64,
-        2 => u16::from_le_bytes(data[start..start + 2].try_into().unwrap()) as u64,
-        4 => u32::from_le_bytes(data[start..start + 4].try_into().unwrap()) as u64,
-        8 => u64::from_le_bytes(data[start..start + 8].try_into().unwrap()),
+fn gv_read_offset(data: &[u8], osz: usize, index: usize) -> Result<u64> {
+    let start = index
+        .checked_mul(osz)
+        .ok_or_else(|| anyhow!("offset index overflow"))?;
+    let end = start
+        .checked_add(osz)
+        .ok_or_else(|| anyhow!("offset end overflow"))?;
+    let slice = data
+        .get(start..end)
+        .ok_or_else(|| anyhow!("offset {start}..{end} out of range (len={})", data.len()))?;
+    Ok(match osz {
+        1 => slice[0] as u64,
+        2 => u16::from_le_bytes(slice.try_into().unwrap()) as u64,
+        4 => u32::from_le_bytes(slice.try_into().unwrap()) as u64,
+        8 => u64::from_le_bytes(slice.try_into().unwrap()),
         _ => 0,
-    }
+    })
 }
 
 // ---------- Superblock parser ----------
@@ -135,9 +143,8 @@ struct SuperblockChildRanges {
 fn compute_child_ranges(
     total_size: u64,
     frame_offsets: &[u64; N_FRAME_OFFSETS],
-) -> SuperblockChildRanges {
-    // Map: for each variable-size child (0,2,3,4,5,6,7), what frame offset index?
-    // var_children: [(child_index, frame_offset_index_for_end)]
+) -> Result<SuperblockChildRanges> {
+    // Frame offset index to child mapping:
     // child 0: end = fo[0]
     // child 1: fixed, 8 bytes
     // child 2: end = fo[1]
@@ -148,7 +155,9 @@ fn compute_child_ranges(
     // child 7: end = total_size - n_frame_offsets * osz (LAST)
 
     let osz = gv_offset_size(total_size) as u64;
-    let data_end = total_size - N_FRAME_OFFSETS as u64 * osz;
+    let data_end = total_size
+        .checked_sub(N_FRAME_OFFSETS as u64 * osz)
+        .ok_or_else(|| anyhow!("superblock too small for frame offsets"))?;
 
     let mut ranges = [(0u64, 0u64); N_SUPERBLOCK_CHILDREN];
 
@@ -157,34 +166,30 @@ fn compute_child_ranges(
 
     // Child 1: t (fixed 8 bytes), starts after child 0 aligned to 8
     let start_1 = frame_offsets[0].next_multiple_of(8);
-    ranges[1] = (start_1, start_1 + 8);
+    ranges[1] = (
+        start_1,
+        start_1.checked_add(8).ok_or_else(|| anyhow!("overflow"))?,
+    );
 
     // Child 2: ay, starts after child 1 (no alignment needed for ay)
-    let start_2 = ranges[1].1;
-    ranges[2] = (start_2, frame_offsets[1]);
+    ranges[2] = (ranges[1].1, frame_offsets[1]);
 
     // Child 3: ay, starts after child 2
-    let start_3 = frame_offsets[1];
-    ranges[3] = (start_3, frame_offsets[2]);
+    ranges[3] = (frame_offsets[1], frame_offsets[2]);
 
     // Child 4: commit tuple, starts after child 3 aligned to 8
-    let start_4 = frame_offsets[2].next_multiple_of(8);
-    ranges[4] = (start_4, frame_offsets[3]);
+    ranges[4] = (frame_offsets[2].next_multiple_of(8), frame_offsets[3]);
 
     // Child 5: ay, starts after child 4
-    let start_5 = frame_offsets[3];
-    ranges[5] = (start_5, frame_offsets[4]);
+    ranges[5] = (frame_offsets[3], frame_offsets[4]);
 
     // Child 6: a(uayttay), starts after child 5 aligned to 8
-    let start_6 = frame_offsets[4].next_multiple_of(8);
-    ranges[6] = (start_6, frame_offsets[5]);
+    ranges[6] = (frame_offsets[4].next_multiple_of(8), frame_offsets[5]);
 
-    // Child 7: a(yaytt), starts after child 6 (1-byte alignment for outer `a`)
-    // Actually a(yaytt) elements contain `t` so alignment is 8
-    let start_7 = frame_offsets[5].next_multiple_of(8);
-    ranges[7] = (start_7, data_end);
+    // Child 7: a(yaytt), elements contain `t` so alignment is 8
+    ranges[7] = (frame_offsets[5].next_multiple_of(8), data_end);
 
-    SuperblockChildRanges { ranges }
+    Ok(SuperblockChildRanges { ranges })
 }
 
 /// Reads a byte range from a file descriptor via pread.
@@ -242,29 +247,34 @@ impl MetadataDictIndex {
         let osz = gv_offset_size(dict_size);
 
         // Read the last offset to find last_end (end of data / start of offset table)
-        let last_ofs_buf = source.read_range(
-            file_offset + dict_size - osz as u64,
-            file_offset + dict_size,
-        )?;
-        let last_end = gv_read_offset(&last_ofs_buf, osz, 0);
+        let last_ofs_start = file_offset
+            .checked_add(dict_size)
+            .and_then(|v| v.checked_sub(osz as u64))
+            .ok_or_else(|| anyhow!("metadata dict offset overflow"))?;
+        let last_ofs_buf = source.read_range(last_ofs_start, file_offset + dict_size)?;
+        let last_end = gv_read_offset(&last_ofs_buf, osz, 0)?;
 
-        let offset_table_size = dict_size as usize - last_end as usize - osz;
+        let offset_table_size = (dict_size as usize)
+            .checked_sub(last_end as usize)
+            .and_then(|v| v.checked_sub(osz))
+            .ok_or_else(|| anyhow!("metadata dict offset table overflow"))?;
         let n_entries = offset_table_size.checked_div(osz).map_or(0, |n| n + 1);
 
         // Read the full offset table (small)
-        let offsets_buf = source.read_range(
-            file_offset + last_end,
-            file_offset + last_end + (offset_table_size + osz) as u64,
-        )?;
+        let table_end = file_offset
+            .checked_add(last_end)
+            .and_then(|v| v.checked_add((offset_table_size + osz) as u64))
+            .ok_or_else(|| anyhow!("offset table range overflow"))?;
+        let offsets_buf = source.read_range(file_offset + last_end, table_end)?;
 
         // Read each entry's key string (short, NUL-terminated at start of entry)
         let mut entries = Vec::with_capacity(n_entries);
         for i in 0..n_entries {
-            let end = gv_read_offset(&offsets_buf, osz, i).min(last_end);
+            let end = gv_read_offset(&offsets_buf, osz, i)?.min(last_end);
             let start = if i == 0 {
                 0u64
             } else {
-                gv_read_offset(&offsets_buf, osz, i - 1).next_multiple_of(8)
+                gv_read_offset(&offsets_buf, osz, i - 1)?.next_multiple_of(8)
             };
             if end <= start {
                 continue;
@@ -373,10 +383,16 @@ impl DeltaSuperblock {
                 // Signed format (taya{sv}): child 0 is fixed (t=8 bytes),
                 // child 1 (ay) has one frame offset, child 2 (a{sv}) is LAST.
                 let osz = gv_offset_size(total_size);
-                let fo_buf = source.read_range(total_size - osz as u64, total_size)?;
+                let fo_start = total_size
+                    .checked_sub(osz as u64)
+                    .ok_or_else(|| anyhow!("signed delta too small"))?;
+                let fo_buf = source.read_range(fo_start, total_size)?;
                 let sb_start = 8u64; // ay starts right after the fixed t
-                let sb_end = gv_read_offset(&fo_buf, osz, 0);
-                (sb_start, sb_end - sb_start)
+                let sb_end = gv_read_offset(&fo_buf, osz, 0)?;
+                let sb_size = sb_end
+                    .checked_sub(sb_start)
+                    .ok_or_else(|| anyhow!("signed delta superblock range invalid"))?;
+                (sb_start, sb_size)
             } else {
                 (0, total_size)
             }
@@ -395,20 +411,30 @@ impl DeltaSuperblock {
             variant_size >= fo_size,
             "superblock too small for frame offsets"
         );
-        let fo_buf = source.read_range(
-            base_offset + variant_size - fo_size,
-            base_offset + variant_size,
-        )?;
+        let fo_start = base_offset + variant_size - fo_size;
+        let fo_end = base_offset + variant_size;
+        let fo_buf = source.read_range(fo_start, fo_end)?;
 
-        let frame_offsets: [u64; N_FRAME_OFFSETS] =
-            std::array::from_fn(|i| gv_read_offset(&fo_buf, osz, N_FRAME_OFFSETS - 1 - i));
+        let frame_offsets: [u64; N_FRAME_OFFSETS] = (0..N_FRAME_OFFSETS)
+            .map(|i| gv_read_offset(&fo_buf, osz, N_FRAME_OFFSETS - 1 - i))
+            .collect::<Result<Vec<_>>>()?
+            .try_into()
+            .unwrap();
 
-        let children = compute_child_ranges(variant_size, &frame_offsets);
+        let children = compute_child_ranges(variant_size, &frame_offsets)?;
 
         // Cache the metadata dict offset table and key strings
         let (meta_start, meta_end) = children.ranges[0];
-        let metadata_index =
-            MetadataDictIndex::load(&source, base_offset + meta_start, meta_end - meta_start)?;
+        let meta_size = meta_end
+            .checked_sub(meta_start)
+            .ok_or_else(|| anyhow!("metadata child range invalid"))?;
+        let metadata_index = MetadataDictIndex::load(
+            &source,
+            base_offset
+                .checked_add(meta_start)
+                .ok_or_else(|| anyhow!("metadata offset overflow"))?,
+            meta_size,
+        )?;
 
         let swap_endian = Self::detect_endianness(&source, &metadata_index)?;
 
@@ -444,8 +470,15 @@ impl DeltaSuperblock {
 
     fn read_child(&self, index: usize) -> Result<Vec<u8>> {
         let (start, end) = self.children.ranges[index];
-        self.source
-            .read_range(self.base_offset + start, self.base_offset + end)
+        let abs_start = self
+            .base_offset
+            .checked_add(start)
+            .ok_or_else(|| anyhow!("child offset overflow"))?;
+        let abs_end = self
+            .base_offset
+            .checked_add(end)
+            .ok_or_else(|| anyhow!("child offset overflow"))?;
+        self.source.read_range(abs_start, abs_end)
     }
 
     fn read_child_aligned(&self, index: usize) -> Result<AlignedBuf> {
@@ -906,9 +939,13 @@ fn dispatch_write(state: &mut DeltaExecState) -> Result<()> {
 
     if let Some(ref source) = state.read_source {
         let start = content_offset as usize;
-        let end = start + content_size as usize;
-        ensure!(end <= source.len(), "read_source offset out of range");
-        state.content_buf.extend_from_slice(&source[start..end]);
+        let end = start
+            .checked_add(content_size as usize)
+            .ok_or_else(|| anyhow!("read_source offset overflow"))?;
+        let slice = source
+            .get(start..end)
+            .ok_or_else(|| anyhow!("read_source range {start}..{end} out of bounds"))?;
+        state.content_buf.extend_from_slice(slice);
     } else {
         let data = state.payload_slice(content_offset, content_size)?;
         state.content_buf.extend_from_slice(data);
@@ -923,11 +960,14 @@ fn dispatch_set_read_source<ObjectID: FsVerityHashValue>(
     state: &mut DeltaExecState,
 ) -> Result<()> {
     let source_offset = state.read_varuint()? as usize;
-    ensure!(
-        source_offset + 32 <= state.payload.len(),
-        "read source checksum offset out of range"
-    );
-    let checksum: Sha256Digest = state.payload[source_offset..source_offset + 32]
+    let csum_end = source_offset
+        .checked_add(32)
+        .ok_or_else(|| anyhow!("read source offset overflow"))?;
+    let csum_slice = state
+        .payload
+        .get(source_offset..csum_end)
+        .ok_or_else(|| anyhow!("read source checksum out of range"))?;
+    let checksum: Sha256Digest = csum_slice
         .try_into()
         .map_err(|_| anyhow!("bad read source checksum"))?;
 
@@ -952,7 +992,9 @@ fn dispatch_set_read_source<ObjectID: FsVerityHashValue>(
         // Inline content: everything after the zlib-sized header
         let header_size = std::mem::size_of::<crate::ostree::SizedVariantHeader>();
         let variant_size = crate::ostree::get_sized_variant_size(file_header_data)?;
-        let content_start = header_size + variant_size;
+        let content_start = header_size
+            .checked_add(variant_size)
+            .ok_or_else(|| anyhow!("file header offset overflow"))?;
         let content = file_header_data.get(content_start..).unwrap_or(&[]);
         state.read_source = Some(content.to_vec());
     }
@@ -1325,37 +1367,43 @@ mod tests {
     #[test]
     fn test_gv_read_offset_u8() {
         let data = [10, 20, 30];
-        assert_eq!(gv_read_offset(&data, 1, 0), 10);
-        assert_eq!(gv_read_offset(&data, 1, 1), 20);
-        assert_eq!(gv_read_offset(&data, 1, 2), 30);
+        assert_eq!(gv_read_offset(&data, 1, 0).unwrap(), 10);
+        assert_eq!(gv_read_offset(&data, 1, 1).unwrap(), 20);
+        assert_eq!(gv_read_offset(&data, 1, 2).unwrap(), 30);
     }
 
     #[test]
     fn test_gv_read_offset_u16() {
         let data = 0x1234u16.to_le_bytes();
-        assert_eq!(gv_read_offset(&data, 2, 0), 0x1234);
+        assert_eq!(gv_read_offset(&data, 2, 0).unwrap(), 0x1234);
     }
 
     #[test]
     fn test_gv_read_offset_u32() {
         let data = 0xDEAD_BEEFu32.to_le_bytes();
-        assert_eq!(gv_read_offset(&data, 4, 0), 0xDEAD_BEEF);
+        assert_eq!(gv_read_offset(&data, 4, 0).unwrap(), 0xDEAD_BEEF);
     }
 
     #[test]
     fn test_gv_read_offset_u64() {
         let data = 0x0123_4567_89AB_CDEFu64.to_le_bytes();
-        assert_eq!(gv_read_offset(&data, 8, 0), 0x0123_4567_89AB_CDEF);
+        assert_eq!(gv_read_offset(&data, 8, 0).unwrap(), 0x0123_4567_89AB_CDEF);
     }
 
     #[test]
     fn test_gv_read_offset_multiple() {
-        // Two u16 offsets: 100, 200
         let mut data = vec![];
         data.extend_from_slice(&100u16.to_le_bytes());
         data.extend_from_slice(&200u16.to_le_bytes());
-        assert_eq!(gv_read_offset(&data, 2, 0), 100);
-        assert_eq!(gv_read_offset(&data, 2, 1), 200);
+        assert_eq!(gv_read_offset(&data, 2, 0).unwrap(), 100);
+        assert_eq!(gv_read_offset(&data, 2, 1).unwrap(), 200);
+    }
+
+    #[test]
+    fn test_gv_read_offset_out_of_bounds() {
+        let data = [10];
+        assert!(gv_read_offset(&data, 2, 0).is_err());
+        assert!(gv_read_offset(&data, 1, 1).is_err());
     }
 
     // --- checksum_to_b64 ---

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -1237,8 +1237,202 @@ fn inherit_file<ObjectID: FsVerityHashValue>(
     if writer.contains(id) {
         return Ok(());
     }
+
     if let Some((obj_id, file_header)) = base.lookup(id)? {
         writer.insert(id, obj_id, file_header);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- read_varuint64 ---
+
+    #[test]
+    fn test_varuint_single_byte() {
+        let data = [0x00];
+        let mut pos = 0;
+        assert_eq!(read_varuint64(&data, &mut pos).unwrap(), 0);
+        assert_eq!(pos, 1);
+    }
+
+    #[test]
+    fn test_varuint_max_single_byte() {
+        let data = [0x7F];
+        let mut pos = 0;
+        assert_eq!(read_varuint64(&data, &mut pos).unwrap(), 127);
+        assert_eq!(pos, 1);
+    }
+
+    #[test]
+    fn test_varuint_two_bytes() {
+        // 300 = 0b100101100 → [0xAC, 0x02]
+        let data = [0xAC, 0x02];
+        let mut pos = 0;
+        assert_eq!(read_varuint64(&data, &mut pos).unwrap(), 300);
+        assert_eq!(pos, 2);
+    }
+
+    #[test]
+    fn test_varuint_large() {
+        // 16384 = 0x4000 → [0x80, 0x80, 0x01]
+        let data = [0x80, 0x80, 0x01];
+        let mut pos = 0;
+        assert_eq!(read_varuint64(&data, &mut pos).unwrap(), 16384);
+        assert_eq!(pos, 3);
+    }
+
+    #[test]
+    fn test_varuint_with_offset() {
+        let data = [0xFF, 0x05, 0x00];
+        let mut pos = 1;
+        assert_eq!(read_varuint64(&data, &mut pos).unwrap(), 5);
+        assert_eq!(pos, 2);
+    }
+
+    #[test]
+    fn test_varuint_truncated() {
+        let data = [0x80]; // continuation bit set but no next byte
+        let mut pos = 0;
+        assert!(read_varuint64(&data, &mut pos).is_err());
+    }
+
+    #[test]
+    fn test_varuint_empty() {
+        let data = [];
+        let mut pos = 0;
+        assert!(read_varuint64(&data, &mut pos).is_err());
+    }
+
+    // --- gv_offset_size ---
+
+    #[test]
+    fn test_gv_offset_size() {
+        assert_eq!(gv_offset_size(0), 0);
+        assert_eq!(gv_offset_size(1), 1);
+        assert_eq!(gv_offset_size(0xFF), 1);
+        assert_eq!(gv_offset_size(0x100), 2);
+        assert_eq!(gv_offset_size(0xFFFF), 2);
+        assert_eq!(gv_offset_size(0x1_0000), 4);
+        assert_eq!(gv_offset_size(0xFFFF_FFFF), 4);
+        assert_eq!(gv_offset_size(0x1_0000_0000), 8);
+    }
+
+    // --- gv_read_offset ---
+
+    #[test]
+    fn test_gv_read_offset_u8() {
+        let data = [10, 20, 30];
+        assert_eq!(gv_read_offset(&data, 1, 0), 10);
+        assert_eq!(gv_read_offset(&data, 1, 1), 20);
+        assert_eq!(gv_read_offset(&data, 1, 2), 30);
+    }
+
+    #[test]
+    fn test_gv_read_offset_u16() {
+        let data = 0x1234u16.to_le_bytes();
+        assert_eq!(gv_read_offset(&data, 2, 0), 0x1234);
+    }
+
+    #[test]
+    fn test_gv_read_offset_u32() {
+        let data = 0xDEAD_BEEFu32.to_le_bytes();
+        assert_eq!(gv_read_offset(&data, 4, 0), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn test_gv_read_offset_u64() {
+        let data = 0x0123_4567_89AB_CDEFu64.to_le_bytes();
+        assert_eq!(gv_read_offset(&data, 8, 0), 0x0123_4567_89AB_CDEF);
+    }
+
+    #[test]
+    fn test_gv_read_offset_multiple() {
+        // Two u16 offsets: 100, 200
+        let mut data = vec![];
+        data.extend_from_slice(&100u16.to_le_bytes());
+        data.extend_from_slice(&200u16.to_le_bytes());
+        assert_eq!(gv_read_offset(&data, 2, 0), 100);
+        assert_eq!(gv_read_offset(&data, 2, 1), 200);
+    }
+
+    // --- checksum_to_b64 ---
+
+    #[test]
+    fn test_checksum_to_b64_known() {
+        // All zeros → known base64
+        let zeros = [0u8; 32];
+        let b64 = checksum_to_b64(&zeros);
+        assert_eq!(b64.len(), 43);
+        assert_eq!(b64, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    }
+
+    #[test]
+    fn test_checksum_to_b64_no_slash() {
+        // Ensure '/' is replaced with '_'
+        let csum = [0xFF; 32];
+        let b64 = checksum_to_b64(&csum);
+        assert!(!b64.contains('/'), "base64 should not contain '/'");
+        assert!(!b64.contains('='), "base64 should not contain '='");
+        assert_eq!(b64.len(), 43);
+    }
+
+    #[test]
+    fn test_checksum_to_b64_roundtrip() {
+        use base64::engine::general_purpose::STANDARD;
+        // Verify our encoding matches standard base64 (with / → _ and no padding)
+        let csum: Sha256Digest = [
+            0x49, 0x3e, 0xd6, 0x52, 0x12, 0x57, 0x01, 0x0b, 0xca, 0x52, 0x5c, 0xb6, 0x53, 0x0d,
+            0xcb, 0x27, 0xa9, 0xb2, 0x39, 0x1c, 0x6f, 0x73, 0x3d, 0x0b, 0x30, 0x44, 0x4c, 0x94,
+            0xdf, 0x0e, 0xa9, 0x0f,
+        ];
+        let our_b64 = checksum_to_b64(&csum);
+        let std_b64 = STANDARD
+            .encode(csum)
+            .replace('/', "_")
+            .trim_end_matches('=')
+            .to_string();
+        assert_eq!(our_b64, std_b64);
+    }
+
+    // --- delta_path ---
+
+    #[test]
+    fn test_delta_path_scratch() {
+        let to = [0u8; 32];
+        let path = delta_path(None, &to, "superblock");
+        let b64 = checksum_to_b64(&to);
+        assert_eq!(
+            path,
+            format!("deltas/{}/{}/superblock", &b64[..2], &b64[2..])
+        );
+    }
+
+    #[test]
+    fn test_delta_path_differential() {
+        let from = [1u8; 32];
+        let to = [2u8; 32];
+        let path = delta_path(Some(&from), &to, "superblock");
+        let from_b64 = checksum_to_b64(&from);
+        let to_b64 = checksum_to_b64(&to);
+        assert_eq!(
+            path,
+            format!(
+                "deltas/{}/{}-{}{}/superblock",
+                &from_b64[..2],
+                &from_b64[2..],
+                &to_b64[..2],
+                &to_b64[2..]
+            )
+        );
+    }
+
+    #[test]
+    fn test_delta_path_part() {
+        let to = [0u8; 32];
+        let path = delta_path(None, &to, "0");
+        assert!(path.ends_with("/0"));
+    }
 }

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -112,10 +112,6 @@ fn gv_read_offset(data: &[u8], osz: usize, index: usize) -> u64 {
     }
 }
 
-fn align_up(offset: u64, alignment: u64) -> u64 {
-    (offset + alignment - 1) & !(alignment - 1)
-}
-
 // ---------- Superblock parser ----------
 
 /// The superblock format `(a{sv}tayay(...)aya(uayttay)a(yaytt))` has 8 children.
@@ -160,7 +156,7 @@ fn compute_child_ranges(
     ranges[0] = (0, frame_offsets[0]);
 
     // Child 1: t (fixed 8 bytes), starts after child 0 aligned to 8
-    let start_1 = align_up(frame_offsets[0], 8);
+    let start_1 = frame_offsets[0].next_multiple_of(8);
     ranges[1] = (start_1, start_1 + 8);
 
     // Child 2: ay, starts after child 1 (no alignment needed for ay)
@@ -172,7 +168,7 @@ fn compute_child_ranges(
     ranges[3] = (start_3, frame_offsets[2]);
 
     // Child 4: commit tuple, starts after child 3 aligned to 8
-    let start_4 = align_up(frame_offsets[2], 8);
+    let start_4 = frame_offsets[2].next_multiple_of(8);
     ranges[4] = (start_4, frame_offsets[3]);
 
     // Child 5: ay, starts after child 4
@@ -180,12 +176,12 @@ fn compute_child_ranges(
     ranges[5] = (start_5, frame_offsets[4]);
 
     // Child 6: a(uayttay), starts after child 5 aligned to 8
-    let start_6 = align_up(frame_offsets[4], 8);
+    let start_6 = frame_offsets[4].next_multiple_of(8);
     ranges[6] = (start_6, frame_offsets[5]);
 
     // Child 7: a(yaytt), starts after child 6 (1-byte alignment for outer `a`)
     // Actually a(yaytt) elements contain `t` so alignment is 8
-    let start_7 = align_up(frame_offsets[5], 8);
+    let start_7 = frame_offsets[5].next_multiple_of(8);
     ranges[7] = (start_7, data_end);
 
     SuperblockChildRanges { ranges }
@@ -268,7 +264,7 @@ impl MetadataDictIndex {
             let start = if i == 0 {
                 0u64
             } else {
-                align_up(gv_read_offset(&offsets_buf, osz, i - 1), 8)
+                gv_read_offset(&offsets_buf, osz, i - 1).next_multiple_of(8)
             };
             if end <= start {
                 continue;

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -820,6 +820,16 @@ fn dispatch_open_splice_and_close<ObjectID: FsVerityHashValue>(
         let content_len = state.read_varuint()? as usize;
         let content_offset = state.read_varuint()?;
         let data = state.payload_slice(content_offset, content_len as u64)?;
+
+        let actual = Sha256::digest(data);
+        if *actual != checksum {
+            bail!(
+                "metadata object checksum mismatch: expected {}, got {}",
+                hex::encode(checksum),
+                hex::encode(actual)
+            );
+        }
+
         writer.insert(&checksum, None, data);
     } else {
         // File object
@@ -1007,19 +1017,33 @@ fn dispatch_bspatch(state: &mut DeltaExecState) -> Result<()> {
 fn store_file_object<ObjectID: FsVerityHashValue>(
     repo: &Arc<Repository<ObjectID>>,
     writer: &mut CommitWriter<ObjectID>,
-    checksum: &Sha256Digest,
+    expected_checksum: &Sha256Digest,
     header: &OstreeFileHeader,
     content: &[u8],
 ) -> Result<()> {
+    // Verify the ostree content checksum: SHA-256(regular_header + content)
+    let regular_header = header.serialize_regular_sized();
+    let mut hasher = Sha256::new();
+    hasher.update(&*regular_header);
+    hasher.update(content);
+    let actual = hasher.finalize();
+    if *actual != *expected_checksum {
+        bail!(
+            "file object checksum mismatch: expected {}, got {}",
+            hex::encode(expected_checksum),
+            hex::encode(actual)
+        );
+    }
+
     let zlib_header = header.serialize_zlib_sized();
 
     if should_inline_file::<ObjectID>(content.len()) {
         let mut data = zlib_header;
         data.with_vec(|v| v.extend_from_slice(content));
-        writer.insert(checksum, None, &data);
+        writer.insert(expected_checksum, None, &data);
     } else {
         let obj_id = repo.ensure_object(content)?;
-        writer.insert(checksum, Some(&obj_id), &zlib_header);
+        writer.insert(expected_checksum, Some(&obj_id), &zlib_header);
     }
 
     Ok(())

--- a/crates/composefs-ostree/src/design.rs
+++ b/crates/composefs-ostree/src/design.rs
@@ -122,7 +122,7 @@
 //! ```text
 //!  n_objects x
 //! +-----------------------------------+
-//! | u32: Offset to per-object data    |
+//! | u32: data_block (byte offset / 8) |
 //! | u32: Length of per-object data    |
 //! | u32: Index of external object ref |
 //! |      or MAXUINT32 if none.        |
@@ -132,8 +132,10 @@
 //! This is an array of information for each object. Once you have found
 //! the object id in the object ids table, you would look at the same
 //! index in this table to find the information. Offsets to per-object
-//! data are in bytes from the start of the content area, which starts at
-//! the end of the Objects Info table. All data chunks references are
+//! data are stored divided by 8 (since all data is 8-byte aligned),
+//! allowing up to 32 GB of content to be addressed. The byte offset
+//! is relative to the start of the content area, which starts at
+//! the end of the Objects Info table. All data chunks are
 //! aligned to 8 bytes with respect to the start of the content area.
 //! This is useful because GVariants (used by ostree) naturally want
 //! 8-byte alignment.

--- a/crates/composefs-ostree/src/design.rs
+++ b/crates/composefs-ostree/src/design.rs
@@ -62,9 +62,9 @@
 //! All objects except file objects are stored in the standard ostree
 //! object format.
 //!
-//! OSTree file objects are stored in the archive-z2 format, except not
-//! compressed, and optionally the file content part of it may be stored
-//! as referencing the index of an external object. The z2 format is,
+//! OSTree file objects are stored an ostree object stream (i.e. header +
+//! content data), except the file content part may be stored
+//! by referencing the index of an external object. The object format is,
 //! first an 8-byte header that gives the size (in bytes) of a gvariant,
 //! then comes the gvariant with the file meta in
 //! OSTREE_ZLIB_FILE_HEADER_GVARIANT_FORMAT format, and then the
@@ -94,13 +94,13 @@
 //! content data and optionally a reference to an external object.
 //!
 //! The exact form of the data looks like this, packed in order from the
-//! start of the splitstream content. All ints are in little endian.
+//! start of the splitstream content. All numbers are in little endian.
 //!
 //! ### Header
 //! ```text
 //! +-----------------------------------+
 //! | u32: index of commit object       |
-//! | u32: flags (currently unused)      |
+//! | u32: flags (currently unused)     |
 //! | [u32; 256]: end index of bucket   |
 //! +-----------------------------------+
 //! ```
@@ -112,10 +112,10 @@
 //!
 //! ### Object ids
 //! ```text
-//!  n_objects x
-//! +-----------------------------------+
-//! |  [u8; 32] ostree object id        |
-//! +-----------------------------------+
+//!  n_objects x (sorted)
+//! +--------------------------------------------+
+//! |  [u8; 32] ostree object id (binary sha256) |
+//! +--------------------------------------------+
 //! ```
 //!
 //! ### Object Info
@@ -190,7 +190,7 @@
 //! ## Cache storage
 //!
 //! Cached summaries are stored as splitstreams in the composefs
-//! repository with content type `0x7972616d6d75736f` (`"osummary"` LE).
+//! repository with content type `0x7972616d6d75736f`.
 //! The splitstream inline data contains a fixed header, variable-length
 //! HTTP caching strings, and the raw summary GVariant bytes.
 //!

--- a/crates/composefs-ostree/src/lib.rs
+++ b/crates/composefs-ostree/src/lib.rs
@@ -59,6 +59,9 @@ pub struct PullOptions<'a> {
     ///
     /// When `None`, all progress events are silently discarded.
     pub progress: Option<SharedReporter>,
+
+    /// Disable static delta usage, forcing object-by-object fetching.
+    pub disable_deltas: bool,
 }
 
 impl std::fmt::Debug for PullOptions<'_> {
@@ -113,7 +116,9 @@ pub async fn pull<ObjectID: FsVerityHashValue>(
     };
 
     // Try delta pull first
-    if let Some((verity, stats)) = ostree_repo.try_pull_delta(repo, &commit_checksum).await? {
+    if !opts.disable_deltas
+        && let Some((verity, stats)) = ostree_repo.try_pull_delta(repo, &commit_checksum).await?
+    {
         reporter.report(ProgressEvent::Message("Using static delta".into()));
         if let Some(ref_name) = reference {
             repo.name_stream(&format!("ostree-commit-{}", stats.commit_id), &ref_name)?;

--- a/crates/composefs-ostree/src/ostree.rs
+++ b/crates/composefs-ostree/src/ostree.rs
@@ -3,7 +3,7 @@
 //! Defines the Rust representations of ostree objects (commits, directory
 //! trees, directory metadata, file headers) and their gvariant wire formats.
 
-use anyhow::{Result, anyhow};
+use anyhow::{Result, anyhow, bail};
 use gvariant::aligned_bytes::{A8, AlignedBuf, AlignedSlice, AsAligned, TryAsAligned};
 use gvariant::{Marker, Structure, gv};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
@@ -29,14 +29,14 @@ impl std::str::FromStr for RepoMode {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<RepoMode> {
-        match s {
-            "bare" => Ok(RepoMode::Bare),
-            "archive" | "archive-z2" => Ok(RepoMode::Archive),
-            "bare-user" => Ok(RepoMode::BareUser),
-            "bare-user-only" => Ok(RepoMode::BareUserOnly),
-            "bare-split-xattrs" => Ok(RepoMode::BareSplitXAttrs),
-            _ => Err(anyhow!("Unsupported repo mode {}", s)),
-        }
+        Ok(match s {
+            "bare" => RepoMode::Bare,
+            "archive" | "archive-z2" => RepoMode::Archive,
+            "bare-user" => RepoMode::BareUser,
+            "bare-user-only" => RepoMode::BareUserOnly,
+            "bare-split-xattrs" => RepoMode::BareSplitXAttrs,
+            _ => bail!("Unsupported repo mode {}", s),
+        })
     }
 }
 
@@ -65,17 +65,17 @@ pub enum ObjectType {
 impl ObjectType {
     /// Decode from the numeric value used in ostree's on-disk format.
     pub fn from_byte(b: u8) -> Result<Self> {
-        match b {
-            1 => Ok(ObjectType::File),
-            2 => Ok(ObjectType::DirTree),
-            3 => Ok(ObjectType::DirMeta),
-            4 => Ok(ObjectType::Commit),
-            5 => Ok(ObjectType::TombstoneCommit),
-            7 => Ok(ObjectType::PayloadLink),
-            8 => Ok(ObjectType::FileXAttrs),
-            9 => Ok(ObjectType::FileXAttrsLink),
-            _ => Err(anyhow!("Unknown object type {b}")),
-        }
+        Ok(match b {
+            1 => ObjectType::File,
+            2 => ObjectType::DirTree,
+            3 => ObjectType::DirMeta,
+            4 => ObjectType::Commit,
+            5 => ObjectType::TombstoneCommit,
+            7 => ObjectType::PayloadLink,
+            8 => ObjectType::FileXAttrs,
+            9 => ObjectType::FileXAttrsLink,
+            _ => bail!("Unknown object type {b}"),
+        })
     }
 
     /// Returns true for metadata object types (not file content).

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -126,7 +126,7 @@ pub trait OstreeRepo<ObjectID: FsVerityHashValue>: Send + Sync {
     }
 }
 
-const OSTREE_SUMMARY_CONTENT_TYPE: u64 = u64::from_le_bytes(*b"osummary");
+const OSTREE_SUMMARY_CONTENT_TYPE: u64 = 0x7972616D6D75736F;
 
 /// Fixed header for a cached summary splitstream blob.
 ///


### PR DESCRIPTION
This is mainly some cleanups from comments outstanding in previous MRs.

There is one real change, which is the changing of offsets in the commit splitstreams to be divided by 8. I think its fine to do this even though this is a format change. I don't think we're guaranteeing this to be stable yet.