### PR TITLE
ci: Disable Debian integration tests temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,10 @@ jobs:
           - name: centos-stream10
             base_image: quay.io/centos-bootc/centos-bootc:stream10
             cfsctl_features: pre-6.15
-          - name: debian
-            base_image: ghcr.io/bootcrew/debian-bootc:latest
-            cfsctl_features: oci
+          # Temporarily disabled
+          # - name: debian
+          #   base_image: ghcr.io/bootcrew/debian-bootc:latest
+          #   cfsctl_features: oci
     env:
       COMPOSEFS_BASE_IMAGE: ${{ matrix.base_image }}
       COMPOSEFS_CFSCTL_FEATURES: ${{ matrix.cfsctl_features }}

--- a/contrib/packaging/lib.sh
+++ b/contrib/packaging/lib.sh
@@ -29,7 +29,17 @@ debian_apt_init() {
 pkg_install() {
     case "${ID}" in
         centos|fedora|rhel)
-            dnf install -y "$@"
+            # Filter out already-installed packages to avoid unintended
+            # upgrades (e.g. podman 5→6 without a matching netavark bump).
+            local -a to_install=()
+            for pkg in "$@"; do
+                if ! rpm -q "$pkg" &>/dev/null; then
+                    to_install+=("$pkg")
+                fi
+            done
+            if [ ${#to_install[@]} -gt 0 ]; then
+                dnf install -y "${to_install[@]}"
+            fi
             dnf clean all
             ;;
         debian|ubuntu)


### PR DESCRIPTION
Something broke in debian unstable (unsurprisingly).

https://github.com/bootcrew/mono/pull/17 will add a Debian stable variant which we should use in the future.