### PR TITLE
setup-root: Tolerate pre-existing /run/systemd/volatile-root symlink

### DIFF
--- a/crates/composefs-setup-root/src/main.rs
+++ b/crates/composefs-setup-root/src/main.rs
@@ -254,8 +254,13 @@ fn gpt_workaround() -> Result<()> {
         major(rootdev.st_rdev),
         minor(rootdev.st_rdev)
     );
-    symlink(target, "/run/systemd/volatile-root")?;
-    Ok(())
+    // Handle the case where the symlink was already created before us,
+    // e.g. by ostree-prepare-root
+    // (https://github.com/ostreedev/ostree/pull/3608).
+    match symlink(target, "/run/systemd/volatile-root") {
+        Ok(()) | Err(Errno::EXIST) => Ok(()),
+        Err(err) => Err(err).context("Creating /run/systemd/volatile-root"),
+    }
 }
 
 /// Strips the optional insecure `?` prefix from a karg value.


### PR DESCRIPTION
ostree-prepare-root is growing the same gpt-auto workaround for composefs roots (creating the /run/systemd/volatile-root symlink so systemd's blockdev_get_root() can resolve the backing device, see https://github.com/systemd/systemd/issues/35017), proposed in https://github.com/ostreedev/ostree/pull/3608. When it runs before composefs-setup-root, the symlink already exists by the time gpt_workaround() runs and the unconditional symlink() call fails with EEXIST. The call site discards the error ("best effort"), but an already existing symlink means the desired end state is in place, so treat it as success rather than an error.

This matches the equivalent change to bootc's vendored copy of this code in https://github.com/bootc-dev/bootc/pull/2276.