### PR TITLE
repo: Resolve bare ref names in open_image()

### DIFF
--- a/crates/composefs-ctl/src/complete.rs
+++ b/crates/composefs-ctl/src/complete.rs
@@ -178,13 +178,15 @@ fn collect_refs<ObjectID: FsVerityHashValue>(
         return vec![];
     };
     let prefix = prefix.as_encoded_bytes();
-    refs.into_iter()
-        .filter_map(|(name, _)| {
-            let candidate = format!("refs/{name}");
-            candidate
-                .as_bytes()
-                .starts_with(prefix)
-                .then(|| CompletionCandidate::new(candidate))
-        })
-        .collect()
+    let mut out = Vec::new();
+    for (name, _) in &refs {
+        if name.as_bytes().starts_with(prefix) {
+            out.push(CompletionCandidate::new(name));
+        }
+        let prefixed = format!("refs/{name}");
+        if prefixed.as_bytes().starts_with(prefix) {
+            out.push(CompletionCandidate::new(prefixed));
+        }
+    }
+    out
 }

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -2491,6 +2491,20 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
     pub fn open_image(&self, name: &str) -> Result<(OwnedFd, bool)> {
         let image = match self.openat(&format!("images/{name}"), OFlags::RDONLY) {
             Ok(fd) => fd,
+            Err(Errno::NOENT) if !name.contains('/') => {
+                // Try resolving as a named ref before giving up
+                match self.openat(&format!("images/refs/{name}"), OFlags::RDONLY) {
+                    Ok(fd) => return Ok((fd, true)),
+                    Err(Errno::NOENT) => {
+                        return Err(anyhow::Error::new(ImageNotFound {
+                            name: name.to_string(),
+                        }));
+                    }
+                    Err(e) => {
+                        return Err(e).with_context(|| format!("Opening ref 'images/refs/{name}'"));
+                    }
+                }
+            }
             Err(Errno::NOENT) => {
                 return Err(anyhow::Error::new(ImageNotFound {
                     name: name.to_string(),
@@ -5948,6 +5962,34 @@ mod tests {
             !target_str.contains(&v2_id.to_hex()),
             "named ref must NOT point to V2 image, but points to: {target_str}"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_open_image_resolves_bare_ref_name() -> Result<()> {
+        let tmp = tempdir();
+        let repo = create_test_repo(&tmp.path().join("repo"))?;
+
+        let obj_size: u64 = 32 * 1024;
+        let obj = generate_test_data(obj_size, 0xBB);
+        let obj_id = repo.ensure_object(&obj)?;
+
+        let fs = make_test_fs(&obj_id, obj_size);
+        let image_id = fs.commit_image(&repo, Some("myimage"))?;
+        repo.sync()?;
+
+        // Opening by digest should work
+        repo.open_image(&image_id.to_hex())?;
+
+        // Opening by refs/ prefix should work
+        repo.open_image("refs/myimage")?;
+
+        // Opening by bare ref name should also work
+        repo.open_image("myimage")?;
+
+        // Non-existent bare name should fail
+        assert!(repo.open_image("no-such-ref").is_err());
+
         Ok(())
     }
 


### PR DESCRIPTION
When opening an image by name, try looking up the name as a ref under images/refs/ if the direct images/{name} lookup fails and the name contains no slashes.  This allows all commands that accept an image name (mount, image-objects, dump-files) to work with bare ref names instead of requiring the refs/ prefix.

Assisted-by: Claude Code (Opus 4.6)
