### PR TITLE
Add API to "ensure" (init if not present) a repository

### DIFF
--- a/crates/composefs-ctl/src/lib.rs
+++ b/crates/composefs-ctl/src/lib.rs
@@ -740,7 +740,7 @@ enum Command {
     Init {
         /// The fs-verity algorithm identifier.
         /// Format: fsverity-<hash>-<lg_blocksize>, e.g. fsverity-sha512-12
-        #[clap(long, value_parser = clap::value_parser!(Algorithm), default_value = "fsverity-sha512-12")]
+        #[clap(long, value_parser = clap::value_parser!(Algorithm), default_value_t = Algorithm::SHA512)]
         algorithm: Algorithm,
         /// Path to the repository directory (created if it doesn't exist).
         /// If omitted, uses --repo/--user/--system location.
@@ -755,6 +755,13 @@ enum Command {
         /// re-imported after migration.
         #[clap(long)]
         reset_metadata: bool,
+        /// Ensure the repository exists, opening it as-is if one is already
+        /// present instead of failing when its on-disk configuration (e.g.
+        /// EROFS format version) differs from the requested one. Useful for
+        /// idempotent invocations from unit files or automation. Has no effect
+        /// on the first initialization of a repository.
+        #[clap(long)]
+        ensure: bool,
         /// Default EROFS format version for images in this repository.
         /// V1 is compatible with C `mkcomposefs` 1.0.8; V2 is the legacy composefs-rs format.
         /// If omitted, falls back to the global `--erofs-version` flag, then defaults to V1.
@@ -1147,6 +1154,7 @@ pub async fn run_app(args: App) -> Result<()> {
         ref path,
         insecure,
         reset_metadata,
+        ensure,
         erofs_version: ref init_erofs_version,
     } = args.cmd
     {
@@ -1160,6 +1168,7 @@ pub async fn run_app(args: App) -> Result<()> {
             path.as_deref(),
             insecure || args.insecure,
             reset_metadata,
+            ensure,
             erofs_version,
             &args,
         );
@@ -1229,6 +1238,7 @@ fn run_init(
     path: Option<&Path>,
     insecure: bool,
     reset_metadata: bool,
+    ensure: bool,
     erofs_version: composefs::erofs::format::FormatVersion,
     args: &App,
 ) -> Result<()> {
@@ -1240,6 +1250,36 @@ fn run_init(
 
     if reset_metadata {
         composefs::repository::reset_metadata(&repo_path)?;
+    }
+
+    if ensure {
+        let formats = composefs::erofs::format::FormatConfig::single(erofs_version);
+        let status =
+            crate::varlink::run_ensure_repository(&repo_path, *algorithm, insecure, Some(formats))?;
+        match status {
+            composefs::repository::EnsureStatus::Created => {
+                println!(
+                    "Initialized composefs repository at {}",
+                    repo_path.display()
+                );
+                println!("  algorithm: {algorithm}");
+                if insecure {
+                    println!("  verity:    not required (insecure)");
+                } else {
+                    println!("  verity:    required");
+                }
+            }
+            composefs::repository::EnsureStatus::Opened => {
+                println!(
+                    "Repository already initialized at {} (existing configuration preserved)",
+                    repo_path.display()
+                );
+            }
+            composefs::repository::EnsureStatus::Upgraded => {
+                println!("Upgraded legacy repository at {}", repo_path.display());
+            }
+        }
+        return Ok(());
     }
 
     // Ensure parent directories exist (init_path only creates the final dir).

--- a/crates/composefs-ctl/src/varlink.rs
+++ b/crates/composefs-ctl/src/varlink.rs
@@ -184,6 +184,13 @@ pub struct InitRepositoryReply {
     pub created: bool,
 }
 
+/// Reply from ensuring a repository exists.
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::Type)]
+pub struct EnsureRepositoryReply {
+    /// What happened when ensuring the repository.
+    pub status: composefs::repository::EnsureStatus,
+}
+
 /// An opened repository, monomorphized over its detected hash algorithm.
 ///
 /// Stored as an [`Arc`] so streaming methods can clone an owned handle into a
@@ -646,6 +653,17 @@ fn run_oci_mount<ObjectID: composefs::fsverity::FsVerityHashValue>(
     Ok((MountReply { fd_index: 0 }, vec![mount_fd]))
 }
 
+/// Parse a wire-format algorithm string (e.g. `"fsverity-sha512-12"`),
+/// falling back to the service default ([`Algorithm::SHA512`]) when omitted.
+fn parse_algorithm(algorithm: Option<&str>) -> std::result::Result<Algorithm, RepositoryError> {
+    match algorithm {
+        Some(s) => s.parse().map_err(|e| RepositoryError::InvalidSpec {
+            message: format!("invalid algorithm: {e}"),
+        }),
+        None => Ok(Algorithm::SHA512),
+    }
+}
+
 /// Initialize (or verify) a repository at `path` with the given algorithm.
 ///
 /// Creates parent directories if needed, then delegates to
@@ -691,6 +709,43 @@ fn run_init_repository(
         }
     };
     Ok(InitRepositoryReply { created })
+}
+
+/// Ensure a repository exists at `path`: create parent directories, then
+/// delegate to [`Repository::ensure_path`]. Unlike [`run_init_repository`],
+/// this never bails when a repository already exists with a different
+/// on-disk configuration (e.g. EROFS format version) — the existing
+/// repository is simply opened as-is. `erofs_formats`, if given, is only
+/// applied when a brand-new repository is created; it has no effect when an
+/// existing repository is opened or an old-format one is upgraded.
+pub(crate) fn run_ensure_repository(
+    path: &Path,
+    algorithm: Algorithm,
+    insecure: bool,
+    erofs_formats: Option<composefs::erofs::format::FormatConfig>,
+) -> anyhow::Result<composefs::repository::EnsureStatus> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent directories for {}", path.display()))?;
+    }
+
+    let mut config = RepositoryConfig::new(algorithm);
+    if insecure {
+        config = config.set_insecure();
+    }
+    if let Some(formats) = erofs_formats {
+        config.erofs_formats = formats;
+    }
+
+    let status = match algorithm {
+        Algorithm::Sha256 { .. } => {
+            Repository::<Sha256HashValue>::ensure_path(CWD, path, config)?.1
+        }
+        Algorithm::Sha512 { .. } => {
+            Repository::<Sha512HashValue>::ensure_path(CWD, path, config)?.1
+        }
+    };
+    Ok(status)
 }
 
 /// OCI helper functions backing the `org.composefs.Oci` interface, gated behind
@@ -863,12 +918,12 @@ mod service_impl {
     #![allow(missing_docs)]
 
     use super::{
-        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply,
-        ListImageRefsReply, MountParams, MountReply, OpenRepo, OpenRepositoryReply,
-        RepositoryError, run_fsck, run_gc, run_image_objects, run_init_repository,
-        run_list_image_refs, run_mount,
+        CfsctlService, EnsureRepositoryReply, FsckReply, GcReply, ImageObjectsReply,
+        InitRepositoryReply, ListImageRefsReply, MountParams, MountReply, OpenRepo,
+        OpenRepositoryReply, RepositoryError, parse_algorithm, run_ensure_repository, run_fsck,
+        run_gc, run_image_objects, run_init_repository, run_list_image_refs, run_mount,
     };
-    use composefs::fsverity::{Algorithm, Sha256HashValue, Sha512HashValue};
+    use composefs::fsverity::{Sha256HashValue, Sha512HashValue};
 
     #[zlink::service(
         interface = "org.composefs.Repository",
@@ -893,15 +948,36 @@ mod service_impl {
             algorithm: Option<String>,
             insecure: Option<bool>,
         ) -> std::result::Result<InitRepositoryReply, RepositoryError> {
-            let algorithm: Algorithm = algorithm
-                .as_deref()
-                .unwrap_or("fsverity-sha512-12")
-                .parse()
-                .map_err(|e| RepositoryError::InvalidSpec {
-                    message: format!("invalid algorithm: {e}"),
-                })?;
+            let algorithm = parse_algorithm(algorithm.as_deref())?;
             let insecure = insecure.unwrap_or(self.open_opts.insecure);
             run_init_repository(std::path::Path::new(&path), algorithm, insecure)
+        }
+
+        /// Ensure a repository exists at the given path: open it as-is if it
+        /// already exists (preserving its on-disk configuration even if it
+        /// differs from the crate's current defaults), initialize a fresh one
+        /// if none exists, or upgrade an old-format (pre-`meta.json`) repository
+        /// in place.
+        ///
+        /// Unlike [`init_repository`](Self::init_repository), this never fails
+        /// due to a configuration mismatch with an existing repository — it is
+        /// the appropriate method for idempotent "make sure this repo exists"
+        /// callers (e.g. a service ensuring its repository is available at
+        /// startup).
+        async fn ensure_repository(
+            &mut self,
+            path: String,
+            algorithm: Option<String>,
+            insecure: Option<bool>,
+        ) -> std::result::Result<EnsureRepositoryReply, RepositoryError> {
+            let algorithm = parse_algorithm(algorithm.as_deref())?;
+            let insecure = insecure.unwrap_or(self.open_opts.insecure);
+            let status =
+                run_ensure_repository(std::path::Path::new(&path), algorithm, insecure, None)
+                    .map_err(|e| RepositoryError::InternalError {
+                        message: format!("{e:#}"),
+                    })?;
+            Ok(EnsureRepositoryReply { status })
         }
 
         /// Open and validate a repository, returning an opaque handle.
@@ -1032,13 +1108,14 @@ mod service_impl {
         parse_local_fetch, pull_stream,
     };
     use super::{
-        CfsctlService, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply,
-        ListImageRefsReply, MountParams, MountReply, OpenRepo, OpenRepositoryReply,
-        RepositoryError, run_compute_id, run_fsck, run_gc, run_image_objects, run_init_repository,
+        CfsctlService, EnsureRepositoryReply, FsckReply, GcReply, ImageObjectsReply,
+        InitRepositoryReply, ListImageRefsReply, MountParams, MountReply, OpenRepo,
+        OpenRepositoryReply, RepositoryError, parse_algorithm, run_compute_id,
+        run_ensure_repository, run_fsck, run_gc, run_image_objects, run_init_repository,
         run_inspect, run_list_image_refs, run_list_images, run_mount, run_oci_fsck, run_oci_mount,
         run_tag, run_untag,
     };
-    use composefs::fsverity::{Algorithm, FsVerityHashValue, Sha256HashValue, Sha512HashValue};
+    use composefs::fsverity::{FsVerityHashValue, Sha256HashValue, Sha512HashValue};
     use composefs_oci::layer_transport::{RepoLayerSource, serve_get_layer};
     use composefs_oci::varlink_types::GetLayerParams;
     use composefs_splitdirfdstream::seed_from_id;
@@ -1068,15 +1145,36 @@ mod service_impl {
             algorithm: Option<String>,
             insecure: Option<bool>,
         ) -> std::result::Result<InitRepositoryReply, RepositoryError> {
-            let algorithm: Algorithm = algorithm
-                .as_deref()
-                .unwrap_or("fsverity-sha512-12")
-                .parse()
-                .map_err(|e| RepositoryError::InvalidSpec {
-                    message: format!("invalid algorithm: {e}"),
-                })?;
+            let algorithm = parse_algorithm(algorithm.as_deref())?;
             let insecure = insecure.unwrap_or(self.open_opts.insecure);
             run_init_repository(std::path::Path::new(&path), algorithm, insecure)
+        }
+
+        /// Ensure a repository exists at the given path: open it as-is if it
+        /// already exists (preserving its on-disk configuration even if it
+        /// differs from the crate's current defaults), initialize a fresh one
+        /// if none exists, or upgrade an old-format (pre-`meta.json`) repository
+        /// in place.
+        ///
+        /// Unlike [`init_repository`](Self::init_repository), this never fails
+        /// due to a configuration mismatch with an existing repository — it is
+        /// the appropriate method for idempotent "make sure this repo exists"
+        /// callers (e.g. a service ensuring its repository is available at
+        /// startup).
+        async fn ensure_repository(
+            &mut self,
+            path: String,
+            algorithm: Option<String>,
+            insecure: Option<bool>,
+        ) -> std::result::Result<EnsureRepositoryReply, RepositoryError> {
+            let algorithm = parse_algorithm(algorithm.as_deref())?;
+            let insecure = insecure.unwrap_or(self.open_opts.insecure);
+            let status =
+                run_ensure_repository(std::path::Path::new(&path), algorithm, insecure, None)
+                    .map_err(|e| RepositoryError::InternalError {
+                        message: format!("{e:#}"),
+                    })?;
+            Ok(EnsureRepositoryReply { status })
         }
 
         /// Open and validate a repository, returning an opaque handle.
@@ -2657,8 +2755,8 @@ pub mod proxy {
         ListImagesReply, OciComputeIdReply, OciError, OciFsckReply, OciInspectReply, PullProgress,
     };
     use super::{
-        FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply, OpenRepositoryReply,
-        RepositoryError,
+        EnsureRepositoryReply, FsckReply, GcReply, ImageObjectsReply, InitRepositoryReply,
+        OpenRepositoryReply, RepositoryError,
     };
     #[cfg(feature = "oci")]
     pub use composefs_oci::varlink_types::GetLayerParams;
@@ -2675,6 +2773,14 @@ pub mod proxy {
             algorithm: Option<&str>,
             insecure: Option<bool>,
         ) -> zlink::Result<Result<InitRepositoryReply, RepositoryError>>;
+
+        /// Ensure a repository exists (open as-is, initialize, or upgrade).
+        async fn ensure_repository(
+            &mut self,
+            path: &str,
+            algorithm: Option<&str>,
+            insecure: Option<bool>,
+        ) -> zlink::Result<Result<EnsureRepositoryReply, RepositoryError>>;
 
         /// Open and validate a repository, returning an opaque handle.
         async fn open_repository(

--- a/crates/composefs-integration-tests/src/tests/ostree.rs
+++ b/crates/composefs-integration-tests/src/tests/ostree.rs
@@ -370,6 +370,11 @@ impl HttpServer {
                 "-m",
                 "http.server",
                 &port.to_string(),
+                // Bind explicitly to 127.0.0.1: without this, Python may bind
+                // dual-stack/all-interfaces instead, which some sandboxed
+                // network environments then refuse loopback connections to.
+                "--bind",
+                "127.0.0.1",
                 "--directory",
                 directory.to_str().unwrap(),
             ])

--- a/crates/composefs-integration-tests/src/tests/varlink.rs
+++ b/crates/composefs-integration-tests/src/tests/varlink.rs
@@ -1385,3 +1385,133 @@ fn test_varlink_init_repository_proxy() -> Result<()> {
     Ok(())
 }
 integration_test!(test_varlink_init_repository_proxy);
+
+// ============================================================================
+// EnsureRepository tests
+// ============================================================================
+
+/// Read the on-disk EROFS format version recorded in a repository's
+/// `meta.json` (the `erofs_formats.default` field), to check what
+/// `EnsureRepository`/`InitRepository` actually left on disk without relying
+/// on the library API directly (this crate only talks to `cfsctl` as a
+/// separate process).
+fn read_erofs_default_version(repo: &Path) -> Result<u64> {
+    let meta_json = std::fs::read_to_string(repo.join("meta.json"))
+        .context("reading meta.json to check the on-disk EROFS format")?;
+    let meta: Value = serde_json::from_str(&meta_json).context("parsing meta.json")?;
+    meta["erofs_formats"]["default"]
+        .as_u64()
+        .context("meta.json missing erofs_formats.default")
+}
+
+/// `EnsureRepository` on a completely fresh path (parent directories missing
+/// too) creates a new repository using the crate's default EROFS format
+/// (V1), and returns status `Created`.
+fn test_varlink_ensure_repository_creates_new() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    // We need a running service — use an existing insecure repo for that.
+    let existing_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let svc = VarlinkService::repository(existing_dir.path())?;
+
+    // Point EnsureRepository at a brand-new, nested path (parent directories
+    // missing too).
+    let new_repo_dir = tempfile::tempdir()?;
+    let new_repo_path = new_repo_dir.path().join("nested").join("repo");
+    let path_str = new_repo_path.to_str().context("repo path not UTF-8")?;
+
+    let reply = svc.call_raw(
+        "org.composefs.Repository.EnsureRepository",
+        json!({"path": path_str, "insecure": true}),
+    )?;
+    assert_eq!(
+        reply["status"], "Created",
+        "expected status=Created for a fresh repo, got: {reply}"
+    );
+
+    // A fresh repository must get the crate's default EROFS format (V1).
+    assert_eq!(
+        read_erofs_default_version(&new_repo_path)?,
+        1,
+        "freshly-created repository should use the crate's default EROFS format (V1)"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_ensure_repository_creates_new);
+
+/// `EnsureRepository` on a repository that already exists with a non-default
+/// EROFS format (V2, vs. the crate's V1 default) must open it as-is rather
+/// than failing — this is the regression test for the bug `EnsureRepository`
+/// exists to fix.
+fn test_varlink_ensure_repository_preserves_existing_format() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    // We need a running service — use a throwaway insecure repo for that.
+    let existing_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let svc = VarlinkService::repository(existing_dir.path())?;
+
+    // Pre-initialize a *different* repository with a non-default EROFS
+    // format (V2). `init_insecure_repo` uses `--erofs-version 2`.
+    let target_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let target = target_dir.path();
+    let path_str = target.to_str().context("repo path not UTF-8")?;
+
+    let reply = svc.call_raw(
+        "org.composefs.Repository.EnsureRepository",
+        json!({"path": path_str, "insecure": true}),
+    )?;
+    assert_eq!(
+        reply["status"], "Opened",
+        "expected status=Opened for an existing repo despite format mismatch, got: {reply}"
+    );
+
+    // The on-disk format must still be V2, not silently reset to the
+    // crate's V1 default.
+    assert_eq!(
+        read_erofs_default_version(target)?,
+        2,
+        "EnsureRepository must not alter an existing repository's on-disk EROFS format"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_ensure_repository_preserves_existing_format);
+
+/// `InitRepository`'s existing strict behavior must be unchanged:
+/// re-initializing a repository whose on-disk EROFS format differs from the
+/// requested default is still a hard error, and the existing repository is
+/// left untouched.
+fn test_varlink_init_repository_still_bails_on_config_mismatch() -> Result<()> {
+    let sh = Shell::new()?;
+    let cfsctl = cfsctl()?;
+    // We need a running service — use a throwaway insecure repo for that.
+    let existing_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let svc = VarlinkService::repository(existing_dir.path())?;
+
+    // Pre-initialize a *different* repository with a non-default EROFS
+    // format (V2).
+    let target_dir = init_insecure_repo(&sh, &cfsctl)?;
+    let target = target_dir.path();
+    let path_str = target.to_str().context("repo path not UTF-8")?;
+
+    let err = svc.call_expect_err(
+        "org.composefs.Repository.InitRepository",
+        json!({"path": path_str, "insecure": true}),
+    )?;
+    assert!(
+        err.contains("InternalError"),
+        "expected InternalError for a config mismatch, got: {err}"
+    );
+
+    // The failed call must not have touched the existing repository's
+    // on-disk format.
+    assert_eq!(
+        read_erofs_default_version(target)?,
+        2,
+        "a failed InitRepository call must not alter the existing repository's format"
+    );
+
+    Ok(())
+}
+integration_test!(test_varlink_init_repository_still_bails_on_config_mismatch);

--- a/crates/composefs/src/repository.rs
+++ b/crates/composefs/src/repository.rs
@@ -184,6 +184,22 @@ impl From<std::io::Error> for RepositoryOpenError {
     }
 }
 
+/// Outcome of [`Repository::ensure_path`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "varlink",
+    derive(serde::Serialize, serde::Deserialize, zlink_core::introspect::Type),
+    zlink(crate = "zlink_core")
+)]
+pub enum EnsureStatus {
+    /// An existing (modern, meta.json-based) repository was opened as-is.
+    Opened,
+    /// No repository existed; a fresh one was initialized with the caller's config.
+    Created,
+    /// An old-format (pre-meta.json) repository was upgraded in place.
+    Upgraded,
+}
+
 /// The current repository format version.
 ///
 /// This is a simple integer that is bumped only for fundamental,
@@ -1447,6 +1463,66 @@ impl<ObjectID: FsVerityHashValue> Repository<ObjectID> {
                     .context("opening repository after writing meta.json")?;
 
                 Ok((repo, true))
+            }
+            Err(other) => Err(other.into()),
+        }
+    }
+
+    /// Open a repository if it exists, initialize it if none exists, or
+    /// upgrade it in place if it is an old-format (pre-`meta.json`) repository.
+    ///
+    /// This is a convenience wrapper combining [`open_path`](Self::open_path),
+    /// [`init_path`](Self::init_path), and [`open_upgrade`](Self::open_upgrade):
+    ///
+    /// - If a modern repository already exists, it is opened as-is via
+    ///   [`open_path`](Self::open_path). Its on-disk configuration (including
+    ///   `erofs_formats`) is preserved; the caller's `config` is ignored for an
+    ///   existing repository except that algorithm mismatches are still a hard
+    ///   error (see [`open_path`](Self::open_path)).
+    /// - If no repository exists yet (`meta.json` is missing and there is no
+    ///   `objects/` directory), a fresh repository is initialized with `config`
+    ///   via [`init_path`](Self::init_path).
+    /// - If an old-format repository (pre-`meta.json`) is found, it is
+    ///   non-destructively upgraded via [`open_upgrade`](Self::open_upgrade).
+    ///
+    /// This is useful for callers (e.g. bootc) that want to preserve whatever
+    /// format an existing repository was created with, even if the crate's
+    /// default `RepositoryConfig` has since changed (e.g. a change in the
+    /// default EROFS format version), while still bootstrapping a sensible
+    /// configuration for brand-new repositories.
+    ///
+    /// Like [`init_path`](Self::init_path), the target directory itself is
+    /// created if it doesn't exist (though any missing *parent* directories
+    /// are still the caller's responsibility).
+    ///
+    /// Returns the repository along with an [`EnsureStatus`] describing which
+    /// of the three code paths was taken.
+    #[context("Ensuring repository at {}", path.as_ref().display())]
+    pub fn ensure_path(
+        dirfd: impl AsFd,
+        path: impl AsRef<Path>,
+        config: RepositoryConfig,
+    ) -> Result<(Self, EnsureStatus)> {
+        let path = path.as_ref();
+
+        // Unlike open_path, ensure_path may create the target directory
+        // itself: without this, a completely fresh path (as opposed to an
+        // existing-but-empty directory) would fail open_path's initial
+        // openat() with a plain ENOENT rather than the MetadataMissing this
+        // function matches on below.
+        mkdirat(&dirfd, path, Mode::from_raw_mode(0o700))
+            .or_else(|e| if e == Errno::EXIST { Ok(()) } else { Err(e) })
+            .with_context(|| format!("creating repository directory {}", path.display()))?;
+
+        match Self::open_path(&dirfd, path) {
+            Ok(repo) => Ok((repo, EnsureStatus::Opened)),
+            Err(RepositoryOpenError::MetadataMissing) => {
+                let (repo, _) = Self::init_path(&dirfd, path, config)?;
+                Ok((repo, EnsureStatus::Created))
+            }
+            Err(RepositoryOpenError::OldFormatRepository) => {
+                let (repo, _) = Self::open_upgrade(&dirfd, path)?;
+                Ok((repo, EnsureStatus::Upgraded))
             }
             Err(other) => Err(other.into()),
         }
@@ -5457,6 +5533,43 @@ mod tests {
     }
 
     #[test]
+    fn test_init_path_erofs_version_mismatch_v2_to_v1() -> Result<()> {
+        // Symmetric counterpart of `test_init_path_erofs_version_mismatch`:
+        // a repo initialized as V2 must also bail if `init_path` is later
+        // called with a V1 config (e.g. because the crate's default
+        // erofs_version changed after the repo was created).
+        let tmp = tempdir();
+        let path = tmp.path().join("repo");
+
+        // First init: V2
+        let config_v2 = RepositoryConfig {
+            algorithm: Algorithm::SHA256,
+            erofs_formats: FormatConfig::single(FormatVersion::V2),
+            ..RepositoryConfig::default().set_insecure()
+        };
+        Repository::<Sha256HashValue>::init_path(CWD, &path, config_v2)?;
+
+        // Second init: V1 — should fail because meta.json already exists with V2 config
+        let config_v1 = RepositoryConfig {
+            algorithm: Algorithm::SHA256,
+            erofs_formats: FormatConfig::single(FormatVersion::V1),
+            ..RepositoryConfig::default().set_insecure()
+        };
+        let result = Repository::<Sha256HashValue>::init_path(CWD, &path, config_v1);
+        assert!(
+            result.is_err(),
+            "re-initializing with different erofs_version must fail"
+        );
+        let err = result.unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("erofs_version"),
+            "error message must mention erofs_version, got: {msg}"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_init_path_same_erofs_version_is_idempotent() -> Result<()> {
         let tmp = tempdir();
         let path = tmp.path().join("repo");
@@ -5472,6 +5585,105 @@ mod tests {
         let (repo, was_new) = Repository::<Sha256HashValue>::init_path(CWD, &path, config)?;
         assert!(!was_new, "second init with same config must be idempotent");
         assert_eq!(repo.erofs_version(), FormatVersion::V1);
+        Ok(())
+    }
+
+    // ---- ensure_path tests ----
+
+    #[test]
+    fn test_ensure_path_preserves_existing_format() -> Result<()> {
+        let tmp = tempdir();
+        let path = tmp.path().join("repo");
+
+        let config_v2 = RepositoryConfig {
+            algorithm: Algorithm::SHA256,
+            erofs_formats: FormatConfig::single(FormatVersion::V2),
+            ..RepositoryConfig::default().set_insecure()
+        };
+        Repository::<Sha256HashValue>::init_path(CWD, &path, config_v2)?;
+
+        // ensure_path with a V1-only config must not overwrite the
+        // existing V2 repository; it should simply be opened as-is.
+        let config_v1 = RepositoryConfig {
+            algorithm: Algorithm::SHA256,
+            erofs_formats: FormatConfig::single(FormatVersion::V1),
+            ..RepositoryConfig::default().set_insecure()
+        };
+        let (repo, status) = Repository::<Sha256HashValue>::ensure_path(CWD, &path, config_v1)?;
+        assert_eq!(status, EnsureStatus::Opened);
+        assert_eq!(repo.erofs_version(), FormatVersion::V2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ensure_path_creates_fresh() -> Result<()> {
+        // Unlike open_path/init_path, ensure_path creates the target
+        // directory itself, so a completely fresh path (nothing exists yet)
+        // is expected to work here.
+        let tmp = tempdir();
+        let path = tmp.path().join("repo");
+
+        let config_v2 = RepositoryConfig {
+            algorithm: Algorithm::SHA256,
+            erofs_formats: FormatConfig::single(FormatVersion::V2),
+            ..RepositoryConfig::default().set_insecure()
+        };
+        let (repo, status) = Repository::<Sha256HashValue>::ensure_path(CWD, &path, config_v2)?;
+        assert_eq!(status, EnsureStatus::Created);
+        assert_eq!(repo.erofs_version(), FormatVersion::V2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ensure_path_upgrades_legacy() -> Result<()> {
+        let tmp = tempdir();
+        let path = tmp.path().join("repo");
+
+        // Create a repo, store an object, then remove meta.json to
+        // simulate an old-format repository (mirrors test_open_upgrade_sha256).
+        let (repo, _) = Repository::<Sha256HashValue>::init_path(
+            CWD,
+            &path,
+            RepositoryConfig::default().set_insecure(),
+        )?;
+        let data = b"hello world";
+        let obj_id = repo.ensure_object(data)?;
+        drop(repo);
+        std::fs::remove_file(path.join(REPO_METADATA_FILENAME))?;
+
+        let (repo, status) = Repository::<Sha256HashValue>::ensure_path(
+            CWD,
+            &path,
+            RepositoryConfig::default().set_insecure(),
+        )?;
+        assert_eq!(status, EnsureStatus::Upgraded);
+        assert!(path.join(REPO_METADATA_FILENAME).exists());
+        assert_eq!(&repo.read_object(&obj_id)?[..], data);
+        Ok(())
+    }
+
+    #[test]
+    fn test_ensure_path_algorithm_mismatch_is_hard_error() -> Result<()> {
+        // Init a sha256 repo, then ensure_path as sha512 — an algorithm
+        // mismatch must propagate as a hard error, not silently fall
+        // back to init or upgrade.
+        let tmp = tempdir();
+        let path = tmp.path().join("repo");
+        Repository::<Sha256HashValue>::init_path(
+            CWD,
+            &path,
+            RepositoryConfig::default().set_insecure(),
+        )?;
+
+        let result = Repository::<Sha512HashValue>::ensure_path(
+            CWD,
+            &path,
+            RepositoryConfig::new(Algorithm::SHA512).set_insecure(),
+        );
+        assert!(
+            result.is_err(),
+            "algorithm mismatch must be a hard error, not fall back to init/upgrade"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
It's going to be very common for higher level tools to want
to do "initialize a repo if one doesn't exist".

We're going to hand roll a version of this in
https://github.com/bootc-dev/bootc/pull/2329
temporarily, but let's get a proper API here.

We expose this via Rust (of course) and varlink, and the CLI.

Also add test_init_path_erofs_version_mismatch_v2_to_v1, the missing
symmetric case of the existing V1-to-V2 test, confirming init_path
bails when a V2-initialized repository is later reopened with a V1
config.