### PR TITLE
oci: Handle non-world-readable large files sent as memfd

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -1382,6 +1382,7 @@ pub async fn copy_image(
             let get_params = GetLayerParams {
                 diff_id: Some(diff_id.to_string()),
                 storage: None,
+                ..Default::default()
             };
             let mut get_stream = std::pin::pin!(
                 conn_src

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -2934,6 +2934,7 @@ mod layer_sync_tests {
         let params = GetLayerParams {
             diff_id: Some(diff_id.to_owned()),
             storage: None,
+            ..Default::default()
         };
         let mut stream = std::pin::pin!(
             client

--- a/crates/composefs-integration-tests/src/tests/privileged.rs
+++ b/crates/composefs-integration-tests/src/tests/privileged.rs
@@ -686,7 +686,8 @@ impl Drop for LoopTempDir {
 }
 
 /// Create a minimal OCI directory image with files large enough to exercise
-/// the `ensure_object_from_file` path (> 64 bytes, the inline threshold).
+/// the `ensure_object_from_file` path (> 64 bytes, the inline threshold),
+/// including one non-world-readable file (see bootc-dev/bootc#2324).
 ///
 /// Returns the path to the OCI directory.
 pub(super) fn create_oci_layout_with_large_files(parent: &Path) -> Result<PathBuf> {
@@ -742,6 +743,27 @@ pub(super) fn create_oci_layout_with_large_files(parent: &Path) -> Result<PathBu
         header.set_mtime(1234567890);
         header.set_cksum();
         layer_builder.append_data(&mut header, &name, &data[..])?;
+    }
+
+    // Also add a non-world-readable file (mode 0o600).  This regression-tests
+    // bootc-dev/bootc#2324: without `consumer_has_cap_dac_override` wired up,
+    // cstor import would inline this file's content into the varlink stream,
+    // materialize it into a memfd on the consumer side, and then crash with
+    // EXDEV when zerocopy mode tried to reflink/hardlink the memfd (memfds
+    // can never be zero-copied to a real filesystem).  With the fix, the
+    // privileged (direct, in-process) import path recognizes that it can
+    // bypass DAC checks and emits a real dirfd+filename reference instead,
+    // so this file is hardlinked/reflinked just like the world-readable ones.
+    {
+        let data = vec![0xffu8; 4096];
+        let mut header = tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o600);
+        header.set_uid(0);
+        header.set_gid(0);
+        header.set_mtime(1234567890);
+        header.set_cksum();
+        layer_builder.append_data(&mut header, "usr/restricted_file.bin", &data[..])?;
     }
     let layer = layer_builder.into_inner()?.complete()?;
 

--- a/crates/composefs-oci/src/cstor.rs
+++ b/crates/composefs-oci/src/cstor.rs
@@ -311,6 +311,7 @@ async fn import_from_containers_storage_direct<ObjectID: FsVerityHashValue>(
                 storage_layer_id,
                 diff_id,
                 zerocopy,
+                true, // direct path: only entered when can_bypass_file_permissions()
                 &mut ctx,
             )
             .await?;
@@ -362,6 +363,7 @@ async fn import_from_containers_storage_direct<ObjectID: FsVerityHashValue>(
 /// collects all frames, then drains the `splitdirfdstream` pipe in a
 /// `spawn_blocking` closure while the server-side producer fills the pipe
 /// concurrently on its own thread.
+#[allow(clippy::too_many_arguments)]
 async fn import_layer_via_transfer<ObjectID: FsVerityHashValue>(
     repo: &Arc<Repository<ObjectID>>,
     client: &mut zlink::unix::Connection,
@@ -369,6 +371,7 @@ async fn import_layer_via_transfer<ObjectID: FsVerityHashValue>(
     storage_layer_id: &str,
     diff_id: &OciDigest,
     zerocopy: bool,
+    consumer_has_cap_dac_override: bool,
     ctx: &mut ImportContext,
 ) -> Result<(ObjectID, ImportStats)> {
     // Call get_layer with the storage locator (handle=0; cstor service ignores it).
@@ -378,6 +381,7 @@ async fn import_layer_via_transfer<ObjectID: FsVerityHashValue>(
             storage_path: storage_path.to_owned(),
             layer_id: storage_layer_id.to_owned(),
         }),
+        consumer_has_cap_dac_override,
     };
     let stream = client
         .get_layer(0, params)
@@ -509,6 +513,7 @@ async fn import_from_containers_storage_proxied<ObjectID: FsVerityHashValue>(
                 storage_layer_id,
                 diff_id,
                 zerocopy,
+                false, // proxied path: consumer cannot bypass file permissions
                 &mut ctx,
             )
             .await?;

--- a/crates/composefs-oci/src/layer_sync.rs
+++ b/crates/composefs-oci/src/layer_sync.rs
@@ -158,8 +158,15 @@ fn drain_splitdirfdstream_inner<ObjectID: FsVerityHashValue>(
                     stats.bytes_inlined += length;
                     writer.write_inline(data);
                 } else {
-                    // Large file: store as an external object. A memfd is the
-                    // lightest way to hand an fd to process_file_content.
+                    // Large payload received as Chunk::InlineData (producer
+                    // determined the consumer can't safely open this file by
+                    // name — see consumer_has_cap_dac_override in
+                    // GetLayerParams), so unlike Chunk::FileBackedData below,
+                    // there's no real on-disk file backing this data. We
+                    // materialise it into a memfd purely to hand
+                    // process_file_content an fd; that memfd can never be
+                    // zero-copyable (reflink/hardlink), regardless of the
+                    // caller's `zerocopy` flag, so always pass `false` here.
                     process_file_content(
                         repo,
                         writer,
@@ -168,7 +175,7 @@ fn drain_splitdirfdstream_inner<ObjectID: FsVerityHashValue>(
                         file_content_to_memfd(data)?,
                         length,
                         "<file-content>",
-                        zerocopy,
+                        false,
                         inline_buf,
                     )?;
                 }
@@ -755,6 +762,40 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Regression test: a memfd-backed fd must not error under the copy
+    /// fallback path when the caller correctly identifies it as
+    /// non-zerocopy-able (`zerocopy=false`), since memfds live on tmpfs
+    /// where reflink/hardlink are structurally impossible.
+    #[test]
+    fn test_memfd_file_content_uses_copy_fallback() {
+        let (repo, _tempdir) = create_test_repo();
+        let size: usize = INLINE_CONTENT_MAX_V0 + 1; // just above inline threshold
+        let data: Vec<u8> = (0..size).map(|i| (i % 251) as u8).collect();
+
+        let memfd = file_content_to_memfd(&data).unwrap();
+
+        let mut writer = repo.create_stream(TAR_LAYER_CONTENT_TYPE).unwrap();
+        let mut stats = ImportStats::default();
+        let mut ctx = ImportContext::default();
+        let mut inline_buf = Vec::new();
+
+        process_file_content(
+            &repo,
+            &mut writer,
+            &mut stats,
+            &mut ctx,
+            memfd,
+            size as u64,
+            "memfd-test",
+            false,
+            &mut inline_buf,
+        )
+        .unwrap();
+
+        assert_eq!(stats.objects_copied, 1, "memfd content should be copied");
+        assert_eq!(stats.bytes_copied, size as u64);
     }
 
     // -------------------------------------------------------------------------

--- a/crates/composefs-oci/src/varlink_types.rs
+++ b/crates/composefs-oci/src/varlink_types.rs
@@ -44,12 +44,19 @@ pub struct StorageLocator {
 ///
 /// Both fields are `Option` for forward-compatibility: new locator kinds can
 /// be added in future without breaking old clients.
-#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, zlink::introspect::Type)]
 pub struct GetLayerParams {
     /// OCI diff-id (`sha256:…`) identifying the layer in a composefs repo.
     pub diff_id: Option<String>,
     /// Location of a specific layer inside a containers-storage store.
     pub storage: Option<StorageLocator>,
+    /// Whether the consumer of this layer's bytes can bypass file DAC
+    /// permissions (real root or `CAP_DAC_OVERRIDE`).  When `true`, the cstor
+    /// service may emit `FileBackedData` chunks even for non-world-readable
+    /// files, since the consumer can open them directly.  Defaults to `false`
+    /// for backward compatibility.
+    #[serde(default)]
+    pub consumer_has_cap_dac_override: bool,
 }
 
 // ── Reply types ───────────────────────────────────────────────────────────────

--- a/crates/composefs-storage/src/cstor_service.rs
+++ b/crates/composefs-storage/src/cstor_service.rs
@@ -76,12 +76,16 @@ pub struct StorageLocator {
 ///
 /// This is the wire-format counterpart of `composefs_oci::varlink_types::GetLayerParams`.
 /// The `diff_id` field is ignored by this service; only `storage` is used.
-#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, zlink::introspect::Type)]
 pub struct GetLayerParams {
     /// Ignored by the cstor service (used by the repo service).
     pub diff_id: Option<String>,
     /// Location of the layer in containers-storage (required).
     pub storage: Option<StorageLocator>,
+    /// Whether the consumer can bypass file DAC permissions.
+    /// See `composefs_oci::varlink_types::GetLayerParams` for details.
+    #[serde(default)]
+    pub consumer_has_cap_dac_override: bool,
 }
 
 /// Reply from `GetInfo`.
@@ -139,11 +143,18 @@ pub struct CstorLayerService;
 ///
 /// `link_id_to_dirfd` maps each layer's link ID to the *sparse* dirfd slot
 /// index where its pre-opened diff-directory fd was placed.
+///
+/// `consumer_has_cap_dac_override` controls how non-world-readable files
+/// are transported: when `true`, every file is emitted as `FileBackedData`
+/// (dirfd + filename reference) regardless of its permission bits, since the
+/// consumer is trusted to open it directly; when `false`, non-world-readable
+/// files are still read into memory and sent as `InlineData`, as before.
 pub(crate) fn produce_splitdirfdstream<W: Write>(
     storage: &Storage,
     layer: &Layer,
     link_id_to_dirfd: &HashMap<String, u32>,
     real_indices: &std::collections::HashSet<u32>,
+    consumer_has_cap_dac_override: bool,
     out: W,
 ) -> crate::Result<()> {
     let mut stream = TarSplitFdStream::new(storage, layer)?;
@@ -192,7 +203,7 @@ pub(crate) fn produce_splitdirfdstream<W: Write>(
                     ))
                 })?;
                 let world_readable = stat.st_mode & 0o004 != 0;
-                if world_readable {
+                if world_readable || consumer_has_cap_dac_override {
                     writer
                         .write_file_backed_data(dirfd_index, size, relpath.as_bytes())
                         .map_err(|e| {
@@ -339,6 +350,8 @@ mod service_impl {
                 };
             }
 
+            let consumer_has_cap_dac_override = params.consumer_has_cap_dac_override;
+
             // Extract storage locator (required).
             let locator = match params.storage {
                 Some(l) => l,
@@ -433,9 +446,14 @@ mod service_impl {
             // Phase 3: drop lock (releases shared flock).
             let keepalive_read = layout.keepalive_read;
             spawn_self_reaping_producer(write_fd, keepalive_read, lock, move |wf| {
-                if let Err(e) =
-                    produce_splitdirfdstream(&storage, &layer, &link_id_to_dirfd, &real_indices, wf)
-                {
+                if let Err(e) = produce_splitdirfdstream(
+                    &storage,
+                    &layer,
+                    &link_id_to_dirfd,
+                    &real_indices,
+                    consumer_has_cap_dac_override,
+                    wf,
+                ) {
                     tracing::warn!("cstor producer error: {e:#}");
                 }
             });
@@ -726,8 +744,15 @@ mod tests {
         assert_ne!(child_idx, parent_idx, "real layers occupy distinct slots");
 
         let mut buf = Vec::<u8>::new();
-        produce_splitdirfdstream(&storage, &layer, &link_id_to_dirfd, &real_indices, &mut buf)
-            .unwrap();
+        produce_splitdirfdstream(
+            &storage,
+            &layer,
+            &link_id_to_dirfd,
+            &real_indices,
+            false,
+            &mut buf,
+        )
+        .unwrap();
 
         let mut reader = SplitdirfdstreamReader::new(buf.as_slice());
 
@@ -796,8 +821,15 @@ mod tests {
         let seed = seed_from_id("child-layer-001");
         let (_, link_id_to_dirfd, real_indices) = build_test_layout(&storage, &layer, seed);
         let mut buf = Vec::<u8>::new();
-        produce_splitdirfdstream(&storage, &layer, &link_id_to_dirfd, &real_indices, &mut buf)
-            .unwrap();
+        produce_splitdirfdstream(
+            &storage,
+            &layer,
+            &link_id_to_dirfd,
+            &real_indices,
+            false,
+            &mut buf,
+        )
+        .unwrap();
 
         let mut reader = SplitdirfdstreamReader::new(buf.as_slice());
         let mut saw_file_content = false;
@@ -818,6 +850,60 @@ mod tests {
             }
         }
         assert!(saw_file_content, "expected InlineData chunk for child.txt");
+    }
+
+    /// When the consumer can bypass file permissions, even non-world-readable
+    /// files should be emitted as `FileBackedData` (dirfd + filename reference)
+    /// rather than `InlineData`, enabling zero-copy transport.
+    #[test]
+    fn test_non_world_readable_file_with_bypass_uses_file_backed_data() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let tmp = TempDir::new().unwrap();
+        let storage = create_two_layer_mock(tmp.path());
+
+        let child_txt = tmp
+            .path()
+            .join("overlay/child-layer-001/diff/etc/child.txt");
+        std::fs::set_permissions(&child_txt, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        let layer = Layer::open(&storage, "child-layer-001").unwrap();
+        let seed = seed_from_id("child-layer-001");
+        let (_, link_id_to_dirfd, real_indices) = build_test_layout(&storage, &layer, seed);
+        let mut buf = Vec::<u8>::new();
+        produce_splitdirfdstream(
+            &storage,
+            &layer,
+            &link_id_to_dirfd,
+            &real_indices,
+            true,
+            &mut buf,
+        )
+        .unwrap();
+
+        let mut reader = SplitdirfdstreamReader::new(buf.as_slice());
+        let mut saw_file_backed = false;
+        while let Some(chunk) = reader.next_chunk().unwrap() {
+            match chunk {
+                composefs_splitdirfdstream::Chunk::Metadata(_) => {}
+                composefs_splitdirfdstream::Chunk::FileBackedData { filename, .. } => {
+                    if filename == b"etc/child.txt" {
+                        saw_file_backed = true;
+                        break;
+                    }
+                }
+                composefs_splitdirfdstream::Chunk::InlineData(_) => {
+                    panic!(
+                        "with consumer_has_cap_dac_override=true, non-world-readable \
+                         files must produce FileBackedData, got InlineData"
+                    );
+                }
+            }
+        }
+        assert!(
+            saw_file_backed,
+            "expected FileBackedData chunk for child.txt"
+        );
     }
 
     #[test]
@@ -876,8 +962,15 @@ mod tests {
         assert_eq!(layout.dir_count, EXPECTED_DIR_COUNT);
 
         let mut buf = Vec::<u8>::new();
-        produce_splitdirfdstream(&storage, &layer, &link_id_to_dirfd, &real_indices, &mut buf)
-            .unwrap();
+        produce_splitdirfdstream(
+            &storage,
+            &layer,
+            &link_id_to_dirfd,
+            &real_indices,
+            false,
+            &mut buf,
+        )
+        .unwrap();
 
         // The dirfds region in fds_all starts at index 1.
         let dir_count = layout.dir_count as usize;
@@ -940,6 +1033,7 @@ mod tests {
                 storage_path: storage_path.to_owned(),
                 layer_id: layer_id.to_owned(),
             }),
+            ..Default::default()
         };
 
         let mut stream = std::pin::pin!(client.get_layer(0, params).await.unwrap());


### PR DESCRIPTION
We were sending large non-world-readable files as memfd, but the consumer path errored out on these when zerocopy was enforced (because we can't reflink/hardlink a memfd).

Fix this by making that case not an error - any files sent as "inline data" (via memfd) are not candidates for zerocopy.

However, if the caller has CAP_DAC_OVERRIDE, then we can send them as not-inline data, which would *also* fix the bootc path.

Fixes: bootc-dev/bootc#2324
Assisted-by: AI