### PR TITLE
ostree: Don't support sparse files in ostree commit

### DIFF
--- a/crates/composefs-ostree/src/commit.rs
+++ b/crates/composefs-ostree/src/commit.rs
@@ -331,8 +331,8 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
                     LeafContent::Regular(
                         RegularFile::External(obj_id, _) | RegularFile::ExternalNoVerity(obj_id, _),
                     ) => Some(repo.read_object(obj_id)?),
-                    LeafContent::Regular(RegularFile::Sparse(size)) => {
-                        Some(vec![0u8; *size as usize])
+                    LeafContent::Regular(RegularFile::Sparse(_)) => {
+                        bail!("Sparse files not supported in ostree commit")
                     }
                     _ => None,
                 };


### PR DESCRIPTION
These were potentially allocating a large amount of memory, which is a OOM vector. But sparse files are not really used in practice, they are just a backwards compat hack from the C implementation. Just error out if we find any.