### PR TITLE
docs: Update to match latest v1 default and cover erofs_formats better

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -731,7 +731,7 @@ enum Command {
         #[clap(long)]
         reset_metadata: bool,
         /// Default EROFS format version for images in this repository.
-        /// V1 is compatible with C `mkcomposefs` 1.0.8; V2 is the native format.
+        /// V1 is compatible with C `mkcomposefs` 1.0.8; V2 is the legacy composefs-rs format.
         /// If omitted, falls back to the global `--erofs-version` flag, then defaults to V1.
         #[clap(long)]
         erofs_version: Option<ErofsVersion>,

--- a/crates/composefs-ctl/src/main.rs
+++ b/crates/composefs-ctl/src/main.rs
@@ -17,7 +17,8 @@
 //!    See individual module docs for remaining gaps.
 //! 2. **EROFS output format**: V1 (C-compatible) writer with compact inodes,
 //!    BFS ordering, whiteout table, and overlay xattr escaping is complete and
-//!    tested.  V2 (Rust-native) is the default for the composefs-rs repository.
+//!    tested, and is now the default for new repositories.  V2 remains
+//!    available for callers that need it.
 //! 3. **C shared library (`libcomposefs`)**: TODO(compat): Not yet started.
 //!    This is the next major milestone — providing a C-ABI compatible shared
 //!    library so that existing C consumers (e.g. ostree, bootc) can link

--- a/crates/composefs/src/erofs/format.rs
+++ b/crates/composefs/src/erofs/format.rs
@@ -272,7 +272,7 @@ impl std::ops::BitOr<u32> for FileType {
 
 /// EROFS format version number
 pub const VERSION: U32 = U32::new(1);
-/// Composefs-specific version number (V2, Rust-native format)
+/// Composefs-specific version number (V2, the legacy composefs-rs format)
 pub const COMPOSEFS_VERSION: U32 = U32::new(2);
 /// Composefs-specific version number for V0 (C-compatible, no user whiteouts)
 pub const COMPOSEFS_VERSION_V0: U32 = U32::new(0);
@@ -322,7 +322,8 @@ pub enum FormatVersion {
     /// Format V2: extended inodes, DFS ordering, no whiteout table,
     /// `composefs_version=2`.
     ///
-    /// composefs-rs native format, used by older bootc deployments.
+    /// composefs-rs's original format, now legacy: superseded by V1 as the
+    /// default, but still used by older bootc deployments.
     V2 = 2,
 }
 

--- a/crates/composefs/src/erofs/writer.rs
+++ b/crates/composefs/src/erofs/writer.rs
@@ -26,10 +26,10 @@
 //! writes `composefs_version=1` in the header — equivalent to C `mkcomposefs --min-version=1`.
 //! This is the recommended default for new repositories.
 //!
-//! **V2** (`FormatVersion::V2`) is the composefs-rs native format. It always uses extended
-//! inodes (64 bytes), collects inodes in DFS order, omits the whiteout stub table, sets
-//! `build_time` to 0, and sets `composefs_version` to 2. Whiteout files are stored without
-//! escaping.
+//! **V2** (`FormatVersion::V2`) is composefs-rs's original, now legacy format, kept for
+//! repositories that predate V1 support. It always uses extended inodes (64 bytes), collects
+//! inodes in DFS order, omits the whiteout stub table, sets `build_time` to 0, and sets
+//! `composefs_version` to 2. Whiteout files are stored without escaping.
 //!
 //! ## Two-pass layout + emit design
 //!
@@ -2139,7 +2139,7 @@ fn prepare_erofs_inodes<'a, ObjectID: FsVerityHashValue>(
     (inodes, xattrs, min_mtime, header_flags, composefs_version)
 }
 
-/// Creates an EROFS filesystem image from a composefs tree using the default format (V2).
+/// Creates an EROFS filesystem image from a composefs tree using the default format (V1).
 ///
 /// This function performs a two-pass generation:
 /// 1. First pass determines the layout and sizes of all structures
@@ -2223,7 +2223,7 @@ pub(crate) fn mkfs_erofs_inner<ObjectID: FsVerityHashValue>(
 ///   `composefs_version` is `0` normally, auto-bumped to `1` when user whiteouts are present.
 /// - [`FormatVersion::V1`]: Same layout as V0 but `composefs_version` is always `1`.
 ///   Equivalent to C `mkcomposefs --min-version=1`.
-/// - [`FormatVersion::V2`]: Rust-native format (extended inodes, DFS, `composefs_version=2`).
+/// - [`FormatVersion::V2`]: Legacy composefs-rs format (extended inodes, DFS, `composefs_version=2`).
 ///
 /// Whiteout stubs for Epoch1 formats (V0/V1) are added automatically.
 ///

--- a/crates/composefs/src/erofs_format.rs
+++ b/crates/composefs/src/erofs_format.rs
@@ -5,36 +5,47 @@
 //! and referenced by their fs-verity digest. The EROFS image itself carries only metadata: inodes,
 //! directory entries, extended attributes, and chunk index entries that point to the external files.
 //!
-//! composefs-rs supports two EROFS format versions. V1 is byte-for-byte compatible with the C
-//! `mkcomposefs` tool. V2 is the composefs-rs native format and drops several V1 constraints
-//! that exist only for C compatibility.
+//! composefs-rs supports three EROFS format versions, selected by
+//! [`FormatVersion`][crate::erofs::format::FormatVersion]. V0 and V1 share the same on-disk
+//! layout (compact inodes, BFS ordering, whiteout stub table) and are both byte-for-byte
+//! compatible with the C `mkcomposefs` tool (in its default and `--min-version=1` modes,
+//! respectively); they differ only in the `composefs_version` header field. V2 is
+//! composefs-rs's original, now legacy format, predating V1 support, and drops several V0/V1
+//! constraints that exist only for C compatibility.
 //!
-//! `cfsctl init` defaults to V2; pass `--erofs-version 1` to select V1. Higher-level tools
-//! such as bootc initialize repositories with multiple formats enabled (V1 primary) so that images
-//! can be booted on RHEL9-era kernels that require the `composefs.digest=` karg.
+//! `cfsctl init` defaults to V1; pass `--erofs-version 2` to select V2, or `--erofs-version 0`
+//! to match the plain (no-flags) default of the C `mkcomposefs` tool. Higher-level tools such as
+//! bootc initialize repositories with multiple formats enabled (V1 primary) so that images can be
+//! booted on RHEL9-era kernels that require the `composefs.digest=` karg — see
+//! [Generating multiple EROFS formats][crate::repository_format#generating-multiple-erofs-formats]
+//! for how that's configured.
 //!
-//! ## Format V1
+//! ## Format V0 and V1 — C `mkcomposefs` compatible
 //!
-//! V1 is selected with `cfsctl init --erofs-version 1`. The `v1_erofs` ro-compat feature flag
-//! is written to `meta.json` so that tools without V1 support open the repository read-only.
+//! V0 is selected with `cfsctl init --erofs-version 0` and matches the C `mkcomposefs` tool's
+//! plain (no version flags) output. V1 is selected with `cfsctl init --erofs-version 1` (the
+//! `cfsctl` default) and matches C `mkcomposefs --min-version=1`. The `v1_erofs` ro-compat
+//! feature flag is written to `meta.json` when V1 is the primary format, so that tools without
+//! V1 support open the repository read-only; V0 is not covered by a compatibility flag of its
+//! own (see [`repository_format`][crate::repository_format] for how the format is recorded).
 //!
-//! **`composefs_version` field values in V1:**
+//! **`composefs_version` field values:**
 //!
-//! - `0` — no user-visible whiteout files (character devices with rdev=0) in the tree
-//! - `1` — at least one user-visible whiteout file is present
+//! - V0 — `0` (the constant `COMPOSEFS_VERSION_V0`) when no user-visible whiteout files
+//!   (character devices with rdev=0) are present in the tree, auto-bumped to `1`
+//!   (`COMPOSEFS_VERSION_V1`) when at least one is present.
+//! - V1 — always `1` (`COMPOSEFS_VERSION_V1`), regardless of whether user whiteouts are present.
+//!   This matches C `mkcomposefs --min-version=1`, which forces the same value for forward
+//!   compatibility.
 //!
-//! The constant `COMPOSEFS_VERSION_V1` is 0; the field only reaches 1 when user whiteouts are
-//! found. The `--min-version` flag in `mkcomposefs` (mirrored by `mkfs_erofs_v1_min_version`)
-//! forces the value to 1 even when no user whiteouts exist, for forward compatibility.
+//! **Inode layout:** V0 and V1 use compact inodes (32 bytes) when the file data and inode fit
+//! within the constraints of the compact format, and extended inodes (64 bytes) otherwise.
 //!
-//! **Inode layout:** V1 uses compact inodes (32 bytes) when the file data and inode fit within
-//! the constraints of the compact format, and extended inodes (64 bytes) otherwise.
+//! **Inode traversal order:** V0 and V1 collect inodes in breadth-first order — all entries at
+//! one directory level before descending.
 //!
-//! **Inode traversal order:** V1 collects inodes in breadth-first order — all entries at one
-//! directory level before descending.
-//!
-//! **Whiteout stub table:** V1 includes 256 synthetic inode entries at the start of the inode
-//! area, one per two-hex-character prefix `00`–`ff`. Each entry is a character-device stub
+//! **Whiteout stub table:** V0 and V1 include 256 synthetic inode entries at the start of the
+//! inode area, one per two-hex-character prefix `00`–`ff`. Each entry is a character-device stub
 //! (chr 0,0) used by the overlay filesystem to resolve whiteout paths against the object store.
 //! V2 omits them entirely.
 //!
@@ -46,9 +57,12 @@
 //!
 //! **xattr sharing:** Xattr entries are deduplicated using a sort key that is the full xattr name (prefix string concatenated with the suffix).
 //!
-//! ## Format V2 — Created in composefs-rs
+//! ## Format V2 — legacy composefs-rs format
 //!
-//! V2 is the default for repositories created with `cfsctl init` without `--erofs-version 1`.
+//! V2 is selected with `cfsctl init --erofs-version 2`. It was the `cfsctl` default until V1
+//! became the default; repositories created before V1 support was added, and which therefore
+//! predate the `erofs_formats` `meta.json` field, are still treated as V2 for backward
+//! compatibility.
 //!
 //! **`composefs_version` field:** Always `2` (the constant `COMPOSEFS_VERSION`).
 //!
@@ -68,15 +82,17 @@
 //! The format is fixed at repository initialization time and cannot be changed afterward.
 //!
 //! ```text
-//! cfsctl init                    # V2 (default)
-//! cfsctl init --erofs-version 1  # V1 (C-tool compatible)
+//! cfsctl init                    # V1 (default, C-tool compatible)
+//! cfsctl init --erofs-version 2  # V2 (legacy composefs-rs format)
+//! cfsctl init --erofs-version 0  # V0 (plain C mkcomposefs compatible)
 //! ```
 //!
-//! The format is recorded in `meta.json` (see [`repository_format`][crate::repository_format]) as the `v1_erofs` ro-compat feature flag: present
-//! means V1, absent means V2. Tools that do not recognize this flag open the repository
-//! read-only rather than writing images in the wrong format.
+//! The format is recorded in `meta.json` (see [`repository_format`][crate::repository_format])
+//! in the `erofs_formats` field, which is authoritative. For backward compatibility with tools
+//! that predate that field, the `v1_erofs` ro-compat feature flag is also kept in sync: present
+//! means V1, absent means V2 (the legacy default). Tools that do not recognize the flag open the
+//! repository read-only rather than writing images in the wrong format.
 //!
-//! For the standalone `mkcomposefs` tool, the equivalent flag is `--erofs-version`. The
-//! `--min-version` flag (`mkfs_erofs_v1_min_version` in the Rust API) controls whether the
-//! `composefs_version` field starts at 0 or 1 in V1 images regardless of whether user whiteouts
-//! are present.
+//! The standalone `mkcomposefs` tool (as opposed to `cfsctl`) has no `--erofs-version` flag;
+//! instead its `--version`/`--max-version` flags control whether the `composefs_version` field
+//! starts at 0 or 1 (see the `mkcomposefs` man page for details).

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -461,7 +461,7 @@ impl RepoMetadata {
 /// use composefs::repository::RepositoryConfig;
 /// use composefs::fsverity::Algorithm;
 ///
-/// // Default: SHA-256, fs-verity required, EROFS V2.
+/// // Default: SHA-256, fs-verity required, EROFS V1.
 /// let config = RepositoryConfig::default();
 ///
 /// // SHA-512 with fs-verity required.

--- a/crates/composefs/src/repository_format.rs
+++ b/crates/composefs/src/repository_format.rs
@@ -66,13 +66,21 @@
 //!    - `incompatible` — old tools must refuse the repository entirely.
 //!
 //!    The currently defined feature flags are:
-//!      - `v1_erofs` (read-only-compatible) — present on repositories whose
-//!        EROFS image format is [V1][crate::erofs_format] (C-tool compatible:
-//!        compact inodes, BFS ordering, whiteout table).  This is the single
-//!        flag that encodes the EROFS format version: present → V1, absent
-//!        → V2.  Old
-//!        tools that do not recognise this flag open the repository read-only
-//!        rather than accidentally writing images in the wrong format.
+//!      - `v1_erofs` (read-only-compatible) — legacy on-disk signal for the
+//!        EROFS format, kept for compatibility with tools that predate the
+//!        `erofs_formats` field described below: present → [V1][crate::erofs_format],
+//!        absent → V2.  Tools that do not recognise this flag open the
+//!        repository read-only rather than accidentally writing images in the
+//!        wrong format.
+//!
+//!  - `erofs_formats` (optional) — the authoritative [`FormatConfig`][crate::erofs::format::FormatConfig]
+//!    for this repository, e.g. `{"default": 1}` or, for a repository that
+//!    generates both V1 and V2 images, `{"default": 1, "extra": [2]}`.  When
+//!    present, this field determines the EROFS format(s) produced by
+//!    `commit_image`; the `v1_erofs` flag is derived from it and kept in sync
+//!    purely for old-tool compatibility.  When absent (repositories created
+//!    before this field existed), the effective format falls back to the
+//!    `v1_erofs` flag as described above.
 //!
 //! When `meta.json` is present, `cfsctl` auto-detects the hash algorithm and
 //! errors if `--hash` is explicitly passed with a conflicting value.  When
@@ -82,28 +90,79 @@
 //! ### `cfsctl init --erofs-version`
 //!
 //! The `--erofs-version` flag selects the EROFS format for newly committed
-//! images.  It controls the `v1_erofs` feature flag in `meta.json`:
+//! images.  It sets `erofs_formats` (and, for V1, the legacy `v1_erofs` flag)
+//! in `meta.json`:
 //!
 //! ```text
-//! cfsctl init                          # default: V2 EROFS (composefs-rs native)
-//! cfsctl init --erofs-version 1        # V1 EROFS (C-tool compatible)
+//! cfsctl init                          # default: V1 EROFS (C-tool compatible)
+//! cfsctl init --erofs-version 2        # V2 EROFS (legacy composefs-rs format)
 //! ```
 //!
-//! **V2** (the `cfsctl` default) uses extended inodes, DFS ordering, and
-//! `composefs_version=2` in the EROFS superblock.  This is the composefs-rs native
-//! format and is what all repositories created before V1 support was added use.
-//! Higher-level tools (e.g. bootc) may configure a repository with multiple format
-//! versions (V1 primary + V2 extra) so that images are usable on both RHEL9-era and
-//! newer kernels.
+//! **V1** (the `cfsctl` default) uses compact inodes where possible, BFS
+//! ordering, and a whiteout stub table, producing output byte-for-byte
+//! identical to C `mkcomposefs --min-version=1`.  It is understood by both C
+//! `mkcomposefs`/`composefs-info` 1.0.8+ and composefs-rs, making it the best
+//! choice for interoperability, which is why it became the default on the
+//! path towards a stable composefs-rs 1.0.  The `v1_erofs` ro-compat flag is
+//! written to `meta.json` so that tools which predate V1 support open the
+//! repository read-only rather than writing images in the wrong format.
 //!
-//! **V1** uses compact inodes where possible, BFS ordering, and a whiteout stub
-//! table, producing output byte-for-byte identical to the C `mkcomposefs` tool.
-//! The `v1_erofs` ro-compat flag is written to `meta.json` so that tools which
-//! predate V1 support open the repository read-only rather than writing images
-//! in the wrong format.
+//! **V2** uses extended inodes, DFS ordering, and `composefs_version=2` in the
+//! EROFS superblock.  This is composefs-rs's original format, now legacy, and
+//! is what all repositories created before V1 support was added use — those
+//! old repositories (which lack an `erofs_formats` field and the `v1_erofs`
+//! flag) continue to default to V2 rather than being silently reinterpreted
+//! as V1.  V2 remains available for callers that need it, e.g. higher-level
+//! tools (such as bootc) may configure a repository with multiple format
+//! versions (V1 primary + V2 extra) so that images are usable on both
+//! RHEL9-era and newer kernels.
+//!
+//! There is also a [V0][crate::erofs_format] format matching the plain
+//! (non-`--min-version=1`) default output of C `mkcomposefs`.  It shares V1's
+//! on-disk layout and is selectable via `--erofs-version 0`, but — since no
+//! repository created before `erofs_formats` existed could have used it — it
+//! is not represented by a `meta.json` feature flag of its own; the
+//! `erofs_formats` field is authoritative for it.
 //!
 //! Re-initializing an existing repository with a different `--erofs-version` is
-//! rejected with an error; the format version is fixed at init time.
+//! rejected with an error; the format version is fixed at init time (see below
+//! for how to configure more than one format).
+//!
+//! ### Generating multiple EROFS formats
+//!
+//! `erofs_formats` is not limited to a single version: [`FormatConfig`][crate::erofs::format::FormatConfig]
+//! has a `default` version (which claims the named ref and is what
+//! [`erofs_version()`][crate::repository::Repository::erofs_version] reports)
+//! plus an `extra` set of additional versions to generate alongside it, e.g.
+//! `{"default": 1, "extra": [2]}` for a repository that produces both V1 and
+//! V2 images from every commit.
+//!
+//! This is an API-level capability, not currently exposed through `cfsctl`:
+//! a caller embedding the `composefs` crate directly (such as bootc) builds a
+//! [`RepositoryConfig`][crate::repository::RepositoryConfig] with the desired
+//! `erofs_formats` and passes it to
+//! [`Repository::init_path`][crate::repository::Repository::init_path] at
+//! creation time.  As above, there is currently no supported way — via the
+//! CLI or the library — to add a format to a repository after it has been
+//! initialized; `erofs_formats` is fixed for the lifetime of the repository.
+//!
+//! Once configured, every commit uses
+//! [`FileSystem::commit_images()`][crate::tree::FileSystem::commit_images],
+//! which generates one EROFS image per configured version and returns a
+//! `HashMap<FormatVersion, ObjectID>`.  Only the `default` version's image
+//! receives the optional named ref passed in; images for `extra` versions are
+//! still written to `objects/` (content-addressed, like any other image) but
+//! are otherwise anonymous, so the caller is responsible for tracking their
+//! IDs itself.  [`FileSystem::commit_image()`][crate::tree::FileSystem::commit_image]
+//! is a convenience wrapper around `commit_images()` that returns just the
+//! `default` version's ID, for callers that don't need `extra` formats.
+//!
+//! The OCI crate does exactly this for dual-format repositories: it calls
+//! `commit_images()` once per image and stores the resulting IDs as two
+//! separate named refs on the config splitstream (`composefs.image` for V2,
+//! `composefs.image.v1` for V1 — see [EROFS image tracking](#erofs-image-tracking-via-config-splitstream-refs)
+//! below), so that both versions of the image stay reachable through GC
+//! regardless of which one is the repository's `default`.
 //!
 //! ## `objects/`
 //!


### PR DESCRIPTION
Commit 080f92584 ("erofs: Switch default format version from V2 to V1") flipped cfsctl's default EROFS format but left several doc comments describing the old default.

Also ensure we have good doc coverage for the `erofs_formats` metadata.