### PR TITLE
fuse: Use inode check for detecting the initial user namespace

### DIFF
--- a/crates/composefs-ctl/src/fuse.rs
+++ b/crates/composefs-ctl/src/fuse.rs
@@ -32,8 +32,9 @@ pub(crate) enum MountMode {
 }
 
 fn in_init_user_namespace() -> bool {
-    std::fs::read_to_string("/proc/self/uid_map")
-        .map(|s| s.trim() == "0          0 4294967295")
+    const USER_NS_INIT_INO: u64 = 0xEFFF_FFFD;
+    std::fs::metadata("/proc/self/ns/user")
+        .map(|m| std::os::linux::fs::MetadataExt::st_ino(&m) == USER_NS_INIT_INO)
         .unwrap_or(false)
 }
 


### PR DESCRIPTION
The previous heuristic parsed /proc/self/uid_map looking for a full range mapping (4294967295), assuming only the initial user namespace could have it.  This is incorrect: a non-initial user namespace can also have a full identity map, e.g. with systemd PrivateUsers=full.

Use the kernel-defined USER_NS_INIT_INO inode number on /proc/self/ns/user instead, which is the authoritative way to identify the initial user namespace.

See: https://github.com/containers/crun/issues/2150

@alexlarsson @cgwalters PTAL