### PR TITLE
Replace sha2 crate with openssl for hash computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,6 @@ ocidir = "0.8.0"
 zlink = { version = "0.6", default-features = false, features = ["tokio", "introspection", "proxy", "server", "service", "tracing"] }
 zlink-core = { version = "0.6", default-features = false, features = ["introspection", "std", "tracing"] }
 
-[profile.dev.package.sha2]
-# this is *really* slow otherwise
-opt-level = 3
-
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/crates/composefs-http/Cargo.toml
+++ b/crates/composefs-http/Cargo.toml
@@ -16,7 +16,6 @@ bytes = { version = "1.7.1", default-features = false }
 composefs = { workspace = true }
 hex = { version = "0.4.0", default-features = false }
 reqwest = { version = "0.13.0", features = ["zstd"] }
-sha2 = { version = "0.11.0", default-features = false }
 tokio = { version = "1.24.2", default-features = false }
 
 [dev-dependencies]

--- a/crates/composefs-http/src/lib.rs
+++ b/crates/composefs-http/src/lib.rs
@@ -14,9 +14,9 @@ use std::{
 
 use anyhow::{Result, bail};
 use bytes::Bytes;
+use composefs::digest::{Digest, Sha256};
 use composefs::util::DigestWrite;
 use reqwest::{Client, Response, Url};
-use sha2::{Digest, Sha256};
 use tokio::task::JoinSet;
 
 use composefs::progress::{ComponentId, NullReporter, ProgressEvent, ProgressUnit, SharedReporter};

--- a/crates/composefs-oci/Cargo.toml
+++ b/crates/composefs-oci/Cargo.toml
@@ -37,7 +37,6 @@ rustix = { version = "1.0.0", features = ["fs"] }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "2.0.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
-sha2 = { version = "0.11.0", default-features = false }
 rand = { version = "0.10.0", default-features = false, optional = true }
 tar = { version = "0.4.38", default-features = false, optional = true }
 tar-core = "0.1.0"

--- a/crates/composefs-oci/src/delta.rs
+++ b/crates/composefs-oci/src/delta.rs
@@ -201,24 +201,24 @@ fn read_uvarint(r: &mut impl io::BufRead) -> Result<u64> {
 }
 
 enum OciHasher {
-    Sha256(sha2::Sha256),
-    Sha384(sha2::Sha384),
-    Sha512(sha2::Sha512),
+    Sha256(composefs::digest::Sha256),
+    Sha384(composefs::digest::Sha384),
+    Sha512(composefs::digest::Sha512),
 }
 
 impl OciHasher {
     fn new(algorithm: &DigestAlgorithm) -> Result<Self> {
-        use sha2::Digest;
+        use composefs::digest::Digest;
         match algorithm {
-            &DigestAlgorithm::Sha256 => Ok(Self::Sha256(sha2::Sha256::new())),
-            &DigestAlgorithm::Sha384 => Ok(Self::Sha384(sha2::Sha384::new())),
-            &DigestAlgorithm::Sha512 => Ok(Self::Sha512(sha2::Sha512::new())),
+            &DigestAlgorithm::Sha256 => Ok(Self::Sha256(composefs::digest::Sha256::new())),
+            &DigestAlgorithm::Sha384 => Ok(Self::Sha384(composefs::digest::Sha384::new())),
+            &DigestAlgorithm::Sha512 => Ok(Self::Sha512(composefs::digest::Sha512::new())),
             other => bail!("Unsupported digest algorithm: {other}"),
         }
     }
 
     fn update(&mut self, data: &[u8]) {
-        use sha2::Digest;
+        use composefs::digest::Digest;
         match self {
             Self::Sha256(h) => h.update(data),
             Self::Sha384(h) => h.update(data),
@@ -227,7 +227,7 @@ impl OciHasher {
     }
 
     fn finalize(self) -> Result<OciDigest> {
-        use sha2::Digest;
+        use composefs::digest::Digest;
         let (algorithm, hex) = match self {
             Self::Sha256(h) => ("sha256", hex::encode(h.finalize())),
             Self::Sha384(h) => ("sha384", hex::encode(h.finalize())),

--- a/crates/composefs-oci/src/image.rs
+++ b/crates/composefs-oci/src/image.rs
@@ -11,9 +11,9 @@
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use anyhow::{Context, Result, ensure};
+use composefs::digest::{Digest, Sha256};
 use composefs::util::DigestWrite;
 use fn_error_context::context;
-use sha2::{Digest, Sha256};
 
 use composefs::{
     fsverity::FsVerityHashValue,

--- a/crates/composefs-oci/src/layer_sync.rs
+++ b/crates/composefs-oci/src/layer_sync.rs
@@ -19,9 +19,9 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use cap_std_ext::cap_std;
+use composefs::digest::{Digest as _, Sha256};
 use composefs_splitdirfdstream::{Chunk, SplitdirfdstreamReader, SplitdirfdstreamWriter};
 use rustix::fs::{MemfdFlags, fstat, memfd_create};
-use sha2::{Digest as _, Sha256};
 
 use composefs::{
     INLINE_CONTENT_MAX_V0,

--- a/crates/composefs-oci/src/lib.rs
+++ b/crates/composefs-oci/src/lib.rs
@@ -59,10 +59,10 @@ use anyhow::{Context, Result, ensure};
 /// Re-exported from `oci-spec` for convenience.
 pub use containers_image_proxy::oci_spec::image::Digest as OciDigest;
 
+use composefs::digest::{Digest, Sha256};
 use containers_image_proxy::ImageProxyConfig;
 use containers_image_proxy::oci_spec::image::ImageConfiguration;
 use containers_image_proxy::oci_spec::image::{Descriptor, ImageManifest, MediaType};
-use sha2::{Digest, Sha256};
 
 use composefs::{
     erofs::format::{FormatEpoch, FormatVersion},
@@ -471,7 +471,7 @@ pub async fn pull<ObjectID: FsVerityHashValue>(
 }
 
 /// Convert a SHA-256 hash output to an OCI content digest.
-pub(crate) fn sha256_output_to_digest(output: sha2::digest::Output<Sha256>) -> OciDigest {
+pub(crate) fn sha256_output_to_digest(output: composefs::digest::Output<Sha256>) -> OciDigest {
     let hex = hex::encode(output);
     format!("sha256:{hex}")
         .try_into()

--- a/crates/composefs-oci/src/test_util.rs
+++ b/crates/composefs-oci/src/test_util.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use crate::oci_image::write_manifest;
 use crate::skopeo::OCI_CONFIG_CONTENT_TYPE;
+use composefs::digest::{Digest, Sha256};
 use composefs::dumpfile_parse::{Entry, Item};
 use composefs::fsverity::Sha256HashValue;
 use composefs::repository::{Repository, RepositoryConfig};
@@ -30,7 +31,6 @@ use containers_image_proxy::oci_spec::image::{
     ImageManifestBuilder, MediaType, RootFsBuilder,
 };
 use rustix::fs::FileType;
-use sha2::{Digest, Sha256};
 
 fn hash(bytes: &[u8]) -> OciDigest {
     let mut context = Sha256::new();

--- a/crates/composefs-ostree/Cargo.toml
+++ b/crates/composefs-ostree/Cargo.toml
@@ -23,7 +23,6 @@ gvariant = { version = "0.5.1", default-features = true}
 hex = { version = "0.4.0", default-features = false, features = ["std"] }
 rand = { version = "0.10.0", default-features = false, features = ["thread_rng"] }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "mount", "process", "std"] }
-sha2 = { version = "0.11.0", default-features = false }
 zerocopy = { version = "0.8.0", default-features = false, features = ["derive", "std"] }
 reqwest = { version = "0.13.0", features = ["stream", "zstd"] }
 tokio = { version = "1.24.2", default-features = false, features = ["rt", "sync"] }

--- a/crates/composefs-ostree/src/commit.rs
+++ b/crates/composefs-ostree/src/commit.rs
@@ -9,7 +9,7 @@ use gvariant::aligned_bytes::{A8, AlignedBuf, AlignedSlice, TryAsAligned};
 use std::{fmt, io::Read, mem::size_of, sync::Arc};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
-use sha2::{Digest, Sha256};
+use composefs::digest::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, HashMap},
     ffi::OsStr,
@@ -210,7 +210,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
 
         let commit = metadata.into_commit(root_tree_id, root_meta_id);
         let commit_data = commit.serialize();
-        let commit_id: Sha256Digest = Sha256::digest(&commit_data).into();
+        let commit_id: Sha256Digest = Sha256::digest(&commit_data);
         writer.insert(&commit_id, None, &commit_data);
         writer.set_commit_id(&commit_id);
 
@@ -256,7 +256,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
             xattrs: stat_xattrs_to_vec(&dir.stat),
         };
         let dirmeta_data = dirmeta.serialize();
-        let dirmeta_id: Sha256Digest = Sha256::digest(&dirmeta_data).into();
+        let dirmeta_id: Sha256Digest = Sha256::digest(&dirmeta_data);
         writer.insert(&dirmeta_id, None, &dirmeta_data);
 
         let dirtree = OstreeDirTree {
@@ -264,7 +264,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
             dirs: dir_entries,
         };
         let dirtree_data = dirtree.serialize();
-        let dirtree_id: Sha256Digest = Sha256::digest(&dirtree_data).into();
+        let dirtree_id: Sha256Digest = Sha256::digest(&dirtree_data);
         writer.insert(&dirtree_id, None, &dirtree_data);
 
         Ok((dirtree_id, dirmeta_id))
@@ -320,7 +320,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
                     }
                     hasher.update(&buf[..n]);
                 }
-                let checksum: Sha256Digest = hasher.finalize().into();
+                let checksum: Sha256Digest = hasher.finalize();
                 writer.insert(&checksum, Some(obj_id), &zlib_header);
                 Ok(checksum)
             }
@@ -342,7 +342,7 @@ impl<ObjectID: FsVerityHashValue> CommitWriter<ObjectID> {
                 if let Some(ref bytes) = content {
                     hasher.update(bytes);
                 }
-                let checksum: Sha256Digest = hasher.finalize().into();
+                let checksum: Sha256Digest = hasher.finalize();
 
                 if let Some(bytes) = content {
                     let mut data = zlib_header;
@@ -692,7 +692,7 @@ impl<ObjectID: FsVerityHashValue> CommitReader<ObjectID> {
         })?;
 
         let dirmeta_sha = Sha256::digest(dirmeta);
-        if *dirmeta_sha != *dirmeta_id {
+        if dirmeta_sha != *dirmeta_id {
             bail!(
                 "Invalid dirmeta checksum {:?}, expected {:?}",
                 dirmeta_sha,

--- a/crates/composefs-ostree/src/delta.rs
+++ b/crates/composefs-ostree/src/delta.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use anyhow::{Context, Result, anyhow, bail, ensure};
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD_NO_PAD;
+use composefs::digest::{Digest, Sha256};
 use gvariant::aligned_bytes::{AlignedBuf, TryAsAligned};
 use gvariant::{Marker, Structure, gv};
 use rustix::fs::{Mode, OFlags, openat, seek};
-use sha2::{Digest, Sha256};
 
 use composefs::fsverity::FsVerityHashValue;
 use composefs::repository::Repository;
@@ -851,7 +851,7 @@ fn dispatch_open_splice_and_close<ObjectID: FsVerityHashValue>(
         let data = state.payload_slice(content_offset, content_len as u64)?;
 
         let actual = Sha256::digest(data);
-        if *actual != checksum {
+        if actual != checksum {
             bail!(
                 "metadata object checksum mismatch: expected {}, got {}",
                 hex::encode(checksum),
@@ -1065,7 +1065,7 @@ fn store_file_object<ObjectID: FsVerityHashValue>(
     hasher.update(&*regular_header);
     hasher.update(content);
     let actual = hasher.finalize();
-    if *actual != *expected_checksum {
+    if actual != *expected_checksum {
         bail!(
             "file object checksum mismatch: expected {}, got {}",
             hex::encode(expected_checksum),
@@ -1148,7 +1148,7 @@ pub fn apply_delta_offline<ObjectID: FsVerityHashValue>(
 
         // Verify checksum of raw part data
         let actual = Sha256::digest(&raw);
-        if *actual != header.checksum {
+        if actual != header.checksum {
             bail!(
                 "delta part {i} checksum mismatch: expected {}, got {}",
                 hex::encode(header.checksum),

--- a/crates/composefs-ostree/src/pull.rs
+++ b/crates/composefs-ostree/src/pull.rs
@@ -6,6 +6,7 @@
 //! shared objects.
 
 use anyhow::{Result, bail};
+use composefs::digest::{Digest, Sha256};
 use composefs::{
     fsverity::FsVerityHashValue,
     progress::{ComponentId, ProgressEvent, ProgressUnit, SharedReporter},
@@ -13,7 +14,6 @@ use composefs::{
     util::Sha256Digest,
 };
 use gvariant::aligned_bytes::AlignedBuf;
-use sha2::{Digest, Sha256};
 use std::collections::{HashSet, VecDeque};
 use std::{fmt, sync::Arc};
 use tokio::sync::Semaphore;
@@ -248,7 +248,7 @@ impl<ObjectID: FsVerityHashValue, RepoType: OstreeRepo<ObjectID> + 'static>
         data: AlignedBuf,
     ) -> Result<()> {
         let data_sha = Sha256::digest(&*data);
-        if *data_sha != *id {
+        if data_sha != *id {
             bail!(
                 "Invalid {:?} checksum {:?}, expected {:?}",
                 obj_type,

--- a/crates/composefs-ostree/src/repo.rs
+++ b/crates/composefs-ostree/src/repo.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Context, Result, anyhow, bail};
 use cap_std::fs::Dir;
+use composefs::digest::{Digest, Sha256};
 use configparser::ini::Ini;
 use flate2::read::DeflateDecoder;
 use gvariant::aligned_bytes::{AlignedBuf, TryAsAligned};
@@ -13,7 +14,6 @@ use reqwest::{Client, StatusCode, Url, header};
 use rustix::fd::AsRawFd;
 use rustix::fs::{FileType, Mode, OFlags, fstat, getxattr, listxattr, openat, readlinkat};
 use rustix::io::Errno;
-use sha2::{Digest, Sha256};
 use std::ffi::CStr;
 use std::mem::MaybeUninit;
 use std::{
@@ -84,7 +84,7 @@ fn hash_and_store_file<ObjectID: FsVerityHashValue>(
     };
 
     let actual_checksum = hasher.finalize();
-    if *actual_checksum != *expected_checksum {
+    if actual_checksum != *expected_checksum {
         bail!(
             "Unexpected file checksum {}, expected {}",
             hex::encode(actual_checksum),
@@ -567,8 +567,8 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
             Some(data) => data,
             None => self.fetch_delta_part(from, to, index).await?,
         };
-        let actual = sha2::Sha256::digest(&raw);
-        if *actual != *expected_checksum {
+        let actual = Sha256::digest(&raw);
+        if actual != *expected_checksum {
             bail!(
                 "delta part {index} checksum mismatch: expected {}, got {}",
                 hex::encode(expected_checksum),
@@ -649,7 +649,7 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
             .context("Decompressing subsummary")?;
 
         let actual = Sha256::digest(&summary_data);
-        if *actual != checksum {
+        if actual != checksum {
             bail!(
                 "subsummary checksum mismatch: expected {}, got {}",
                 checksum_hex,
@@ -724,7 +724,7 @@ impl<ObjectID: FsVerityHashValue> RemoteRepo<ObjectID> {
             .await
             .with_context(|| format!("Reading summary from {url}"))?;
 
-        let data_checksum: Sha256Digest = Sha256::digest(&summary_data).into();
+        let data_checksum: Sha256Digest = Sha256::digest(&summary_data);
         let info = SummaryCacheInfo {
             etag,
             last_modified,
@@ -1332,7 +1332,7 @@ impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
             return Ok(());
         }
 
-        let actual: Sha256Digest = Sha256::digest(data).into();
+        let actual: Sha256Digest = Sha256::digest(data);
         if actual != *checksum {
             bail!(
                 "metadata object checksum mismatch: expected {}, got {}",
@@ -1417,7 +1417,7 @@ impl<ObjectID: FsVerityHashValue> LocalRepo<ObjectID> {
             }
         }
 
-        let actual: Sha256Digest = hasher.finalize().into();
+        let actual: Sha256Digest = hasher.finalize();
         if actual != *checksum {
             bail!(
                 "file object checksum mismatch: expected {}, got {}",

--- a/crates/composefs-splitdirfdstream/Cargo.toml
+++ b/crates/composefs-splitdirfdstream/Cargo.toml
@@ -20,7 +20,7 @@ tokio = ["dep:tokio"]
 rand = { version = "0.10.0", default-features = false, features = ["alloc"] }
 rand_pcg = { version = "0.10.0", default-features = false }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "pipe", "std"] }
-sha2 = { version = "0.11", default-features = false }
+openssl = { version = "0.10", default-features = false }
 thiserror = { version = "2.0.0", default-features = false }
 tokio = { version = "1", default-features = false, features = ["rt"], optional = true }
 

--- a/crates/composefs-splitdirfdstream/src/transport.rs
+++ b/crates/composefs-splitdirfdstream/src/transport.rs
@@ -69,8 +69,8 @@ pub(crate) fn split_into_frames(fds: Vec<OwnedFd>, n_frames: usize) -> Vec<Vec<O
 /// Uses the first 8 bytes of SHA-256(id) interpreted as little-endian u64.
 /// The result is stable across runs for the same id string.
 pub fn seed_from_id(id: &str) -> u64 {
-    use sha2::Digest as _;
-    let hash = sha2::Sha256::digest(id.as_bytes());
+    let hash = openssl::hash::hash(openssl::hash::MessageDigest::sha256(), id.as_bytes())
+        .expect("SHA-256 hashing should not fail");
     u64::from_le_bytes(hash[..8].try_into().expect("sha256 is at least 8 bytes"))
 }
 

--- a/crates/composefs/Cargo.toml
+++ b/crates/composefs/Cargo.toml
@@ -28,7 +28,7 @@ log = { version = "0.4.8", default-features = false }
 once_cell = { version = "1.21.3", default-features = false, features = ["std"] }
 rustix = { version = "1.0.0", default-features = false, features = ["fs", "mount", "process", "std", "thread"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
-sha2 = { version = "0.11.0", default-features = false }
+openssl = { version = "0.10", default-features = false }
 thiserror = { version = "2.0.0", default-features = false }
 tokio = { version = "1.24.2", default-features = false, features = ["macros", "process", "io-util", "rt-multi-thread", "sync"] }
 tempfile = { version = "3.8.0", optional = true, default-features = false }

--- a/crates/composefs/src/digest.rs
+++ b/crates/composefs/src/digest.rs
@@ -1,0 +1,160 @@
+//! Cryptographic hash digest wrappers backed by OpenSSL.
+//!
+//! Provides [`Digest`] and [`FixedOutputReset`] traits with concrete
+//! implementations for SHA-256, SHA-384, and SHA-512 using the system
+//! OpenSSL library.
+
+use openssl::hash::{Hasher, MessageDigest};
+use std::fmt;
+
+/// The output type of a [`Digest`] algorithm.
+pub type Output<D> = <D as Digest>::Output;
+
+/// Trait for cryptographic hash digest algorithms.
+pub trait Digest: fmt::Debug {
+    /// Fixed-size byte array produced by this algorithm.
+    type Output: AsRef<[u8]> + AsMut<[u8]> + Clone + fmt::Debug + PartialEq + Eq;
+
+    /// Create a new hasher in its initial state.
+    fn new() -> Self;
+
+    /// Feed data into the hasher.
+    fn update(&mut self, data: impl AsRef<[u8]>);
+
+    /// Consume the hasher and return the computed digest.
+    fn finalize(self) -> Self::Output;
+
+    /// One-shot convenience: hash `data` and return the digest.
+    fn digest(data: impl AsRef<[u8]>) -> Self::Output
+    where
+        Self: Sized,
+    {
+        let mut h = Self::new();
+        h.update(data);
+        h.finalize()
+    }
+}
+
+/// A [`Digest`] that can be finalized and reused without re-allocating.
+pub trait FixedOutputReset: Digest {
+    /// Return the computed digest and reset the hasher for reuse.
+    fn finalize_reset(&mut self) -> Self::Output;
+}
+
+macro_rules! impl_digest {
+    ($name:ident, $md:expr, $size:literal) => {
+        /// OpenSSL-backed hasher.
+        pub struct $name(Hasher);
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($name)).finish_non_exhaustive()
+            }
+        }
+
+        impl Digest for $name {
+            type Output = [u8; $size];
+
+            fn new() -> Self {
+                Self(Hasher::new($md).expect(concat!(stringify!($name), " hasher creation failed")))
+            }
+
+            fn update(&mut self, data: impl AsRef<[u8]>) {
+                self.0
+                    .update(data.as_ref())
+                    .expect(concat!(stringify!($name), " update failed"));
+            }
+
+            fn finalize(mut self) -> [u8; $size] {
+                let result = self
+                    .0
+                    .finish()
+                    .expect(concat!(stringify!($name), " finalize failed"));
+                let mut out = [0u8; $size];
+                out.copy_from_slice(&result);
+                out
+            }
+        }
+
+        impl FixedOutputReset for $name {
+            fn finalize_reset(&mut self) -> [u8; $size] {
+                let result = self
+                    .0
+                    .finish()
+                    .expect(concat!(stringify!($name), " finalize failed"));
+                let mut out = [0u8; $size];
+                out.copy_from_slice(&result);
+                out
+            }
+        }
+    };
+}
+
+impl_digest!(Sha256, MessageDigest::sha256(), 32);
+impl_digest!(Sha384, MessageDigest::sha384(), 48);
+impl_digest!(Sha512, MessageDigest::sha512(), 64);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_empty() {
+        let hash = Sha256::digest(b"");
+        assert_eq!(
+            hex::encode(hash),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sha256_hello() {
+        let hash = Sha256::digest(b"hello world");
+        assert_eq!(
+            hex::encode(hash),
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn sha256_incremental() {
+        let mut h = Sha256::new();
+        h.update(b"hello ");
+        h.update(b"world");
+        let hash = h.finalize();
+        assert_eq!(
+            hex::encode(hash),
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn sha256_finalize_reset() {
+        let mut h = Sha256::new();
+        h.update(b"hello world");
+        let hash1 = h.finalize_reset();
+
+        h.update(b"hello world");
+        let hash2 = h.finalize_reset();
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn sha384_empty() {
+        let hash = Sha384::digest(b"");
+        assert_eq!(
+            hex::encode(hash),
+            "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+        );
+    }
+
+    #[test]
+    fn sha512_empty() {
+        let hash = Sha512::digest(b"");
+        assert_eq!(
+            hex::encode(hash),
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        );
+    }
+}

--- a/crates/composefs/src/fsverity/digest.rs
+++ b/crates/composefs/src/fsverity/digest.rs
@@ -5,7 +5,7 @@
 
 use core::mem::size_of;
 
-use sha2::Digest;
+use crate::digest::{Digest, FixedOutputReset};
 
 use super::FsVerityHashValue;
 

--- a/crates/composefs/src/fsverity/hashvalue.rs
+++ b/crates/composefs/src/fsverity/hashvalue.rs
@@ -6,8 +6,8 @@
 
 use core::{fmt, hash::Hash, str::FromStr};
 
+use crate::digest::{Digest, FixedOutputReset, Output, Sha256, Sha512};
 use hex::FromHexError;
-use sha2::{Digest, Sha256, Sha512, digest::FixedOutputReset, digest::Output};
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 /// Trait for fs-verity hash value types supporting SHA-256 and SHA-512.
@@ -164,7 +164,7 @@ pub struct Sha256HashValue([u8; 32]);
 
 impl From<Output<Sha256>> for Sha256HashValue {
     fn from(value: Output<Sha256>) -> Self {
-        Self(value.into())
+        Self(value)
     }
 }
 
@@ -183,7 +183,7 @@ pub struct Sha512HashValue([u8; 64]);
 
 impl From<Output<Sha512>> for Sha512HashValue {
     fn from(value: Output<Sha512>) -> Self {
-        Self(value.into())
+        Self(value)
     }
 }
 

--- a/crates/composefs/src/lib.rs
+++ b/crates/composefs/src/lib.rs
@@ -45,6 +45,7 @@
 // exceptions carry a local `#[allow]` with justification. Test code is exempt.
 #![cfg_attr(not(test), deny(clippy::print_stdout, clippy::print_stderr))]
 
+pub mod digest;
 pub mod dumpfile;
 pub mod dumpfile_parse;
 pub mod erofs;

--- a/crates/composefs/src/util.rs
+++ b/crates/composefs/src/util.rs
@@ -4,8 +4,8 @@
 //! I/O utilities for reading data streams, SHA256 digest parsing, and
 //! filesystem operations like atomic symlink replacement.
 
+use crate::digest::Digest;
 use rand::{RngExt, distr::Alphanumeric};
-use sha2::Digest;
 use std::{
     io::{Error, ErrorKind, Read, Result},
     os::{
@@ -21,11 +21,10 @@ use rustix::{
 };
 use tokio::io::{AsyncRead, AsyncReadExt};
 
-/// Adapts a [`sha2::Digest`] hasher to implement [`std::io::Write`].
+/// Adapts a [`Digest`] hasher to implement [`std::io::Write`].
 ///
-/// sha2 0.11 removed its `std::io::Write` impl. This wrapper bridges
-/// the gap so that digest hashers can still be used with APIs that
-/// accept `impl Write` (e.g. [`SplitStreamReader::cat`]).
+/// This wrapper bridges the gap so that digest hashers can be used with
+/// APIs that accept `impl Write` (e.g. [`SplitStreamReader::cat`]).
 #[derive(Debug)]
 pub struct DigestWrite<D: Digest>(pub D);
 
@@ -42,7 +41,7 @@ impl<D: Digest> std::io::Write for DigestWrite<D> {
 
 impl<D: Digest> DigestWrite<D> {
     /// Consumes the wrapper and returns the computed digest.
-    pub fn finalize(self) -> sha2::digest::Output<D> {
+    pub fn finalize(self) -> crate::digest::Output<D> {
         self.0.finalize()
     }
 }


### PR DESCRIPTION
All SHA-256/384/512 hashing was previously done via the pure-Rust sha2 crate. Switch to the system OpenSSL library instead, which is already a transitive dependency and avoids bundling a separate crypto implementation.

A new composefs::digest module provides Digest/FixedOutputReset traits with Sha256, Sha384, and Sha512 types wrapping openssl::hash::Hasher. Downstream workspace crates now import from composefs::digest rather than sha2 directly. composefs-splitdirfdstream (which does not depend on composefs) uses openssl::hash::hash() for its single call site.

The [profile.dev.package.sha2] opt-level override is removed since OpenSSL is a pre-compiled system library.

Assisted-by: AI

Closes: #351