### PR TITLE
cfsctl: Add shell completion support via clap_complete

### DIFF
--- a/crates/composefs-ctl/Cargo.toml
+++ b/crates/composefs-ctl/Cargo.toml
@@ -31,6 +31,7 @@ rhel9 = ['composefs/rhel9']
 anyhow = { version = "1.0.87", default-features = false }
 fn-error-context = "0.2"
 clap = { version = "4.5.0", default-features = false, features = ["std", "help", "usage", "derive", "wrap_help"] }
+clap_complete = { version = "4.5.0", default-features = false, features = ["unstable-dynamic"] }
 comfy-table = { version = "7.1", default-features = false }
 composefs = { workspace = true, features = ["varlink"] }
 composefs-boot = { workspace = true }

--- a/crates/composefs-ctl/cfsctl.bash-completion
+++ b/crates/composefs-ctl/cfsctl.bash-completion
@@ -1,0 +1,66 @@
+# Bash completion for cfsctl
+#
+# Install: source this file, or copy it to /etc/bash_completion.d/
+#
+# This script works around bash's COMP_WORDBREAKS splitting which
+# breaks values containing ':' (like docker:// image references).
+# It re-parses COMP_LINE so the full unsplit word reaches cfsctl's
+# dynamic completer, then trims the colon prefix from replies so
+# bash replaces the correct fragment on the command line.
+
+_clap_complete_cfsctl() {
+    local IFS=$'\013'
+    local _CLAP_COMPLETE_COMP_TYPE=${COMP_TYPE}
+    if compopt +o nospace 2> /dev/null; then
+        local _CLAP_COMPLETE_SPACE=false
+    else
+        local _CLAP_COMPLETE_SPACE=true
+    fi
+
+    # Split COMP_LINE on whitespace only, ignoring COMP_WORDBREAKS,
+    # so that docker://quay.io/foo:latest stays one word.
+    local line="${COMP_LINE:0:COMP_POINT}"
+    local -a words
+    IFS=$' \t\n' read -ra words <<< "$line"
+    if [[ "$line" =~ [[:space:]]$ ]]; then
+        words+=('')
+    fi
+    local cword=$(( ${#words[@]} - 1 ))
+
+    COMPREPLY=( $( \
+        _CLAP_IFS="$IFS" \
+        _CLAP_COMPLETE_INDEX="$cword" \
+        _CLAP_COMPLETE_COMP_TYPE="$_CLAP_COMPLETE_COMP_TYPE" \
+        _CLAP_COMPLETE_SPACE="$_CLAP_COMPLETE_SPACE" \
+        COMPLETE="bash" \
+        cfsctl -- "${words[@]}" \
+    ) )
+
+    if [[ $? != 0 ]]; then
+        unset COMPREPLY
+        return
+    fi
+
+    if [[ $_CLAP_COMPLETE_SPACE == false ]] && [[ "${COMPREPLY-}" =~ [=/:]$ ]]; then
+        compopt -o nospace
+    fi
+
+    # Bash already has everything up to the last COMP_WORDBREAKS
+    # character (: or =) on the command line.  Strip that prefix
+    # from COMPREPLY so bash replaces the right fragment.
+    local cur="${words[$cword]}"
+    if [[ "$cur" == *[:=]* ]]; then
+        local suffix="${cur##*[:=]}"
+        local wb_prefix="${cur%"$suffix"}"
+        local i
+        for (( i = 0; i < ${#COMPREPLY[@]}; i++ )); do
+            COMPREPLY[$i]="${COMPREPLY[$i]#"$wb_prefix"}"
+        done
+    fi
+}
+
+if [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 || "${BASH_VERSINFO[0]}" -gt 4 ]]; then
+    complete -o nospace -o bashdefault -o nosort -F _clap_complete_cfsctl cfsctl
+else
+    complete -o nospace -o bashdefault -F _clap_complete_cfsctl cfsctl
+fi

--- a/crates/composefs-ctl/src/complete.rs
+++ b/crates/composefs-ctl/src/complete.rs
@@ -1,0 +1,190 @@
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use clap_complete::engine::CompletionCandidate;
+use composefs::fsverity::{FsVerityHashValue, Sha256HashValue, Sha512HashValue};
+use composefs::repository::Repository;
+use rustix::fs::CWD;
+
+use crate::HashType;
+
+fn resolve_repo_for_completion() -> Option<(PathBuf, HashType)> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut repo_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--repo" => {
+                repo_path = args.get(i + 1).map(PathBuf::from);
+                i += 2;
+            }
+            _ if args[i].starts_with("--repo=") => {
+                repo_path = args[i].strip_prefix("--repo=").map(PathBuf::from);
+                i += 1;
+            }
+            "--user" => {
+                repo_path = composefs::repository::user_path().ok();
+                i += 1;
+            }
+            "--system" => {
+                repo_path = Some(composefs::repository::system_path());
+                i += 1;
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+    let repo_path = repo_path.or_else(|| crate::default_repo_path().ok())?;
+    let hash_type = crate::resolve_hash_type(&repo_path, None, false).ok()?;
+    Some((repo_path, hash_type))
+}
+
+/// Complete OCI image tag names from the active repository.
+#[cfg(feature = "oci")]
+pub fn complete_oci_tags(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Some((repo_path, hash_type)) = resolve_repo_for_completion() else {
+        return vec![];
+    };
+    match hash_type {
+        HashType::Sha256 => collect_oci::<Sha256HashValue>(&repo_path, current, true, false),
+        HashType::Sha512 => collect_oci::<Sha512HashValue>(&repo_path, current, true, false),
+    }
+}
+
+/// Complete OCI manifest digests from the active repository.
+#[cfg(feature = "oci")]
+pub fn complete_oci_digests(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Some((repo_path, hash_type)) = resolve_repo_for_completion() else {
+        return vec![];
+    };
+    match hash_type {
+        HashType::Sha256 => collect_oci::<Sha256HashValue>(&repo_path, current, false, true),
+        HashType::Sha512 => collect_oci::<Sha512HashValue>(&repo_path, current, false, true),
+    }
+}
+
+/// Complete OCI image tags and manifest digests from the active repository.
+#[cfg(feature = "oci")]
+pub fn complete_oci_tags_and_digests(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Some((repo_path, hash_type)) = resolve_repo_for_completion() else {
+        return vec![];
+    };
+    match hash_type {
+        HashType::Sha256 => collect_oci::<Sha256HashValue>(&repo_path, current, true, true),
+        HashType::Sha512 => collect_oci::<Sha512HashValue>(&repo_path, current, true, true),
+    }
+}
+
+#[cfg(feature = "oci")]
+fn collect_oci<ObjectID: FsVerityHashValue>(
+    repo_path: &Path,
+    prefix: &OsStr,
+    tags: bool,
+    digests: bool,
+) -> Vec<CompletionCandidate> {
+    let Some(repo) = Repository::<ObjectID>::open_path(CWD, repo_path).ok() else {
+        return vec![];
+    };
+    let Ok(images) = composefs_oci::oci_image::list_images(&repo) else {
+        return vec![];
+    };
+    let prefix = prefix.as_encoded_bytes();
+    let mut out = Vec::new();
+    for img in &images {
+        if tags && img.name.as_bytes().starts_with(prefix) {
+            out.push(CompletionCandidate::new(&img.name));
+        }
+        if digests {
+            let d: &str = img.manifest_digest.as_ref();
+            if d.as_bytes().starts_with(prefix) {
+                out.push(CompletionCandidate::new(d));
+            }
+        }
+    }
+    out
+}
+
+/// Complete ostree commit references from the active repository.
+#[cfg(feature = "ostree")]
+pub fn complete_ostree_refs(current: &OsStr) -> Vec<CompletionCandidate> {
+    let Some((repo_path, hash_type)) = resolve_repo_for_completion() else {
+        return vec![];
+    };
+    match hash_type {
+        HashType::Sha256 => collect_ostree_refs::<Sha256HashValue>(&repo_path, current),
+        HashType::Sha512 => collect_ostree_refs::<Sha512HashValue>(&repo_path, current),
+    }
+}
+
+#[cfg(feature = "ostree")]
+fn collect_ostree_refs<ObjectID: FsVerityHashValue>(
+    repo_path: &Path,
+    prefix: &OsStr,
+) -> Vec<CompletionCandidate> {
+    let Some(repo) = Repository::<ObjectID>::open_path(CWD, repo_path).ok() else {
+        return vec![];
+    };
+    let Ok(commits) = composefs_ostree::list_commits(&repo) else {
+        return vec![];
+    };
+    let prefix = prefix.as_encoded_bytes();
+    commits
+        .into_iter()
+        .filter(|c| c.name.as_bytes().starts_with(prefix))
+        .map(|c| CompletionCandidate::new(c.name))
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+enum RefKind {
+    Image,
+    Stream,
+}
+
+/// Complete image names (`refs/…`) from the active repository.
+pub fn complete_image_refs(current: &OsStr) -> Vec<CompletionCandidate> {
+    complete_refs(current, RefKind::Image)
+}
+
+/// Complete stream names (`refs/…`) from the active repository.
+pub fn complete_stream_refs(current: &OsStr) -> Vec<CompletionCandidate> {
+    complete_refs(current, RefKind::Stream)
+}
+
+fn complete_refs(current: &OsStr, kind: RefKind) -> Vec<CompletionCandidate> {
+    let Some((repo_path, hash_type)) = resolve_repo_for_completion() else {
+        return vec![];
+    };
+    match hash_type {
+        HashType::Sha256 => collect_refs::<Sha256HashValue>(&repo_path, current, kind),
+        HashType::Sha512 => collect_refs::<Sha512HashValue>(&repo_path, current, kind),
+    }
+}
+
+fn collect_refs<ObjectID: FsVerityHashValue>(
+    repo_path: &Path,
+    prefix: &OsStr,
+    kind: RefKind,
+) -> Vec<CompletionCandidate> {
+    let Some(repo) = Repository::<ObjectID>::open_path(CWD, repo_path).ok() else {
+        return vec![];
+    };
+    let refs = match kind {
+        RefKind::Image => repo.list_image_refs(""),
+        RefKind::Stream => repo.list_stream_refs(""),
+    };
+    let Ok(refs) = refs else {
+        return vec![];
+    };
+    let prefix = prefix.as_encoded_bytes();
+    refs.into_iter()
+        .filter_map(|(name, _)| {
+            let candidate = format!("refs/{name}");
+            candidate
+                .as_bytes()
+                .starts_with(prefix)
+                .then(|| CompletionCandidate::new(candidate))
+        })
+        .collect()
+}

--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -22,6 +22,8 @@ pub use composefs_http;
 #[cfg(feature = "oci")]
 pub use composefs_oci;
 
+/// Shell completion helpers for dynamic value completion via [`clap_complete`].
+pub mod complete;
 pub mod composefs_info;
 #[cfg(feature = "fuse")]
 pub mod fuse;
@@ -45,8 +47,14 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 use clap::{Parser, Subcommand, ValueEnum};
+use clap_complete::engine::ArgValueCompleter;
 #[cfg(any(feature = "oci", feature = "ostree"))]
 use comfy_table::{Table, presets::UTF8_FULL};
+#[cfg(feature = "ostree")]
+use complete::complete_ostree_refs;
+use complete::{complete_image_refs, complete_stream_refs};
+#[cfg(feature = "oci")]
+use complete::{complete_oci_digests, complete_oci_tags, complete_oci_tags_and_digests};
 #[cfg(any(feature = "oci", feature = "http", feature = "ostree"))]
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use rustix::fs::{CWD, Mode, OFlags};
@@ -169,7 +177,7 @@ impl ProgressReporter for IndicatifReporter {
 #[clap(name = "cfsctl", version)]
 pub struct App {
     /// Operate on repo at path
-    #[clap(long, group = "repopath")]
+    #[clap(long, group = "repopath", value_hint = clap::ValueHint::DirPath)]
     repo: Option<PathBuf>,
     /// Operate on repo at standard user location $HOME/.var/lib/composefs
     #[clap(long, group = "repopath")]
@@ -339,6 +347,7 @@ struct OCIConfigFilesystemOptions {
 #[derive(Debug, Parser)]
 struct OCIConfigOptions {
     /// Ref name (e.g. myimage:latest) or @digest (e.g. @sha256:a1b2c3...)
+    #[arg(add = ArgValueCompleter::new(complete_oci_tags_and_digests))]
     config_name: OciReference,
     /// verity digest for the manifest stream to be verified against
     config_verity: Option<String>,
@@ -397,6 +406,7 @@ enum OciCommand {
     #[clap(name = "inspect")]
     Inspect {
         /// Ref name (e.g. myimage:latest) or @digest (e.g. @sha256:a1b2c3...)
+        #[arg(add = ArgValueCompleter::new(complete_oci_tags_and_digests))]
         image: OciReference,
         /// Output only the raw manifest JSON (as originally stored)
         #[clap(long, conflicts_with = "config")]
@@ -410,6 +420,7 @@ enum OciCommand {
     /// Example: cfsctl oci tag sha256:a1b2c3... myimage:latest
     Tag {
         /// Manifest digest, e.g. sha256:a1b2c3...
+        #[arg(add = ArgValueCompleter::new(complete_oci_digests))]
         manifest_digest: composefs_oci::OciDigest,
         /// Tag name to assign (must not contain '@')
         name: String,
@@ -417,6 +428,7 @@ enum OciCommand {
     /// Remove a tag from an image
     Untag {
         /// Tag name to remove
+        #[arg(add = ArgValueCompleter::new(complete_oci_tags))]
         name: String,
     },
     /// Inspect a stored layer
@@ -437,8 +449,10 @@ enum OciCommand {
     /// Mount an OCI image's composefs EROFS at the given mountpoint
     Mount {
         /// Image reference (tag name or manifest digest)
+        #[arg(add = ArgValueCompleter::new(complete_oci_tags_and_digests))]
         image: String,
         /// Target mountpoint
+        #[arg(value_hint = clap::ValueHint::AnyPath)]
         mountpoint: String,
         /// Mount the bootable variant instead of the regular EROFS image
         #[arg(long)]
@@ -464,7 +478,7 @@ enum OciCommand {
         #[clap(flatten)]
         config_opts: OCIConfigOptions,
         /// boot partition mount point
-        #[clap(long, default_value = "/boot")]
+        #[clap(long, default_value = "/boot", value_hint = clap::ValueHint::DirPath)]
         bootdir: PathBuf,
         /// Boot entry identifier to use. By default uses ID provided by the image or kernel version
         #[clap(long)]
@@ -480,6 +494,7 @@ enum OciCommand {
     /// integrity and splitstream validation.
     Fsck {
         /// Check only the named image instead of all tagged images
+        #[arg(add = ArgValueCompleter::new(complete_oci_tags))]
         image: Option<String>,
         /// Output results as JSON (always exits 0 unless the check itself fails)
         #[clap(long)]
@@ -492,7 +507,7 @@ enum OciCommand {
     /// socket. Kept for discoverability under the `oci` subcommand.
     Varlink {
         /// Unix socket path to listen on (omit when using systemd socket activation).
-        #[clap(long)]
+        #[clap(long, value_hint = clap::ValueHint::AnyPath)]
         address: Option<PathBuf>,
     },
 }
@@ -501,6 +516,7 @@ enum OciCommand {
 #[derive(Debug, Subcommand)]
 enum OstreeCommand {
     PullLocal {
+        #[arg(value_hint = clap::ValueHint::DirPath)]
         ostree_repo_path: PathBuf,
         /// Ostree ref name or commit ID (64-character hex)
         ostree_ref: String,
@@ -508,6 +524,7 @@ enum OstreeCommand {
         base_name: Option<String>,
     },
     Pull {
+        #[arg(value_hint = clap::ValueHint::Url)]
         ostree_repo_url: String,
         /// Ostree ref name or commit ID (64-character hex)
         ostree_ref: String,
@@ -517,8 +534,10 @@ enum OstreeCommand {
     /// Mount an ostree commit's composefs EROFS at the given mountpoint
     Mount {
         /// Ostree commit ref or commit ID
+        #[arg(add = ArgValueCompleter::new(complete_ostree_refs))]
         commit: String,
         /// Target mountpoint
+        #[arg(value_hint = clap::ValueHint::AnyPath)]
         mountpoint: String,
         #[clap(flatten)]
         mount_opts: MountOpts,
@@ -526,16 +545,19 @@ enum OstreeCommand {
     /// Dump the filesystem of an ostree commit as a composefs dumpfile to stdout
     Dump {
         /// Ostree commit ref name
+        #[arg(add = ArgValueCompleter::new(complete_ostree_refs))]
         commit_name: String,
     },
     /// Compute the composefs image ID of an ostree commit
     ComputeId {
         /// Ostree commit ref name
+        #[arg(add = ArgValueCompleter::new(complete_ostree_refs))]
         commit_name: String,
     },
     /// Show the contents of an ostree commit
     Inspect {
         /// Ostree ref name, commit ID, or commit ID prefix
+        #[arg(add = ArgValueCompleter::new(complete_ostree_refs))]
         source: String,
         /// Print only the commit metadata key-value pairs
         #[clap(long)]
@@ -546,6 +568,7 @@ enum OstreeCommand {
     /// The source can be an ostree commit checksum or an existing ref name.
     Tag {
         /// Ostree commit checksum (hex) or existing ref name
+        #[arg(add = ArgValueCompleter::new(complete_ostree_refs))]
         source: String,
         /// Tag name to assign
         name: String,
@@ -553,6 +576,7 @@ enum OstreeCommand {
     /// Remove a named ostree reference
     Untag {
         /// Tag name to remove
+        #[arg(add = ArgValueCompleter::new(complete_ostree_refs))]
         name: String,
     },
     /// List all ostree commits in the repository
@@ -561,11 +585,13 @@ enum OstreeCommand {
     /// Apply a static delta to the repository
     ApplyDelta {
         /// Path to the delta file (single-file) or superblock
+        #[arg(value_hint = clap::ValueHint::FilePath)]
         delta_path: PathBuf,
     },
     /// List refs available in a remote ostree repository
     ListRefs {
         /// URL of the remote ostree repository
+        #[arg(value_hint = clap::ValueHint::Url)]
         ostree_repo_url: String,
         /// Summary index subset key (defaults to system architecture)
         #[clap(long)]
@@ -577,6 +603,7 @@ enum OstreeCommand {
 #[derive(Debug, Parser)]
 struct FsReadOptions {
     /// The path to the filesystem
+    #[arg(value_hint = clap::ValueHint::DirPath)]
     path: PathBuf,
     /// Transform the filesystem for boot (SELinux labels, empty /boot and /sysroot)
     #[clap(long)]
@@ -598,10 +625,10 @@ struct MountOpts {
     #[arg(long)]
     foreground: bool,
     /// Writable upper layer directory for overlayfs
-    #[arg(long, requires = "workdir")]
+    #[arg(long, requires = "workdir", value_hint = clap::ValueHint::DirPath)]
     upperdir: Option<PathBuf>,
     /// Work directory for overlayfs (required with --upperdir)
-    #[arg(long, requires = "upperdir")]
+    #[arg(long, requires = "upperdir", value_hint = clap::ValueHint::DirPath)]
     workdir: Option<PathBuf>,
     /// Mount read-write (requires --upperdir)
     #[arg(long, requires = "upperdir")]
@@ -659,6 +686,7 @@ enum Command {
         algorithm: Algorithm,
         /// Path to the repository directory (created if it doesn't exist).
         /// If omitted, uses --repo/--user/--system location.
+        #[arg(value_hint = clap::ValueHint::DirPath)]
         path: Option<PathBuf>,
         /// Do not enable fs-verity on meta.json (insecure repository).
         #[clap(long)]
@@ -681,6 +709,7 @@ enum Command {
     /// Reconstitutes a split stream and writes it to stdout
     Cat {
         /// the name of the stream to cat, either a content identifier or prefixed with 'ref/'
+        #[arg(add = ArgValueCompleter::new(complete_stream_refs))]
         name: String,
     },
     /// Perform garbage collection
@@ -708,8 +737,10 @@ enum Command {
     /// Mounts a composefs image, possibly enforcing fsverity of the image
     Mount {
         /// the name of the image to mount, either an fs-verity hash or prefixed with 'ref/'
+        #[arg(add = ArgValueCompleter::new(complete_image_refs))]
         name: String,
         /// the mountpoint
+        #[arg(value_hint = clap::ValueHint::AnyPath)]
         mountpoint: String,
         #[clap(flatten)]
         mount_opts: MountOpts,
@@ -746,6 +777,7 @@ enum Command {
     #[clap(name = "compute-karg")]
     ComputeKarg {
         /// The path to the filesystem
+        #[arg(value_hint = clap::ValueHint::DirPath)]
         path: PathBuf,
         /// Don't copy /usr metadata to root directory (use if root already has well-defined metadata)
         #[clap(long)]
@@ -760,6 +792,7 @@ enum Command {
     /// Lists all object IDs referenced by an image
     ImageObjects {
         /// the name of the image to read, either an object ID digest or prefixed with 'ref/'
+        #[arg(add = ArgValueCompleter::new(complete_image_refs))]
         name: String,
     },
     /// Extract file information from a composefs image for specified files or directories
@@ -767,8 +800,10 @@ enum Command {
     /// By default, outputs information in composefs dumpfile format
     DumpFiles {
         /// The name of the composefs image to read from, either an object ID digest or prefixed with 'ref/'
+        #[arg(add = ArgValueCompleter::new(complete_image_refs))]
         image_name: String,
         /// File or directory paths to process. If a path is a directory, its contents will be listed.
+        #[arg(value_hint = clap::ValueHint::AnyPath)]
         files: Vec<PathBuf>,
         /// Show backing path information instead of dumpfile format
         /// For each file, prints either "inline" for files stored within the image,
@@ -791,7 +826,11 @@ enum Command {
         metadata_only: bool,
     },
     #[cfg(feature = "http")]
-    Fetch { url: String, name: String },
+    Fetch {
+        #[arg(value_hint = clap::ValueHint::Url)]
+        url: String,
+        name: String,
+    },
     /// Serve the varlink RPC API on a Unix socket or systemd socket.
     ///
     /// A single service answers both the `org.composefs.Repository` and (when
@@ -799,7 +838,7 @@ enum Command {
     /// socket.
     Varlink {
         /// Unix socket path to listen on (omit when using systemd socket activation).
-        #[clap(long)]
+        #[clap(long, value_hint = clap::ValueHint::AnyPath)]
         address: Option<PathBuf>,
     },
 

--- a/crates/composefs-ctl/src/main.rs
+++ b/crates/composefs-ctl/src/main.rs
@@ -79,6 +79,12 @@ fn main() -> Result<()> {
             #[cfg(feature = "containers-storage")]
             cstorage::init_if_helper();
 
+            clap_complete::CompleteEnv::with_factory(|| {
+                use clap::CommandFactory;
+                composefs_ctl::App::command()
+            })
+            .complete();
+
             // Now we can create the tokio runtime for the main application
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -3588,18 +3588,40 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
 
     /// Lists all named stream references under a given prefix.
     ///
-    /// Returns (name, target) pairs where name is relative to the prefix.
+    /// Recurses into subdirectories.  Names are returned relative to
+    /// the prefix (e.g. with prefix `"ostree/"`, a ref stored at
+    /// `streams/refs/ostree/stable` is returned as `("stable", target)`).
     pub fn list_stream_refs(&self, prefix: &str) -> Result<Vec<(String, String)>> {
         let ref_path = format!("streams/refs/{prefix}");
+        self.list_refs_in(&ref_path)
+    }
 
-        let dir_fd = match self.openat(&ref_path, OFlags::RDONLY | OFlags::DIRECTORY) {
+    /// Lists all named image references under a given prefix.
+    ///
+    /// Recurses into subdirectories.  Names are returned relative to
+    /// the prefix.
+    pub fn list_image_refs(&self, prefix: &str) -> Result<Vec<(String, String)>> {
+        let ref_path = format!("images/refs/{prefix}");
+        self.list_refs_in(&ref_path)
+    }
+
+    fn list_refs_in(&self, path: &str) -> Result<Vec<(String, String)>> {
+        let dir_fd = match self.openat(path, OFlags::RDONLY | OFlags::DIRECTORY) {
             Ok(fd) => fd,
             Err(Errno::NOENT) => return Ok(Vec::new()),
             Err(e) => return Err(e.into()),
         };
-
         let mut refs = Vec::new();
-        for item in Dir::read_from(&dir_fd)? {
+        Self::collect_refs(&dir_fd, "", &mut refs)?;
+        Ok(refs)
+    }
+
+    fn collect_refs(
+        dir_fd: &OwnedFd,
+        prefix: &str,
+        refs: &mut Vec<(String, String)>,
+    ) -> Result<()> {
+        for item in Dir::read_from(dir_fd)? {
             let entry = item?;
             let name_bytes = entry.file_name().to_bytes();
 
@@ -3607,19 +3629,32 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
                 continue;
             }
 
-            let name = match std::str::from_utf8(name_bytes) {
-                Ok(s) => s.to_string(),
-                Err(_) => continue,
+            let Ok(name) = std::str::from_utf8(name_bytes) else {
+                continue;
             };
 
-            if let Ok(target) = readlinkat(&dir_fd, name_bytes, vec![])
-                && let Ok(target_str) = target.into_string()
-            {
-                refs.push((name, target_str));
+            let full_name = format!("{prefix}{name}");
+
+            match entry.file_type() {
+                FileType::Directory => {
+                    let sub_fd = openat(
+                        dir_fd,
+                        name_bytes,
+                        OFlags::RDONLY | OFlags::DIRECTORY | OFlags::CLOEXEC,
+                        Mode::empty(),
+                    )?;
+                    Self::collect_refs(&sub_fd, &format!("{full_name}/"), refs)?;
+                }
+                _ => {
+                    if let Ok(target) = readlinkat(dir_fd, name_bytes, vec![])
+                        && let Ok(target_str) = target.into_string()
+                    {
+                        refs.push((full_name, target_str));
+                    }
+                }
             }
         }
-
-        Ok(refs)
+        Ok(())
     }
 }
 


### PR DESCRIPTION
 Add dynamic shell completion using clap_complete's CompleteEnv for zsh/fish, and a standalone bash completion script that works around bash's COMP_WORDBREAKS splitting (which breaks docker:// URLs).
    
Custom value completers provide context-aware completions:
- OCI: tags, manifest digests, or both depending on the subcommand
- ostree: commit ref names
- Generic: image and stream refs from the repository
    
Value hints (DirPath, FilePath, Url, AnyPath) are set on all path/URL arguments for filesystem and URL completion.
    
The bash script (cfsctl.bash-completion) re-parses COMP_LINE on whitespace only so values containing : and = stay intact, then trims the word-break prefix from replies so bash replaces the correct fragment.
